### PR TITLE
feat(Problem.add_experiment): accept plot=dict[str, callable] for multi-view

### DIFF
--- a/mosaic/benchmarks/core/config.py
+++ b/mosaic/benchmarks/core/config.py
@@ -283,7 +283,7 @@ class Problem:
         key: str,
         kernel: Callable,
         *,
-        plot: Callable | None = None,
+        plot: Callable | dict[str, Callable] | None = None,
         plot_description: str = "",
         reduce: Callable | None = None,
         status_check: list | None = None,
@@ -306,6 +306,15 @@ class Problem:
         list of per-sub-experiment result dicts (if ``reduce is None``) or
         ``reduce(results)`` otherwise. Plots that need ``exp_key=`` get it
         wrapped in automatically.
+
+        Pass a ``dict[str, callable]`` instead of a single callable to
+        attach **multiple views** to one experiment (mirrors the asie
+        ``plot={"view": fn, ...}`` shape). Each entry runs independently;
+        an exception in one view is logged but does not skip the others.
+        Each view receives the same ``(cfg, exp_key=..., sub_keys=...)``
+        kwargs the single-callable form would — a view's signature
+        decides which of those it sees, exactly like the single-callable
+        case.
 
         ``plot_description`` is stored on every sub-experiment's params for
         introspection (e.g. ``mosaic status``).
@@ -383,6 +392,8 @@ class Problem:
                     )
 
         if plot is not None:
+            if isinstance(plot, dict):
+                plot = self._compose_plot_views(key, plot)
             self._register_plot(key, plot, sub_keys, reduce)
 
     @staticmethod
