### PR TITLE
ci(thermal-mesh): cap spatial_cost N_values at 1024 (speculative OOM fix)

### DIFF
--- a/mosaic/benchmarks/problems/thermal_mesh.py
+++ b/mosaic/benchmarks/problems/thermal_mesh.py
@@ -880,9 +880,7 @@ CONFIG = ProblemConfig(
         runs=[
             dict(
                 physics=dict(Lx=2.0, Ly=1.0, Lz=1.0, Q_total=1.0, rho_0=0.5),
-                cost=dict(
-                    N_values=[16, 32, 64, 128, 256, 512, 1024, 2048, 4500], n_trials=3
-                ),
+                cost=dict(N_values=[16, 32, 64, 128, 256, 512, 1024], n_trials=3),
             )
         ],
     ),


### PR DESCRIPTION
## Context

On benchmark run [26225239754](https://github.com/pasteurlabs/mosaic/actions/runs/26225239754) (branch `test/ci-smoke-spectral-euler`), the `cost / thermal-mesh (gpu)` cell **crashed at 55m1s** — not a clean job timeout. GitHub's annotation:

> ⚠️ The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, **starves it for CPU/Memory**, or blocks its network access can cause this error.

The log artifact for the cell came back `BlobNotFound`, which is the tell-tale sign of a hard runner death (runner process killed before logs could upload). Three other cells in the same run hit clean 120-min timeouts; only this one was an actual crash.

## Suspected cause (not confirmed)

Most likely: **host OOM during jax-fem's CPU-side linear solve.** `mosaic/tesseracts/thermal-mesh/jax-fem/tesseract_api.py:267-268`:

```python
solver_options={"umfpack_solver": {}},
adjoint_solver_options={"umfpack_solver": {}},
```

UMFPACK is a sparse-direct LU factoriser with no GPU implementation, so the linear solve runs on host RAM even when the rest of jax-fem is on GPU. UMFPACK's L+U factors fill in super-linearly in mesh size; at the top of the original sweep (`nx=2048, 4500`) the factorisation memory can plausibly exceed the 16 GB hosted-runner budget for a 3D thermal mesh.

Corroborating signal: `dealii_heat` on the CPU sibling cell hit a per-call read timeout at exactly `nx=4500`, so the top of the sweep was already known-unreliable.

**Caveats** (why this is speculative):
- The crashed cell's log artifact is missing, so the specific `nx` that triggered the crash is unknown.
- No host `dmesg` / `journalctl` available for hosted runners to confirm `oom_kill_process`.
- Could also be CPU starvation, network blip, or a CUDA-side OOM rather than host OOM.

## Change

Cap `thermal-mesh` `cost.spatial_cost` `N_values` from `[16, 32, 64, 128, 256, 512, 1024, 2048, 4500]` to `[16, 32, 64, 128, 256, 512, 1024]` — drops the two top sizes, keeps 7 of 9 sweep points. No other changes.

## Validation

- [ ] Re-trigger CI on this branch and confirm `cost / thermal-mesh (gpu)` completes without a runner-lost-communication event
- [ ] `cost / thermal-mesh (cpu)` should also finish within 120 min once the nx=4500 row (which was per-call-timing-out at 66 min) is gone

## Followups (out of scope)

If this PR confirms the diagnosis:
- Migrate `jax-fem` (both thermal-mesh and structural-mesh) from UMFPACK to an iterative GPU solver (e.g. `petsc_solver` with CG/GMRES, or pure-JAX iterative).
- Restore the original sweep range, or extend further, once the iterative solver lands.

If this PR does **not** fix the crash, the next most likely culprits are CUDA-side OOM in one of the differentiable solvers, or memory leakage across the matrix's per-(suite, problem) cell start-up.

## Target

Merging to `test/ci-smoke-spectral-euler` (not `main`) so the cap can be validated against the original crashing CI configuration before going wider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)