### PR TITLE
chore: drop legacy fallbacks + trim verbose docstrings

### DIFF
--- a/mosaic/benchmarks/cli/run.py
+++ b/mosaic/benchmarks/cli/run.py
@@ -277,9 +277,8 @@ def _run_suites_for_problem(
         print_rule(f"  suite: {suite}")
         try:
             exps, plot_fns_fn = _suite_components(suite, cfg=cfg)
-            # Resolve --experiments against this suite's registry: a literal
-            # multi-segment name (e.g. "physical_laws/vs_N") wins over the
-            # legacy "<suite>/<exp>/<ic>" interpretation when it matches.
+            # Literal multi-segment names (e.g. "physical_laws/vs_N") win over
+            # the "<suite>/<exp>/<ic>" interpretation when both match.
             resolved_to_run, _ = _resolve_experiment_target(experiments, exps)
             effective_to_run = (
                 resolved_to_run if resolved_to_run is not None else to_run

--- a/mosaic/benchmarks/core/config.py
+++ b/mosaic/benchmarks/core/config.py
@@ -23,25 +23,9 @@ TESSERACTS_DIR: Path = Path(__file__).resolve().parents[2] / "tesseracts"
 class ExclusionCategory(str, Enum):
     """Why a solver does not run for a given experiment.
 
-    The ``(str, Enum)`` mixin means each member *is* a string (e.g.
-    ``ExclusionCategory.CATEGORICAL == "categorical"``), so the on-disk
-    serialisation of an :class:`Exclusion` lands as a plain string — no
-    schema change vs. the legacy free-form strings.
-
-    Members:
-      * ``CATEGORICAL`` — method-intrinsic limitation (e.g. FFT-only solver
-        on non-periodic BCs; non-differentiable C++ solver). Permanent;
-        excluded from the campaign score denominator.
-      * ``INFEASIBLE`` — would run but the result is not meaningful.
-      * ``NOT_IMPLEMENTED`` — could in principle run but the support hasn't
-        been wired yet. Counts in the score as "work to do".
-      * ``UNSTABLE`` — runs but blows up; same as NOT_IMPLEMENTED in scoring.
-      * ``UPSTREAM_BUG`` — failure attributable to a tracked upstream issue.
-      * ``WIP`` — temporarily skipped while work is in progress.
-      * ``UNSPECIFIED`` — fallback for legacy / un-categorised entries.
-      * ``ANOMALY_EXPLAINED`` — the solver runs and produces output that's
-        anomalous for documented method-intrinsic reasons; not a runtime
-        skip, only a display annotation.
+    ``CATEGORICAL`` is permanent (excluded from the campaign-score denominator);
+    all others count as "work to do". ``ANOMALY_EXPLAINED`` is a display-only
+    annotation — the solver still runs.
     """
 
     CATEGORICAL = "categorical"
@@ -54,8 +38,7 @@ class ExclusionCategory(str, Enum):
     ANOMALY_EXPLAINED = "anomaly_explained"
 
 
-# Categories that are *permanent* — these stay out of the campaign score
-# denominator. Everything else counts as "work to do" at the neutral weight.
+# Categories that are permanent — out of the score denominator.
 EXCL_PERMANENT: frozenset[ExclusionCategory] = frozenset(
     {ExclusionCategory.CATEGORICAL}
 )
@@ -64,20 +47,7 @@ EXCL_PERMANENT: frozenset[ExclusionCategory] = frozenset(
 class AdStrategy(str, Enum):
     """How a solver computes gradients.
 
-    Same ``(str, Enum)`` mixin as :class:`ExclusionCategory` — members
-    serialise to plain strings on disk (e.g. ``AdStrategy.AUTODIFF == "autodiff"``).
-
-    Members:
-      * ``AUTODIFF`` — native reverse-mode AD traces through the forward pass
-        (``jax.vjp``, ``torch.autograd``, ``Zygote``, ``wp.Tape``).
-      * ``ADJOINT``  — explicitly formulated adjoint equations
-        (dolfin-adjoint, pyadjoint, analytic self-adjoint SIMP sensitivity).
-      * ``HYBRID``   — analytic gradient rules combined with autodiff
-        (implicit-function theorem, custom VJP rules that call autodiff internally).
-
-    The ``None`` sentinel represents *non-differentiable*; it is not a
-    member of the enum (so ``ad_strategy: AdStrategy | None`` carries the
-    "no gradient support" case explicitly).
+    ``None`` (the absence of an :class:`AdStrategy`) means non-differentiable.
     """
 
     AUTODIFF = "autodiff"
@@ -85,22 +55,8 @@ class AdStrategy(str, Enum):
     HYBRID = "hybrid"
 
 
-# ── New experiment/plot abstractions ─────────────────────────────────────────
-#
-# These are the canonical types for the closure-style refactor. They live
-# above ``Problem`` so the dataclass annotation below can reference
-# them. See plan: `~/.claude/plans/i-want-to-make-encapsulated-token.md`.
-
-
 class ExperimentFn(Protocol):
-    """Callable that runs one experiment.
-
-    Signature: ``(cfg, tags, **overrides) -> dict``. Experiments capture
-    problem-specific state (``make_ic``, ``make_inputs``, ``error_fn``,
-    per-experiment params, …) in their closures so the runner doesn't need
-    to know about it. Returns a result dict saved by
-    :func:`mosaic.benchmarks.core.io.save_experiment`.
-    """
+    """``(cfg, tags, **overrides) -> dict`` — runs one experiment."""
 
     def __call__(
         self, cfg: Problem, tags: dict[str, str], **overrides: Any
@@ -108,25 +64,14 @@ class ExperimentFn(Protocol):
 
 
 class PlotFn(Protocol):
-    """Callable that renders the plots for one experiment.
-
-    Signature: ``(cfg, **kw) -> Any``. Like :class:`ExperimentFn`, plot
-    functions close over problem-specific presentation state (colormap,
-    axis labels, ``field_to_2d``, ``agreement_transform``, …) so the cfg
-    surface stays small.
-    """
+    """``(cfg, **kw) -> Any`` — renders the plots for one experiment."""
 
     def __call__(self, cfg: Problem, **kw: Any) -> Any: ...
 
 
 @dataclass
 class Experiment:
-    """An experiment is a closure plus the params it was built with.
-
-    ``params`` is the introspection manifest — what configuration the closure
-    captured. The runner only invokes ``fn``; ``params`` is read by status,
-    documentation, and result-saving for provenance.
-    """
+    """Registered experiment: its runner closure plus an introspection manifest."""
 
     fn: ExperimentFn
     params: dict = field(default_factory=dict)
@@ -134,15 +79,12 @@ class Experiment:
 
 @dataclass
 class Problem:
-    """The single per-problem definition: closure deps + metadata +
-    registries + builder methods.
+    """A benchmark domain definition.
 
-    Each problem's ``config.py`` instantiates one ``Problem`` (with closure
-    deps: ``make_ic``, ``error_fn``, ``output_key``, …), then
-    :meth:`add_experiment` / :meth:`add_ic` / :meth:`add_extra_plot`
-    register experiments + ICs + plot fns at ``"<suite>/<name>"`` keys.
-    The runner / status / CLI consume ``Problem`` directly — there is no
-    separate "config" wrapper.
+    Each problem's ``config.py`` instantiates one ``Problem`` with the
+    domain's closure deps (``make_ic``, ``error_fn``, ``output_key``, …)
+    and then calls :meth:`add_experiment` / :meth:`add_ic` /
+    :meth:`add_extra_plot` to populate the registries.
     """
 
     # ── Metadata ─────────────────────────────────────────────────────────
@@ -165,11 +107,8 @@ class Problem:
     ic_key: str = ""
     domain_extent: float = 1.0
     resolution_key: str = "N"
-    # Analytic reference solution callable (e.g. TGV viscous decay). Threaded
-    # into runner closures as the cfg-level fallback when per-run ``reference``
-    # is a fine-grid spec dict rather than a callable. Lives at Problem level
-    # because the analytic is tied to the problem (TGV analytic for ns-grid,
-    # TGV3D for ns-3d-grid), not the experiment.
+    # Cfg-level fallback for per-run ``reference`` when the run dict specifies
+    # a fine-grid spec rather than a callable.
     reference: Callable | None = None
 
     # ── Registries (filled by .add_experiment / .add_ic / .add_extra_plot) ─────────
@@ -177,20 +116,11 @@ class Problem:
     plot_fns: dict[str, PlotFn] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Setup that can't be expressed declaratively:
+        """Resolve ``tesseract_dir`` and wrap ``make_inputs`` to look up specs by name.
 
-        - Resolve a relative :attr:`tesseract_dir` against
-          :data:`TESSERACTS_DIR` (so configs can pass a slug string like
-          ``"navier-stokes-grid"``).
-        - Wrap :attr:`make_inputs` so it looks up the :class:`SolverSpec`
-          from the solver name. The user-provided callable has signature
-          ``(spec: SolverSpec, ic, **physics) -> dict``; the wrapped
-          version exposed as ``cfg.make_inputs`` has signature
-          ``(name: str, ic, **physics) -> dict``. This drops the
-          per-problem ``build_make_inputs(solvers)`` closure factory.
-
-        ICs are registered explicitly via :meth:`add_ic` after construction —
-        no auto-registration from :attr:`make_ic` happens here.
+        The user-provided ``make_inputs`` has signature
+        ``(spec: SolverSpec, ic, **physics) -> dict``; the wrapped version
+        exposed as ``cfg.make_inputs`` takes a ``name: str`` instead.
         """
         if isinstance(self.tesseract_dir, str):
             self.tesseract_dir = Path(self.tesseract_dir)
@@ -198,12 +128,8 @@ class Problem:
             self.tesseract_dir = TESSERACTS_DIR / self.tesseract_dir
 
         if self.make_inputs is not None:
-            # __post_init__ also runs when ``dataclasses.replace(cfg, solvers=...)``
-            # builds a filtered copy (CLI -s filter, --hardware filter, etc.).
-            # Unwrap to the original user function before re-wrapping, otherwise
-            # the second pass nests `wrapper(wrapper(...))` and the inner call
-            # receives a SolverSpec where it expected a name → ``TypeError:
-            # unhashable type: 'SolverSpec'``.
+            # ``dataclasses.replace(cfg, solvers=...)`` re-runs ``__post_init__``;
+            # unwrap to the original user fn so we don't double-wrap.
             _user_fn = getattr(self.make_inputs, "_mosaic_raw", self.make_inputs)
             _spec_by_name = {s.name: s for s in self.solvers}
 
@@ -289,55 +215,22 @@ class Problem:
         status_check: list | None = None,
         **config,
     ) -> None:
-        """Register an experiment at ``key`` with optional sweep + plot + reduce.
+        """Register an experiment at ``key``.
 
-        Any value inside ``**config`` (top-level or nested inside a dict
-        kwarg) that is a list-of-primitives is treated as a **sweep axis**.
-        Multiple sweep axes must have matching lengths; the framework
-        parallel-zips them and registers one sub-experiment per zipped
-        tuple, keyed at ``<key>/<auto-suffix>``. The suffix is derived
-        from the differing key→value pairs (e.g. ``steps_10_nu_0p001``).
+        List-valued entries in ``**config`` (nested one level inside dict
+        kwargs like ``physics={"N": [...]}``) become sweep axes; multi-axis
+        sweeps are parallel-zipped. Variant fan-out via ``runs=[{...}, ...]``
+        registers one sub-experiment per variant under ``<key>/<variant>``.
 
-        If no sweep axes are present, a single experiment is registered
-        at ``key`` exactly.
+        ``plot`` accepts a single callable or a ``{view: callable, ...}`` dict
+        (each view runs independently; an exception in one is logged and
+        skipped). ``status_check`` adds per-experiment status callables on
+        top of suite-level defaults. ``plot_description`` is stored on the
+        experiment's params for ``mosaic status`` to display.
 
-        ``plot`` (optional) is registered once at the **parent** ``key`` —
-        it runs after all sub-experiments complete and receives either the
-        list of per-sub-experiment result dicts (if ``reduce is None``) or
-        ``reduce(results)`` otherwise. Plots that need ``exp_key=`` get it
-        wrapped in automatically.
-
-        Pass a ``dict[str, callable]`` instead of a single callable to
-        attach **multiple views** to one experiment (mirrors the asie
-        ``plot={"view": fn, ...}`` shape). Each entry runs independently;
-        an exception in one view is logged but does not skip the others.
-        Each view receives the same ``(cfg, exp_key=..., sub_keys=...)``
-        kwargs the single-callable form would — a view's signature
-        decides which of those it sees, exactly like the single-callable
-        case.
-
-        ``plot_description`` is stored on every sub-experiment's params for
-        introspection (e.g. ``mosaic status``).
-
-        ``status_check`` (optional) is a list of check callables (built via
-        the factories in :mod:`mosaic.benchmarks.core.status_checks` —
-        ``median_k(k)``, ``max_error(t)``, ``min_cosine(t)``, …) attached to
-        every sub-experiment's params. Merged on top of any suite-level
-        defaults from :attr:`status_checks` when the status pipeline
-        classifies a result.
-
-        Per-experiment exclusions are attached via :meth:`exclude` — call
-        ``problem.exclude(key, {solver_name: Exclusion, ...})`` immediately
-        after this method to register them at the same key.
+        Per-(solver, experiment) exclusions are attached via
+        ``problem.exclude(key, {solver_name: Exclusion, ...})``.
         """
-        # Shorthand: ``run=dict`` wraps into ``runs=[dict]`` and list-valued
-        # fields in the run get auto-converted into the runner's sweep dict
-        # form (``sweep={"key": k, "values": [...]}`` + scalar override).
-        # The kernel's ``sweep_mode`` decides whether auto-sweep detection
-        # applies — kernels declared ``sweep_mode="none"`` consume list-valued
-        # config fields directly off ``ctx.run`` (e.g. ``fd_check`` iterating
-        # ``fd.eps_values``), so we must not collapse those lists into
-        # ``sweep=`` + scalar placeholder.
         from mosaic.benchmarks.core.experiment import get_kernel_config
 
         kernel_sweep_mode = get_kernel_config(kernel).get("sweep_mode", "none")
@@ -425,32 +318,17 @@ class Problem:
     ) -> dict:
         """Convert ``.add_experiment()`` shorthand into the canonical runner payload.
 
-        Two accepted input forms (in order of precedence):
+        Two input shapes are accepted: ``runs=[{...}, ...]`` (passed through),
+        or bare run-dict fields (``ic=``, ``physics=``, ``fd=``, ``optim=``,
+        ``jacobian=``, ``reference=``, ``sweep=``) which are collected into a
+        single run dict. A list-of-dicts in any field fans out to one variant
+        per element (parallel-zipped across fields).
 
-        1. ``runs=[{...}, ...]`` (explicit multi-variant): pass through.
-           Use this when variants have **structurally different** payloads
-           — e.g. different swept keys per variant (``physical_laws``:
-           ``vs_N``, ``vs_steps``, ``vs_nu``).
-        2. Bare run-dict fields (``ic=``, ``physics=``, ``fd=``, ``optim=``,
-           ``jacobian=``, ``reference=``, ``sweep=``) at the top level:
-           collected into a single run dict, then wrapped into
-           ``runs=[{...}]``. When any payload field is a **list of dicts**
-           (e.g. ``ic=[{tgv}, {multimode}]``), it fans out: each element
-           becomes one variant, with shared fields broadcast. Multiple
-           list-of-dicts fields parallel-zip (same length required).
-
-        After collection, each run dict is scanned for list-valued fields
-        (nested one level inside ``physics``/``fd``/``optim``/etc.). The
-        first list found becomes the sweep axis: ``sweep={"key": k, "values":
-        [...]}`` is added and the field is replaced with its first value (a
-        placeholder; the runner overwrites it per sweep iteration). When an
-        explicit ``sweep=`` is supplied via shorthand, auto-detect is skipped.
-
-        ``sweep_mode`` mirrors the kernel decorator's ``sweep_mode``. When it
-        is ``"none"`` the runner ignores the ``sweep=`` block entirely, so
-        list-valued fields on the run dict are kernel inputs (e.g. ``fd_check``
-        iterating ``fd.eps_values``) — auto-sweep detection is skipped so we
-        don't substitute the original list with a scalar placeholder.
+        Each run dict is then scanned for the first list-valued field nested
+        one level inside a dict kwarg — that becomes the sweep axis
+        (``sweep={"key": k, "values": [...]}``). For ``sweep_mode="none"``
+        kernels auto-detection is skipped: the kernel consumes the list
+        directly off ``ctx.run``.
         """
         # ── Step 1: collect run dict(s) ─────────────────────────────────
         if "runs" in config:

--- a/mosaic/benchmarks/core/experiment.py
+++ b/mosaic/benchmarks/core/experiment.py
@@ -116,25 +116,11 @@ def kernel(
     snapshot_filename: str = "gradient_fields.npz",
     snapshot_prefixes: tuple[str, ...] = ("grad",),
 ):
-    """Decorator: tag a function as an experiment kernel and attach its framework config.
+    """Decorator: tag a ``(t, ctx) -> dict`` function as an experiment kernel.
 
-    The decorated function is still a plain ``(t, ctx) -> dict`` — the
-    decorator just attaches a ``_mosaic_kernel_config`` attribute so
-    :meth:`Problem.add_experiment` can recognise it and route the registration
-    through :func:`run_experiment` automatically.
-
-    Example::
-
-        @kernel(sweep_mode="default", horizons_shared=True)
-        def param_sweep(t, ctx):
-            ...
-
-        problem.add_experiment(
-            "gradient/horizon_sweep",
-            param_sweep,        # ← kernel, not a wrapper
-            physics={"steps": [10, 20, 40, 80]},
-            ...,
-        )
+    Attaches a ``_mosaic_kernel_config`` attribute that
+    :meth:`Problem.add_experiment` reads to route registration through
+    :func:`run_experiment`.
     """
 
     def decorate(fn):
@@ -196,14 +182,9 @@ def run_experiment(  # noqa: C901, PLR0913 — generic harness, refactor tracked
 ) -> dict:
     """Generic per-solver experiment driver.
 
-    Most callers won't invoke this directly — they decorate a kernel with
-    :func:`experiment` and pass it to :meth:`Problem.add_experiment`, which
-    routes through here. The signature is exposed for direct programmatic
-    use (one-off runs, tests).
-
-    Staleness: :func:`save_harness_result` is called with
-    ``harness_fn=kernel_fn`` so editing the kernel correctly invalidates
-    cached results.
+    Called from the closure :meth:`Problem.add_experiment` builds; not
+    typically invoked directly. ``save_harness_result`` is called with
+    ``harness_fn=kernel_fn`` so editing the kernel invalidates cached results.
     """
     if sweep_mode not in ("none", "default", "limits"):
         raise ValueError(

--- a/mosaic/benchmarks/core/io.py
+++ b/mosaic/benchmarks/core/io.py
@@ -56,16 +56,7 @@ RESULTS_DIR_ENV = "MOSAIC_RESULTS_DIR"
 
 
 def results_dir() -> Path:
-    """Return the root results directory, respecting env-var overrides.
-
-    Priority:
-      1. ``MOSAIC_RESULTS_DIR`` env var (set by ``--output-dir`` or the shell).
-      2. ``Path.cwd() / "mosaic-results"`` otherwise.
-
-    The legacy behaviour wrote inside the git tree (``mosaic/results``); that
-    broke read-only installs and made the output location invisible to the
-    caller.
-    """
+    """Root results directory: ``$MOSAIC_RESULTS_DIR`` if set, else ``./mosaic-results``."""
     if d := os.environ.get(RESULTS_DIR_ENV):
         return Path(d)
     return Path.cwd() / "mosaic-results"

--- a/mosaic/benchmarks/core/memory.py
+++ b/mosaic/benchmarks/core/memory.py
@@ -1,28 +1,18 @@
 """Background-polled memory sampler for GPU VRAM and container RAM.
 
-This module owns three concerns that previously lived inside the gradient
-suite:
+* :func:`sample_vram_mib` — single-shot NVML query.
+* :func:`sample_container_ram_mib` — single-shot Docker-SDK query.
+* :func:`container_id_from_tesseract` — pull the container name from a
+  served Tesseract handle.
+* :class:`MemoryPoller` — context manager that records **peak** observed
+  VRAM and RAM. Use it when the container may be OOM-killed mid-call so
+  the last sample before the kill captures the threshold;
+  :class:`~mosaic.benchmarks.core.hardware.ResourceSampler` is the cheaper
+  delta variant for healthy steady-state workloads.
 
-  * Single-shot memory queries — :func:`sample_vram_mib` (via NVML) and
-    :func:`sample_container_ram_mib` (via the Docker SDK).
-  * Tesseract → container-id extraction — :func:`container_id_from_tesseract`,
-    which understands both modern (``_serve_context``) and legacy
-    (``_container`` / ``_service`` / ``_backend``) layouts.
-  * A polling sampler — :class:`MemoryPoller`, used as a context manager,
-    that records the **peak** observed VRAM and RAM across the lifetime of
-    the block. This is the right tool for failure-boundary experiments
-    such as horizon_sweep_limits, where the container can be OOM-killed
-    mid-call: the last sample taken before the kill captures the
-    ~OOM threshold (a final-delta read would either be 0 or fail).
-
-Both single-shot queries are best-effort: they return ``None`` on any
-failure (no NVIDIA driver, no Docker socket, container gone, …) so
-callers degrade gracefully on CPU-only / no-Docker hosts.
-
-The complementary tool, :class:`mosaic.benchmarks.core.hardware.ResourceSampler`,
-is a cheaper *before/after delta* sampler. Pick the poller when you need
-absolute peak or expect the container to die; pick ResourceSampler when
-you only want the workload's incremental cost in the steady state.
+Single-shot queries are best-effort (no NVIDIA driver, no Docker socket,
+container gone → ``None``) so callers degrade gracefully on CPU-only
+hosts.
 """
 
 from __future__ import annotations
@@ -119,30 +109,15 @@ def sample_container_ram_mib(container_id: str) -> float | None:
 
 
 def container_id_from_tesseract(t) -> str | None:
-    """Extract a Docker container name/ID from a Tesseract instance.
+    """Extract the container name/ID from a served Tesseract handle.
 
-    Prefers ``_serve_context['container_name']`` (tesseract_core ≥ 0.9),
-    then falls back to scanning legacy Docker-SDK Container object
-    attributes. Returns ``None`` if neither path yields an ID.
+    Reads ``_serve_context['container_name']``; returns ``None`` when the
+    handle has no serve context (e.g. ``from_tesseract_api`` rather than
+    ``from_image``).
     """
-    try:
-        ctx = getattr(t, "_serve_context", None)
-        if isinstance(ctx, dict):
-            name = ctx.get("container_name") or ctx.get("container_id")
-            if name:
-                return name
-    except Exception:
-        pass
-    for attr in ("_container", "container", "_service", "_backend"):
-        try:
-            obj = getattr(t, attr, None)
-            if obj is None:
-                continue
-            cid = getattr(obj, "id", None) or getattr(obj, "short_id", None)
-            if isinstance(cid, str) and len(cid) >= 12:
-                return cid[:12]
-        except Exception:
-            continue
+    ctx = getattr(t, "_serve_context", None)
+    if isinstance(ctx, dict):
+        return ctx.get("container_name") or ctx.get("container_id")
     return None
 
 

--- a/mosaic/benchmarks/core/status.py
+++ b/mosaic/benchmarks/core/status.py
@@ -148,8 +148,8 @@ def _lookup_check(cfg: Problem, suite: str, experiment: str) -> list:
       3. ``cfg.experiments[full].params["status_check"]`` — inline overrides
          set on the ``.add_experiment(..., status_check=[...])`` call
 
-    Each source may be either a list of callables (canonical) or a legacy
-    threshold dict; both are normalized via :func:`status_checks.normalize`.
+    Each source is a list of callables (or a single callable); both shapes
+    are normalised via :func:`status_checks.normalize`.
     """
     from .status_checks import normalize
 
@@ -940,7 +940,7 @@ def _refine_for_suite(
 def _row_harness_stale(data: dict, harness_hash_cache: dict[str, str | None]) -> bool:
     """Whether the result's stored harness hash matches the current source.
 
-    Missing-or-empty stored hash → stale (strict legacy policy).
+    Missing-or-empty stored hash → stale.
     """
     stored_harness_hash = data.get("harness_hash")
     stored_harness_fn = data.get("harness_fn")
@@ -961,9 +961,9 @@ def _apply_staleness(
     """Mark row-level (harness) and cell-level (tesseract) staleness on cells.
 
     Row-level: if the stored harness hash differs from the current on-disk
-    source (or nothing was stored, per the strict legacy policy), every
-    non-excluded cell gets ``*``. Cell-level: mismatch or missing tesseract
-    hash flags that solver alone even if the row as a whole isn't stale.
+    source (or no hash was stored), every non-excluded cell gets ``*``.
+    Cell-level: mismatch or missing tesseract hash flags that solver alone
+    even if the row as a whole isn't stale.
     """
     row_stale = _row_harness_stale(data, harness_hash_cache)
     stored_tess = data.get("tesseract_hashes") or {}


### PR DESCRIPTION
## Summary

Two cleanups, net **-176 lines**:

### Legacy paths removed

Stop carrying backward-compat code for tesseract-core versions older than the one we depend on (currently 1.8.0):

- **`container_id_from_tesseract`** — drop the `_container` / `_service` / `_backend` attribute-scan fallback. Only `_serve_context['container_name']` (tesseract-core ≥ 0.9) is supported.
- **`status._lookup_check`** — drop the "legacy threshold dict" mention; `normalize()` has only accepted list/callable for a while now.
- **`results_dir`** — drop the historical note about writing inside the git tree.

### Overly verbose docstrings trimmed

Docstrings that re-explained what the code already shows are replaced by a single sentence covering the load-bearing fact. Examples:

- `Problem.add_experiment` — 40-line walkthrough → ~12 lines covering what `runs=`, list-valued config, `plot=dict`, `status_check`, and `exclude()` do.
- `ExclusionCategory` / `AdStrategy` — drop the schema-rationale paragraphs.
- `Problem.__post_init__` — drop the "wrapper unwrap" deep-dive comment; one line on `dataclasses.replace` re-entry is enough.
- `kernel` / `run_experiment` — drop the example code blocks; the function names tell the reader where to look.

What's preserved: actual interface contracts (the kernel return dict, `discover_solvers` YAML schema, `save_field_snapshots_npz` on-disk layout) — those document behaviour readers can't infer from the code.

## Test plan

- [x] `pytest mosaic/tests/` — 236 passing, 5 failed (same pre-existing scaffold failures on dev)
- [x] `ruff check` clean on every touched file
- [x] All four problems still import cleanly: `python -c "from mosaic.benchmarks.problems import PROBLEMS, get_config; [get_config(p) for p in PROBLEMS]"`

## What's next

This is the cleanup pass before resuming the asie-adoption series:

- ⏳ #32 — `coords` typed sweep position (open)
- After cleanup lands: `Goal(name, description, check)` per-experiment success predicate
- Then: `add_sweep_plot(group_by=..., filter=...)` aggregator-by-coord plot registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)