@@ -813,6 +824,66 @@ class Problem:
         """
         for solver_name, excl in exclusions.items():
             self.exclusions.setdefault(solver_name, {})[key] = excl
+
+    @staticmethod
+    def _compose_plot_views(key: str, views: dict[str, Callable]) -> Callable:
+        """Collapse ``plot={"view": fn, ...}`` into one callable.
+
+        The returned callable accepts the same ``(cfg, exp_key=..., sub_keys=...,
+        suffix=...)`` keyword set the runner passes to a registered plot fn,
+        and dispatches to each view with only the kwargs that view's
+        signature actually declares. An exception in one view is logged
+        (with the view name + experiment key) and does not abort the others.
+
+        The composite's own signature is synthesised so :meth:`_register_plot`'s
+        ``inspect.signature(plot).parameters`` sees the union of params the
+        underlying views care about — the wrappers it adds (``exp_key=``,
+        ``sub_keys=``) then forward correctly.
+        """
+        import inspect
+
+        union_params: set[str] = set()
+        view_sigs: dict[str, set[str]] = {}
+        for view_name, fn in views.items():
+            try:
+                sig_params = set(inspect.signature(fn).parameters)
+            except (TypeError, ValueError):
+                sig_params = set()
+            view_sigs[view_name] = sig_params
+            union_params.update(sig_params)
+
+        def _composite(cfg, **kw):
+            from mosaic.benchmarks.core.console import print_warn
+
+            for view_name, fn in views.items():
+                sig_params = view_sigs[view_name]
+                # Forward only kwargs this view declares — matches the
+                # single-callable behaviour and stops a view that doesn't
+                # take ``suffix=`` from receiving one.
+                fn_kw = {k: v for k, v in kw.items() if k in sig_params}
+                try:
+                    fn(cfg, **fn_kw)
+                except Exception as exc:
+                    print_warn(f"plot {key}#{view_name}: {type(exc).__name__}: {exc}")
+
+        # Synthesise a signature so _register_plot's inspect sees the
+        # union of params (cfg + whichever of {exp_key, sub_keys, suffix}
+        # any view declares).
+        synth_params = [
+            inspect.Parameter("cfg", inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        for name in ("exp_key", "sub_keys", "results", "suffix"):
+            if name in union_params:
+                synth_params.append(
+                    inspect.Parameter(
+                        name,
+                        inspect.Parameter.KEYWORD_ONLY,
+                        default=None,
+                    )
+                )
+        _composite.__signature__ = inspect.Signature(synth_params)
+        _composite.__name__ = f"_composite_plot[{', '.join(views)}]"
+        return _composite
 
     def _register_plot(
         self,

--- a/mosaic/tests/core/test_plot_views.py
+++ b/mosaic/tests/core/test_plot_views.py
@@ -1,0 +1,98 @@
+"""Tests for ``plot=dict[str, callable]`` multi-view support on ``add_experiment``.
+
+The composite plot wrapper that ``Problem.add_experiment(plot={...})`` produces
+must:
+
+  * Call every view in declaration order.
+  * Forward only the kwargs each view's signature declares (so a view written
+    as ``def f(cfg)`` doesn't blow up when the runner passes ``suffix=``).
+  * Survive one view raising and keep going.
+  * Expose the union of ``{exp_key, sub_keys, results, suffix}`` parameters
+    on its synthesised signature, so ``_register_plot``'s inspect-based
+    wrapping picks the right (single-leaf vs. sweep) injection path.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from mosaic.benchmarks.core.config import Problem
+
+
+class ComposePlotViewsTests(unittest.TestCase):
+    def test_calls_every_view_in_order(self) -> None:
+        called: list[str] = []
+
+        def view_a(cfg):
+            called.append("a")
+
+        def view_b(cfg):
+            called.append("b")
+
+        composite = Problem._compose_plot_views(
+            "key", {"first": view_a, "second": view_b}
+        )
+        composite(cfg=None)
+        self.assertEqual(called, ["a", "b"])
+
+    def test_filters_kwargs_per_view_signature(self) -> None:
+        seen: dict[str, dict] = {}
+
+        def needs_exp_key(cfg, *, exp_key):
+            seen["exp_key_view"] = {"exp_key": exp_key}
+
+        def needs_sub_keys(cfg, *, sub_keys):
+            seen["sub_keys_view"] = {"sub_keys": sub_keys}
+
+        def plain(cfg):
+            seen["plain"] = {}
+
+        composite = Problem._compose_plot_views(
+            "k",
+            {
+                "exp_key_view": needs_exp_key,
+                "sub_keys_view": needs_sub_keys,
+                "plain": plain,
+            },
+        )
+        composite(cfg=None, exp_key="tgv", sub_keys=["a", "b"], suffix="_debug")
+        # Each view sees only what it declared.
+        self.assertEqual(seen["exp_key_view"], {"exp_key": "tgv"})
+        self.assertEqual(seen["sub_keys_view"], {"sub_keys": ["a", "b"]})
+        self.assertEqual(seen["plain"], {})
+
+    def test_one_view_raising_doesnt_skip_others(self) -> None:
+        called: list[str] = []
+
+        def bad(cfg):
+            called.append("bad")
+            raise RuntimeError("boom")
+
+        def good(cfg):
+            called.append("good")
+
+        composite = Problem._compose_plot_views("k", {"bad": bad, "good": good})
+        composite(cfg=None)
+        self.assertEqual(called, ["bad", "good"])
+
+    def test_synth_signature_union(self) -> None:
+        import inspect
+
+        def takes_exp_key(cfg, *, exp_key):
+            pass
+
+        def takes_sub_keys(cfg, *, sub_keys):
+            pass
+
+        composite = Problem._compose_plot_views(
+            "k", {"a": takes_exp_key, "b": takes_sub_keys}
+        )
+        params = set(inspect.signature(composite).parameters)
+        # The synthesised signature must expose the union so _register_plot's
+        # inspect picks both injection paths.
+        self.assertIn("exp_key", params)
+        self.assertIn("sub_keys", params)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First of four small PRs adopting smoother API patterns from auto-sie (the ASIE campaign framework). This one ports the **multi-view plot dict** shape:

```python
problem.add_experiment(
    "gradient/fd_check",
    fd_check,
    physics={"N": 32, ...},
    plot={
        "grad_compare": _grad_compare_plot,
        "vorticity":    _vorticity_plot,
    },
)
```

Each entry runs independently; an exception in one view is logged but does not skip the others; each view receives only the kwargs its own signature declares. Single-callable `plot=callable` behaviour is unchanged.

## Implementation

Tiny diff. One new `Problem._compose_plot_views(key, views) -> Callable` static method collapses the dict into a single composite, then dispatches through the existing `_register_plot` path. The composite synthesises its own signature as the union of the views' parameters so `_register_plot`'s `inspect.signature(...)`-driven `exp_key=` / `sub_keys=` injection keeps working.

## What's next

If this lands cleanly, three more PRs in order of size:

2. `coords` typed sweep position on `Experiment` (replaces name-encoded sweep position parsing in `_extra/` aggregators).
3. `Goal(name, description, check)` abstraction (per-experiment success predicate; adds a goal-pass axis to the status pipeline).
4. `add_sweep_plot(group_by=..., filter=...)` aggregator-by-coord plot registration (builds on #2).

## Test plan

- [x] `pytest mosaic/tests/core/test_plot_views.py` — 4 new tests pass
- [x] `pytest mosaic/tests/` — 236 passed, 5 failed (same pre-existing scaffold failures on dev)
- [x] `ruff check --fix && ruff format` — clean (pre-commit ran)

🤖 Generated with [Claude Code](https://claude.com/claude-code)