### PR TITLE
build(jax-fem): install jax[cuda12] to match uses_gpu=true

### DIFF
--- a/mosaic/tesseracts/structural-mesh/jax-fem/tesseract_environment.yaml
+++ b/mosaic/tesseracts/structural-mesh/jax-fem/tesseract_environment.yaml
@@ -17,5 +17,5 @@ dependencies:
       - wheel
       - fenics-basix==0.9.0
       - pyfiglet==1.0.3
-      - jax[cpu]==0.5.3
+      - jax[cuda12]==0.5.3
       - jax-fem==0.0.9

--- a/mosaic/tesseracts/structural-mesh/jax-fem/tesseract_requirements.txt
+++ b/mosaic/tesseracts/structural-mesh/jax-fem/tesseract_requirements.txt
@@ -5,6 +5,6 @@ gmsh==4.13.1
 petsc4py==3.22.4
 fenics-basix==0.9.0
 pyfiglet==1.0.3
-jax[cpu]==0.5.3
+jax[cuda12]==0.5.3
 jax-fem==0.0.9
 ../../../mosaic_shared

--- a/mosaic/tesseracts/thermal-mesh/jax-fem/tesseract_environment.yaml
+++ b/mosaic/tesseracts/thermal-mesh/jax-fem/tesseract_environment.yaml
@@ -17,5 +17,5 @@ dependencies:
       - wheel
       - fenics-basix==0.9.0
       - pyfiglet==1.0.3
-      - jax[cpu]==0.5.3
+      - jax[cuda12]==0.5.3
       - jax-fem==0.0.9


### PR DESCRIPTION
## Summary

Both jax-fem tesseracts (structural-mesh and thermal-mesh) advertise `uses_gpu: true` in their config metadata, but pin `jax[cpu]==0.5.3` in the build env — so the runtime falls back to CPU JAX even on a GPU host. Switch to `jax[cuda12]==0.5.3` so the installed jaxlib matches the metadata.

## Type of change

- [ ] New solver backend
- [ ] Solver tuning / improvement
- [ ] New benchmark domain
- [x] Harness / infrastructure change
- [ ] Documentation
- [x] Bug fix

## Checklist

- [x] `ruff check --fix && ruff format` passes
- [ ] `pytest` passes (unit tests, no Docker required)

## Status output

N/A — build-env change only.

```

```

## Notes

- Three files changed: structural-mesh/jax-fem `tesseract_requirements.txt` + `tesseract_environment.yaml`, thermal-mesh/jax-fem `tesseract_environment.yaml`. Same single-line swap in each.
- Image grows by ~2 GB (CUDA wheels). Acceptable trade because the metadata already promised GPU.
