### PR TITLE
feat(Goal): per-experiment success predicates (asie pattern)

### DIFF
--- a/mosaic/benchmarks/core/config.py
+++ b/mosaic/benchmarks/core/config.py
@@ -69,13 +69,28 @@ class PlotFn(Protocol):
     def __call__(self, cfg: Problem, **kw: Any) -> Any: ...
 
 
+@dataclass(frozen=True)
+class Goal:
+    """Per-experiment success predicate.
+
+    ``check(result_dict) -> bool``. Evaluated after the run; the boolean
+    is persisted into ``result.json`` under ``result["goals"][name]``.
+    A raising check is recorded as ``False``.
+    """
+
+    name: str
+    description: str
+    check: Callable[[dict], bool]
+
+
 @dataclass
 class Experiment:
-    """Registered experiment: runner closure, introspection manifest, sweep coords."""
+    """Registered experiment: runner closure, params, coords, success criteria."""
 
     fn: ExperimentFn
     params: dict = field(default_factory=dict)
     coords: dict[str, Any] = field(default_factory=dict)
+    goals: list[Goal] = field(default_factory=list)
 
 
 @dataclass
@@ -215,6 +230,7 @@ class Problem:
         reduce: Callable | None = None,
         status_check: list | None = None,
         coords: dict[str, Any] | None = None,
+        goals: list[Goal] | None = None,
         **config,
     ) -> None:
         """Register an experiment at ``key``.
@@ -236,6 +252,10 @@ class Problem:
         Persisted into ``result.json`` so aggregator plots can find each
         cell's coordinates without parsing the experiment name.
 
+        ``goals`` is a list of :class:`Goal` success predicates. Each
+        ``check(result_dict) -> bool`` is evaluated after the run and the
+        boolean lands in ``result["goals"][goal.name]``.
+
         Per-(solver, experiment) exclusions are attached via
         ``problem.exclude(key, {solver_name: Exclusion, ...})``.
         """
@@ -251,6 +271,7 @@ class Problem:
         # always — subdir naming lives here at the sweep layer, not in
         # each runner.
         user_coords: dict[str, Any] = dict(coords or {})
+        user_goals: list[Goal] = list(goals or [])
 
         runs = config.get("runs")
         if isinstance(runs, list) and len(runs) > 1:
@@ -271,6 +292,7 @@ class Problem:
                     plot_description=plot_description,
                     status_check=status_check,
                     coords=sub_coords,
+                    goals=user_goals,
                 )
         else:
             sweep_axes = self._collect_sweep_axes(config)
@@ -283,6 +305,7 @@ class Problem:
                     plot_description=plot_description,
                     status_check=status_check,
                     coords=user_coords,
+                    goals=user_goals,
                 )
                 sub_keys = [key]
             else:
@@ -304,6 +327,7 @@ class Problem:
                         plot_description=plot_description,
                         status_check=status_check,
                         coords=sub_coords,
+                        goals=user_goals,
                     )
 
         if plot is not None:
@@ -569,6 +593,7 @@ class Problem:
         plot_description: str = "",
         status_check: list | None = None,
         coords: dict[str, Any] | None = None,
