### PR TITLE
Stop host-side JAX falling back to CPU LLVM JIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ cp production.uv.lock uv.lock && uv sync --frozen
 pip install -r requirements.txt && pip install -e .
 ```
 
+> **CPU-only hosts:** long optimization runs on CPU JAX can hit XLA's LLVM JIT with `Cannot allocate memory` / `can't start new thread` errors. These come from per-process VMA / thread limits, not RAM. Bump the kernel limit and rerun:
+>
+> ```bash
+> sudo sysctl -w vm.max_map_count=1048576
+> ulimit -u 65535
+> export JAX_COMPILATION_CACHE_DIR=$HOME/.cache/jax
+> ```
+
 ### Continuous benchmarking
 
 After the initial paper release, all results are generated automatically by CI:


### PR DESCRIPTION
## Summary

Resolves #15 when merged.
Long optimization runs on CPU JAX hit XLA LLVM `Cannot allocate memory` / `can't start new thread` after a few hundred BFGS re-traces — the LLVM ORC JIT creates a fresh executable mapping per fusion until per-process VMA / thread caps are exhausted (not RAM). This PR adds a `gpu` install extra so NVIDIA hosts run GPU JAX, tunes the host process at `mosaic.benchmarks` import (persistent compilation cache + raised `RLIMIT_NOFILE`/`RLIMIT_NPROC`), and documents the CPU-only mitigation.

## Type of change

- [ ] New solver backend
- [ ] Solver tuning / improvement
- [ ] New benchmark domain
- [ ] Harness / infrastructure change
- [ ] Documentation
- [x] Bug fix

## Checklist

- [ ] `ruff check --fix && ruff format` passes
- [ ] `pytest` passes (unit tests, no Docker required)

### For new solvers

- [ ] `tesseract_config.yaml` has a `metadata.mosaic:` block with at least `name` and `backend`
- [ ] `tesseract build mosaic/tesseracts/<domain>/<solver>` succeeds
- [ ] `mosaic run -p <domain> --suites forward -s <solver> --debug` completes
- [ ] `mosaic status -p <domain> -f` output pasted below
- [ ] Exclusions and explained anomalies documented (if any)

### For solver tuning

- [ ] Before/after `mosaic status --format json` snapshots compared
- [ ] No regressions to other solvers

## Status output

N/A — no solver or experiment behaviour changes; this only affects how the orchestrator interacts with JAX.

```

```

## Notes

- The base install still resolves `jax[cpu]`, so existing CPU-only setups keep working. GPU support is opt-in: `pip install -e ".[gpu]"` / `uv sync --extra gpu`. The `cuda12` extra (PyPI-bundled CUDA wheels) is preferred over `cuda12-local` here because the host conda env has no guaranteed system CUDA, unlike the tesseract containers.
- `mosaic/benchmarks/__init__.py` sets env vars at package import time, so it runs before any submodule pulls JAX. Verified with a BFGS-restart-style reproducer: cold compile 10.5s → warm 1.9s across separate processes sharing the cache dir.
- `vm.max_map_count` can't be raised from inside the process; the README block documents the sysctl + `ulimit` knobs that need root.
