### PR TITLE
docs: fix exclusions schema, document --continue and FAILED-classification

### DIFF
--- a/docs/architecture.qmd
+++ b/docs/architecture.qmd
@@ -66,7 +66,7 @@ Defined in `mosaic/benchmarks/core/config.py`. Each solver backend is described 
 | `image_tag` | `str \| None` | `<image_name>:latest`, populated by `discover_solvers()` |
 | `input_overrides` | `dict` | Per-solver default overrides merged into `cfg.make_inputs` for this solver |
 
-Per-(solver, problem) exclusions and anomaly annotations are *not* stored on `SolverSpec` — they live on the `Problem` (`problem.exclusions[solver_name][key] = Exclusion(...)`, registered via `problem.exclude(key, {solver_name: Exclusion(...)})`).
+Per-(solver, problem) exclusions and anomaly annotations are *not* stored on `SolverSpec` — they live on the `Problem` (`problem.exclusions[key][solver_name] = Exclusion(...)`, registered via `problem.exclude(key, {solver_name: Exclusion(...)})`).
 
 ### `Problem`
 

--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -146,6 +146,30 @@ finer scoping.
 `mosaic run` builds ~20 Docker containers and runs the complete evaluation. Expect **several hours** on a machine with a modern GPU, or **much longer** on CPU only. The container images add up to **dozens of GB** on disk. Consider starting with a single problem (`mosaic run --problems thermal-mesh`) to validate your setup before committing the time and storage.
 :::
 
+## Resuming after a crash
+
+A long run may get killed mid-experiment by an OOM, host reboot, or
+SIGKILL. ``--continue`` resumes from where the prior invocation left
+off, at two granularities:
+
+* **Per experiment.** Experiments whose ``result.json`` already exists
+  under the output directory are skipped entirely. Multi-IC
+  experiments count as done once every IC subdir has a ``result.json``.
+* **Per solver.** Within a partially-completed experiment, each
+  harness writes ``result_partial.json`` after each solver finishes;
+  on resume, solvers already recorded there are filtered out so the
+  remaining ones can pick up the work.
+
+```bash
+mosaic run --continue                       # resume all problems / suites
+mosaic run -p ns-grid --continue            # scope to one problem
+mosaic run --only failed --continue         # only retry failed cells, skip ok
+```
+
+``--continue`` composes with ``--only`` — useful when a long sweep
+mostly succeeded but a few cells timed out: ``--only failed --continue``
+re-runs just those without restarting fresh-ok cells.
+
 ## Understanding output
 
 Results are organized by problem and suite:
@@ -175,6 +199,17 @@ mosaic status --format json > snap.json   # machine-readable snapshot
 ```
 
 ## Troubleshooting
+
+### Container start failures
+
+A solver whose container fails to start — broken image, missing CUDA
+runtime, or an import error inside the API module — surfaces as a
+`failed` cell with the underlying exception message in
+``mosaic status -f``. (Previously these dropped silently as
+``NOT_RUN``, indistinguishable from "wasn't selected"; the runner now
+records them via an ``on_error`` callback so the status pipeline can
+classify the cell as FAILED.) Retry the cell with
+``mosaic run --only failed`` once the container is fixed.
 
 ### Container build failures
 


### PR DESCRIPTION
## Summary

Doc gaps surfaced after rolling PRs #8/#10/#11/#21/#22/#9 into ``dev``:

1. **`architecture.qmd:69`** — fix wrong ``Problem.exclusions`` key order
   (was ``[solver_name][key]``, schema is ``[key][solver_name]``).
2. **`getting-started.qmd`** — document ``mosaic run --continue`` and
   ``result_partial.json`` checkpointing (PRs #25, #26).
3. **`getting-started.qmd`** — document the PR #10 behavior change where
   solver-start failures land as ``failed`` cells instead of disappearing
   as ``NOT_RUN``.

## Test plan

- [ ] Quarto build of ``docs/`` passes locally (or via the ``docs.yml``
      workflow PR #9 added).
- [ ] ``--continue`` section reflects the actual flag set on ``mosaic run --help``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)