### PR TITLE
test: fix VJP endpoint signature in integration test

### DIFF
--- a/mosaic/tests/test_integration.py
+++ b/mosaic/tests/test_integration.py
@@ -59,7 +59,11 @@ def test_vjp_returns_finite_gradient(built_solver):
 
         result = np.asarray(out["result"])
         cotangent = {"result": np.ones_like(result)}
-        grad = t.vector_jacobian_product({}, cotangent)
+        # tesseract_core's VJP endpoint takes ``(inputs, vjp_inputs,
+        # vjp_outputs, cotangent_vector)`` — the two ``vjp_*`` lists pick
+        # which input/output pair the gradient is computed against. Lists
+        # rather than sets because the SDK serialises them over JSON.
+        grad = t.vector_jacobian_product({}, ["v0"], ["result"], cotangent)
         assert "v0" in grad, f"Missing 'v0' gradient. Got: {list(grad.keys())}"
         g = np.asarray(grad["v0"])
         assert g.size > 0, "gradient is empty"


### PR DESCRIPTION
## Summary

\`tesseract_core\`'s \`vector_jacobian_product\` endpoint takes four positional args: \`(inputs, vjp_inputs, vjp_outputs, cotangent_vector)\`. The two \`vjp_*\` lists select which input/output pair the gradient is computed against; they're lists (not sets) because the SDK serialises them over JSON.

The previous call in \`test_vjp_returns_finite_gradient\` passed only \`(inputs, cotangent)\` — that raises a \`TypeError\` on any invocation. The test sits behind the \`integration\` pytest mark so it doesn't run in the default suite, which is why this slipped through.

## Type of change

- [ ] New solver backend
- [ ] Solver tuning / improvement
- [ ] New benchmark domain
- [ ] Harness / infrastructure change
- [ ] Documentation
- [x] Bug fix

## Checklist

- [x] \`ruff check --fix && ruff format\` passes
- [ ] \`pytest\` passes (unit tests, no Docker required)

## Status output

N/A — single-line test fix.

\`\`\`

\`\`\`

## Notes

- Test runs only under \`pytest -m integration\` (requires Docker + a built Tesseract image), so the fix isn't covered by the default CI lane. A manual \`pytest -m integration mosaic/tests/test_integration.py::test_vjp_returns_finite_gradient\` is the verification path.