### PR TITLE
feat(Experiment): add coords typed sweep position (asie pattern)

### DIFF
--- a/mosaic/benchmarks/core/config.py
+++ b/mosaic/benchmarks/core/config.py
@@ -126,10 +126,19 @@ class Experiment:
     ``params`` is the introspection manifest — what configuration the closure
     captured. The runner only invokes ``fn``; ``params`` is read by status,
     documentation, and result-saving for provenance.
+
+    ``coords`` is this experiment's position in a sweep's parameter space
+    (e.g. ``{"N": 32, "nu": 0.01}``), borrowed from asie's ``Campaign`` API.
+    Auto-populated from list-valued ``physics={...}`` / top-level kwargs by
+    :meth:`Problem.add_experiment`, or set explicitly via the ``coords=``
+    kwarg. Empty ``{}`` means "not part of any sweep" — fully optional.
+    Persisted into ``result.json`` so aggregator plots can find every cell's
+    coordinates without parsing the experiment name.
     """
 
     fn: ExperimentFn
     params: dict = field(default_factory=dict)
+    coords: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -287,6 +296,7 @@ class Problem:
         plot_description: str = "",
         reduce: Callable | None = None,
         status_check: list | None = None,
+        coords: dict[str, Any] | None = None,
         **config,
     ) -> None:
         """Register an experiment at ``key`` with optional sweep + plot + reduce.
@@ -329,6 +339,15 @@ class Problem:
         Per-experiment exclusions are attached via :meth:`exclude` — call
         ``problem.exclude(key, {solver_name: Exclusion, ...})`` immediately
         after this method to register them at the same key.
+
+        ``coords`` (optional) is this experiment's position in a sweep's
+        parameter space — e.g. ``coords={"N": 32, "regime": "diffusive"}``.
+        Auto-populated from list-valued config entries (the sweep axes)
+        for each sub-experiment; the ``coords`` kwarg adds extra dimensions
+        that the sweep itself doesn't cover (e.g. a regime label that's
+        constant across the sweep). Persisted into ``result.json`` so
+        aggregator plots can find each cell's coordinates without parsing
+        the experiment name.
         """
         # Shorthand: ``run=dict`` wraps into ``runs=[dict]`` and list-valued
         # fields in the run get auto-converted into the runner's sweep dict
@@ -349,6 +368,8 @@ class Problem:
         # The runner is called with ``runs=[single_variant]`` so n_runs==1
         # always — subdir naming lives here at the sweep layer, not in
         # each runner.
+        user_coords: dict[str, Any] = dict(coords or {})
+
         runs = config.get("runs")
         if isinstance(runs, list) and len(runs) > 1:
             sub_keys = []
@@ -357,12 +378,17 @@ class Problem:
                 sub_key = f"{key}/{variant_name}"
                 sub_keys.append(sub_key)
                 sub_config = {**config, "runs": [variant]}
+                # Variant fan-out: tag each sub with ``variant=<name>`` so
+                # aggregator plots can pick subs out by variant without
+                # re-parsing the sub-key. User coords win on collision.
+                sub_coords = {"variant": variant_name, **user_coords}
                 self._register_one_experiment(
                     sub_key,
                     kernel,
                     sub_config,
                     plot_description=plot_description,
                     status_check=status_check,
+                    coords=sub_coords,
                 )
         else:
             sweep_axes = self._collect_sweep_axes(config)
@@ -374,21 +400,28 @@ class Problem:
                     config,
                     plot_description=plot_description,
                     status_check=status_check,
+                    coords=user_coords,
                 )
                 sub_keys = [key]
             else:
                 n_subs = self._validate_axes(sweep_axes)
                 sub_keys = []
                 for i in range(n_subs):
-                    sub_config, suffix = self._materialize_one(config, sweep_axes, i)
+                    sub_config, suffix, axis_coords = self._materialize_one(
+                        config, sweep_axes, i
+                    )
                     sub_key = f"{key}/{suffix}"
                     sub_keys.append(sub_key)
+                    # Auto-derived axis position + any user-supplied
+                    # constant-across-the-sweep coords (e.g. ``regime``).
+                    sub_coords = {**axis_coords, **user_coords}
                     self._register_one_experiment(
                         sub_key,
                         kernel,
                         sub_config,
                         plot_description=plot_description,
                         status_check=status_check,
+                        coords=sub_coords,
                     )
 
         if plot is not None:
@@ -603,8 +636,14 @@ class Problem:
         return lengths.pop()
 
     @staticmethod
-    def _materialize_one(config: dict, axes: list, i: int) -> tuple[dict, str]:
-        """Build the i-th sub-experiment's config + an auto-derived path suffix."""
+    def _materialize_one(config: dict, axes: list, i: int) -> tuple[dict, str, dict]:
+        """Build the i-th sub-experiment's config + path suffix + axis coords.
+
+        The auto-derived ``coords`` dict maps each axis's leaf key to its
+        i-th value (``{"N": 32, "nu": 0.01}`` for a parallel-zipped
+        ``physics={"N": [...], "nu": [...]}`` sweep). Nested-axis names
+        use the leaf key only, matching the suffix convention.
+        """
         sub_config: dict = {}
         for k, v in config.items():
             if isinstance(v, dict):
