### PR TITLE
fix(pict): write pict.pth to /python-env site-packages

### DIFF
--- a/mosaic/tesseracts/navier-stokes-grid/pict/tesseract_config.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/pict/tesseract_config.yaml
@@ -81,11 +81,16 @@ build_config:
     - "RUN sed -i 's/os.cpu_count()/1/g' /opt/pict/extensions/setup.py"
     - "RUN cd /opt/pict/extensions && MAX_JOBS=2 pip install . --no-build-isolation --no-deps"
     # PISOtorch_simulation.py / PISOtorch_diff.py / lib/ live at the PICT repo
-    # root and aren't pip-installable. Drop a .pth file into site-packages so
-    # they're on sys.path for every Python invocation.
+    # root and aren't pip-installable. Drop a .pth file into the tesseract
+    # runtime's site-packages so they're on sys.path at container start.
+    # Target /python-env explicitly — ``python -c "import site"`` on PATH at
+    # build time may resolve to a different interpreter (uv-managed / system),
+    # which would land the .pth in a site-packages that the runtime never sees.
     - |
-      RUN PY_SITE=$(python -c "import site; print(site.getsitepackages()[0])") \
-        && echo /opt/pict > "${PY_SITE}/pict.pth"
+      RUN PY_SITE=$(ls -d /python-env/lib/python*/site-packages | head -n1) \
+        && echo /opt/pict > "${PY_SITE}/pict.pth" \
+        && echo "Wrote pict.pth to ${PY_SITE}" \
+        && ls -la /opt/pict/PISOtorch_simulation.py
 
 metadata:
   mosaic:


### PR DESCRIPTION
## Summary

PICT drops a `.pth` file into site-packages so that `PISOtorch_simulation.py`, `PISOtorch_diff.py`, and `lib/` (which live at the PICT repo root and aren't pip-installable) end up on `sys.path` at container start. The previous step resolved the target via `python -c "import site; print(site.getsitepackages()[0])"`, which can land `pict.pth` in a site-packages directory the tesseract runtime never imports if `python` on PATH at build time is a different interpreter (uv-managed env, system python).

Target `/python-env/lib/python*/site-packages` directly. Added a stat of `PISOtorch_simulation.py` to the same `RUN` so build logs surface a missing-file failure immediately rather than at first solver call.

## Type of change

- [ ] New solver backend
- [ ] Solver tuning / improvement
- [ ] New benchmark domain
- [ ] Harness / infrastructure change
- [ ] Documentation
- [x] Bug fix

## Checklist

- [x] `ruff check --fix && ruff format` passes
- [ ] `pytest` passes (unit tests, no Docker required)

## Status output

N/A — pure build-config change.

```

```

## Notes

- Single hunk in `mosaic/tesseracts/navier-stokes-grid/pict/tesseract_config.yaml`.