+        goals: list[Goal] | None = None,
     ) -> None:
         """Build the Experiment lambda for a single (scalar) config and store it.
 
@@ -640,7 +665,10 @@ class Problem:
         if status_check:
             params["status_check"] = list(status_check)
         self.experiments[key] = Experiment(
-            fn=fn, params=params, coords=dict(coords or {})
+            fn=fn,
+            params=params,
+            coords=dict(coords or {}),
+            goals=list(goals or []),
         )
 
     def add_ic(

--- a/mosaic/benchmarks/core/experiment.py
+++ b/mosaic/benchmarks/core/experiment.py
@@ -506,14 +506,24 @@ def run_experiment(  # noqa: C901, PLR0913, PLR0915 — generic harness, refacto
             existing.update(solver_failures)
             result["_solver_failures"] = existing
 
-        # Persist this experiment's sweep coordinates so aggregator plots
-        # (and downstream readers) don't need to re-parse the experiment
-        # name to discover its position in parameter space.
+        # Persist this experiment's sweep coordinates and evaluate its
+        # success predicates so the status pipeline can read both from
+        # ``result.json``.
         if isinstance(result, dict):
             _full_key = f"{suite}/{exp_key}"
             _exp = cfg.experiments.get(_full_key)
             if _exp is not None and _exp.coords:
                 result.setdefault("coords", dict(_exp.coords))
+            if _exp is not None and _exp.goals:
+                goal_results: dict[str, bool] = {}
+                for _goal in _exp.goals:
+                    try:
+                        goal_results[_goal.name] = bool(_goal.check(result))
+                    except Exception:
+                        # A raising check is recorded as failure rather than
+                        # crashing the run — goals are diagnostics, not gates.
+                        goal_results[_goal.name] = False
+                result.setdefault("goals", goal_results)
 
         save_harness_result(
             result,

--- a/mosaic/tests/core/test_goals.py
+++ b/mosaic/tests/core/test_goals.py
@@ -1,0 +1,111 @@
+"""Tests for ``Goal`` per-experiment success predicates.
+
+``Goal(name, description, check)`` is registered via
+``Problem.add_experiment(goals=[Goal(...), ...])``. After each run,
+``run_experiment`` evaluates every goal against the result dict and
+writes the result under ``result["goals"][goal.name]``. A raising check
+records ``False`` instead of crashing the run.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from mosaic.benchmarks.core.config import Goal, Problem
+from mosaic.benchmarks.core.experiment import kernel
+
+
+@kernel(sweep_mode="none")
+def _noop(t, ctx) -> dict:
+    return {"metrics": {}}
+
+
+def _make_problem() -> Problem:
+    return Problem(
+        name="test",
+        tesseract_dir="navier-stokes-grid",
+        output_key="result",
+        ic_key="v0",
+        solvers=[],
+        make_ic={"default": lambda **kw: None},
+        make_inputs=lambda spec, ic, **kw: {},
+        error_fn=lambda *a, **k: 0.0,
+    )
+
+
+class GoalRegistrationTests(unittest.TestCase):
+    def test_goal_dataclass_is_frozen(self) -> None:
+        import dataclasses
+
+        g = Goal("ok", "doc", check=lambda r: True)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            g.name = "renamed"
+
+    def test_no_goals_means_empty_list(self) -> None:
+        p = _make_problem()
+        p.add_experiment("fwd/baseline", _noop, physics={"N": 32})
+        self.assertEqual(p.experiments["fwd/baseline"].goals, [])
+
+    def test_goals_attached_to_single_leaf(self) -> None:
+        g = Goal("rel_error_below_1pct", "rel err < 1%", check=lambda r: True)
+        p = _make_problem()
+        p.add_experiment("fwd/baseline", _noop, physics={"N": 32}, goals=[g])
+        self.assertEqual(p.experiments["fwd/baseline"].goals, [g])
+
+    def test_goals_attached_to_each_variant_in_fan_out(self) -> None:
+        g1 = Goal("g1", "first", check=lambda r: True)
+        g2 = Goal("g2", "second", check=lambda r: False)
+        p = _make_problem()
+        p.add_experiment(
+            "fwd/agreement",
+            _noop,
+            runs=[
+                {"name": "tgv", "ic": {"name": "default"}, "physics": {"N": 32}},
+                {"name": "mm", "ic": {"name": "default"}, "physics": {"N": 32}},
+            ],
+            goals=[g1, g2],
+        )
+        for k, v in p.experiments.items():
+            if k.startswith("fwd/agreement/"):
+                self.assertEqual(v.goals, [g1, g2])
+
+
+class GoalEvaluationTests(unittest.TestCase):
+    """``Experiment``-level helper: evaluate goals against a synthetic result."""
+
+    def _eval(self, goals: list[Goal], result: dict) -> dict[str, bool]:
+        # Mirror the evaluation block inside ``run_experiment`` so we can
+        # test it without standing up the full runner.
+        out: dict[str, bool] = {}
+        for g in goals:
+            try:
+                out[g.name] = bool(g.check(result))
+            except Exception:
+                out[g.name] = False
+        return out
+
+    def test_all_pass_pass(self) -> None:
+        goals = [
+            Goal("a", "", check=lambda r: r["x"] > 0),
+            Goal("b", "", check=lambda r: r["y"] < 10),
+        ]
+        self.assertEqual(self._eval(goals, {"x": 1, "y": 5}), {"a": True, "b": True})
+
+    def test_one_fails_one_passes(self) -> None:
+        goals = [
+            Goal("ok", "", check=lambda r: True),
+            Goal("nope", "", check=lambda r: False),
+        ]
+        self.assertEqual(self._eval(goals, {}), {"ok": True, "nope": False})
+
+    def test_raising_check_records_false(self) -> None:
+        def boom(_):
+            raise RuntimeError("predicate blew up")
+
+        goals = [Goal("safe", "", check=lambda r: True), Goal("boom", "", check=boom)]
+        out = self._eval(goals, {})
+        self.assertEqual(out, {"safe": True, "boom": False})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Third of the four-PR asie-adoption series. Adds `Goal(name, description, check)` per-experiment success predicates.

```python
from mosaic.benchmarks.core.config import Goal

problem.add_experiment(
    "gradient/fd_check",
    fd_check,
    physics={"N": 32, ...},
    goals=[
        Goal("forward_finite", "no NaN/Inf in u_final",
             check=lambda r: all(np.all(np.isfinite(s.get("u_final", [])))
                                 for s in r.get("by_solver", {}).values())),
        Goal("rel_l2_below_1pc", "rel-L2 vs reference < 1%",
             check=lambda r: max(s.get("rel_l2", 1.0)
                                 for s in r.get("by_solver", {}).values()) < 0.01),
    ],
)
```

After the run, `run_experiment` evaluates every goal against the result dict and writes `result["goals"][goal.name] = True/False`. Downstream readers (status pipeline, aggregator plots) can surface goal-pass vs goal-fail directly from `result.json`.

A raising `check` is recorded as `False` rather than crashing the run — goals are diagnostics, not gates.

## Implementation

- New `Goal` frozen dataclass in `core/config.py`.
- New `goals: list[Goal]` field on `Experiment` (alongside `params`, `coords`).
- New `goals=` kwarg on `Problem.add_experiment` and `_register_one_experiment`.
- Variant fan-out propagates the full `goals` list to each sub.
- `run_experiment` evaluates goals next to the existing coords-injection block and writes `result["goals"]` before `save_harness_result`.

## Test plan

- [x] `pytest mosaic/tests/core/test_goals.py` — 7 new tests pass
- [x] `pytest mosaic/tests/` — 243 passing, 5 failed (same pre-existing scaffold failures on dev)
- [x] `ruff check` clean (pre-commit ran)

## What's next

Final asie PR after this: `add_sweep_plot(group_by=..., filter=...)` aggregator-by-coord plot registration (uses PR #32's `coords`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)