@@ -612,6 +651,7 @@ class Problem:
             else:
                 sub_config[k] = v
         parts: list[str] = []
+        coords: dict[str, Any] = {}
         for path, vals in axes:
             v_i = vals[i]
             if len(path) == 1:
@@ -622,8 +662,9 @@ class Problem:
                 sub_config[k][sub_k] = v_i
                 name = sub_k
             parts.append(f"{name}_{Problem._fmt_val(v_i)}")
+            coords[name] = v_i
         suffix = "_".join(parts)
-        return sub_config, suffix
+        return sub_config, suffix, coords
 
     @staticmethod
     def _fmt_val(value) -> str:
@@ -660,6 +701,7 @@ class Problem:
         *,
         plot_description: str = "",
         status_check: list | None = None,
+        coords: dict[str, Any] | None = None,
     ) -> None:
         """Build the Experiment lambda for a single (scalar) config and store it.
 
@@ -730,7 +772,9 @@ class Problem:
         params: dict = {"plot_description": plot_description}
         if status_check:
             params["status_check"] = list(status_check)
-        self.experiments[key] = Experiment(fn=fn, params=params)
+        self.experiments[key] = Experiment(
+            fn=fn, params=params, coords=dict(coords or {})
+        )
 
     def add_ic(
         self,

--- a/mosaic/benchmarks/core/experiment.py
+++ b/mosaic/benchmarks/core/experiment.py
@@ -169,7 +169,7 @@ def get_kernel_config(fn) -> dict:
     return getattr(fn, _KERNEL_CONFIG_ATTR, {})
 
 
-def run_experiment(  # noqa: C901, PLR0913 — generic harness, refactor tracked separately
+def run_experiment(  # noqa: C901, PLR0913, PLR0915 — generic harness, refactor tracked separately
     cfg: Problem,
     tags: dict[str, str],
     kernel_fn: Kernel,
@@ -524,6 +524,15 @@ def run_experiment(  # noqa: C901, PLR0913 — generic harness, refactor tracked
             existing = result.get("_solver_failures") or {}
             existing.update(solver_failures)
             result["_solver_failures"] = existing
+
+        # Persist this experiment's sweep coordinates so aggregator plots
+        # (and downstream readers) don't need to re-parse the experiment
+        # name to discover its position in parameter space.
+        if isinstance(result, dict):
+            _full_key = f"{suite}/{exp_key}"
+            _exp = cfg.experiments.get(_full_key)
+            if _exp is not None and _exp.coords:
+                result.setdefault("coords", dict(_exp.coords))
 
         save_harness_result(
             result,

--- a/mosaic/tests/core/test_coords.py
+++ b/mosaic/tests/core/test_coords.py
@@ -1,0 +1,133 @@
+"""Tests for ``coords`` typed sweep position on ``Experiment``.
+
+``Problem.add_experiment(..., coords={...})`` annotates an experiment with
+its position in a parameter space — borrowed from the asie ``Campaign``
+API. Auto-populated for variant fan-out (``runs=[{name: ...}, ...]``)
+with ``variant=<name>``; user-supplied ``coords`` is merged in (user wins
+on key collision).
+
+Mosaic's internal-sweep path (``physics={"N": [16, 32, 64]}`` on a
+``sweep_mode="default"`` kernel) collapses the axis into a single
+runtime-sweep ``Experiment`` rather than fanning out, so coords are not
+auto-derived for that case — the user can still attach a manual
+``coords={"regime": "diffusive"}`` though, and it stays attached.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from mosaic.benchmarks.core.config import Problem
+from mosaic.benchmarks.core.experiment import kernel
+
+
+@kernel(sweep_mode="none")
+def _noop(t, ctx) -> dict:
+    return {"metrics": {}}
+
+
+@kernel(sweep_mode="default")
+def _noop_sweep(t, ctx) -> dict:
+    return {"metrics": {}}
+
+
+def _make_problem() -> Problem:
+    return Problem(
+        name="test",
+        tesseract_dir="navier-stokes-grid",
+        output_key="result",
+        ic_key="v0",
+        solvers=[],
+        make_ic={"default": lambda **kw: None},
+        make_inputs=lambda spec, ic, **kw: {},
+        error_fn=lambda *a, **k: 0.0,
+    )
+
+
+class CoordsRegistrationTests(unittest.TestCase):
+    def test_no_user_coords_means_empty(self) -> None:
+        p = _make_problem()
+        p.add_experiment("fwd/baseline", _noop, physics={"N": 32})
+        self.assertEqual(p.experiments["fwd/baseline"].coords, {})
+
+    def test_user_coords_attached_to_single_leaf(self) -> None:
+        p = _make_problem()
+        p.add_experiment(
+            "fwd/baseline",
+            _noop,
+            physics={"N": 32},
+            coords={"regime": "diffusive"},
+        )
+        self.assertEqual(p.experiments["fwd/baseline"].coords, {"regime": "diffusive"})
+
+    def test_user_coords_attached_to_runtime_sweep_experiment(self) -> None:
+        # Internal sweep — mosaic registers ONE Experiment that iterates
+        # at runtime. The user coords still attach (as a constant label
+        # for the whole sweep).
+        p = _make_problem()
+        p.add_experiment(
+            "fwd/sweep_N",
+            _noop_sweep,
+            physics={"N": [16, 32, 64]},
+            coords={"regime": "diffusive"},
+        )
+        # No sub_keys are created for the internal sweep.
+        self.assertIn("fwd/sweep_N", p.experiments)
+        self.assertEqual(p.experiments["fwd/sweep_N"].coords, {"regime": "diffusive"})
+
+    def test_variant_fan_out_auto_tags_with_variant_name(self) -> None:
+        p = _make_problem()
+        p.add_experiment(
+            "fwd/agreement",
+            _noop,
+            runs=[
+                {"name": "tgv", "ic": {"name": "default"}, "physics": {"N": 32}},
+                {"name": "mm", "ic": {"name": "default"}, "physics": {"N": 32}},
+            ],
+        )
+        subs = {
+            k: v for k, v in p.experiments.items() if k.startswith("fwd/agreement/")
+        }
+        self.assertEqual(len(subs), 2)
+        self.assertEqual({v.coords["variant"] for v in subs.values()}, {"tgv", "mm"})
+
+    def test_variant_fan_out_merges_user_coords(self) -> None:
+        # User coords carry across every variant (e.g. a constant regime
+        # label). Variant name still auto-tags.
+        p = _make_problem()
+        p.add_experiment(
+            "fwd/agreement",
+            _noop,
+            runs=[
+                {"name": "tgv", "ic": {"name": "default"}, "physics": {"N": 32}},
+                {"name": "mm", "ic": {"name": "default"}, "physics": {"N": 32}},
+            ],
+            coords={"regime": "diffusive"},
+        )
+        for k, v in p.experiments.items():
+            if not k.startswith("fwd/agreement/"):
+                continue
+            self.assertEqual(v.coords.get("regime"), "diffusive")
+            self.assertIn(v.coords["variant"], ("tgv", "mm"))
+
+    def test_user_coords_override_auto_variant_tag(self) -> None:
+        # User-provided coords win on key collision (rare, but the
+        # precedence is documented).
+        p = _make_problem()
+        p.add_experiment(
+            "fwd/agreement",
+            _noop,
+            runs=[
+                {"name": "tgv", "ic": {"name": "default"}, "physics": {"N": 32}},
+            ],
+            coords={"variant": "manual_override"},
+        )
+        # Single-variant runs list goes through the single-leaf path,
+        # so coords is just the user-provided dict.
+        self.assertEqual(
+            p.experiments["fwd/agreement"].coords, {"variant": "manual_override"}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Second of four small PRs adopting smoother API patterns from auto-sie. This one ports the **typed sweep position** field:

```python
problem.add_experiment(
    "fwd/q1_grad_agreement_smallN",
    fd_check,
    physics={"N": 32, "nu": 1.0e-2, ...},
    coords={"N": 32, "regime": "diffusive"},   # ← typed position
    plot=...,
)
```

`coords` is persisted into `result.json` at the top level so aggregator plots and downstream readers find every cell's coordinates without re-parsing the experiment name.

## Auto-population rules

| Path | Coords get |
|------|------------|
| Variant fan-out (`runs=[{"name": "tgv", ...}, ...]`) | `{"variant": <name>}` per sub, merged with user `coords=` |
| Single leaf | Just user `coords=` (or empty) |
| Internal-sweep (`physics={"N": [...]}` on `sweep_mode="default"` kernel) | One Experiment; user `coords=` attaches as whole-sweep label |

User-supplied `coords=` wins on key collision.

## Implementation

- New `coords: dict[str, Any]` field on `Experiment` dataclass.
- New `coords` kwarg on `Problem.add_experiment` and `_register_one_experiment`.
- Variant fan-out auto-tags each sub with `{"variant": variant_name}` before merging user coords.
- `_materialize_one` now returns `(sub_config, suffix, coords)` and populates coords from sweep axes (path-tuple leaf key → i-th value). Wiring is in place even though `_normalize_run_shorthand` usually intercepts list-valued physics first.
- `run_experiment` injects `result['coords']` from `cfg.experiments[<full_key>].coords` before `save_harness_result`, so it lands in `result.json`.

## Test plan

- [x] `pytest mosaic/tests/core/test_coords.py` — 6 new tests pass
- [x] `pytest mosaic/tests/` — 242 passed, 5 failed (same pre-existing scaffold failures on dev)
- [x] `ruff check` clean on touched files

## Next in the asie-adoption series

3. `Goal(name, description, check)` abstraction
4. `add_sweep_plot(group_by=..., filter=...)` (uses this PR's `coords`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)