### PR TITLE
fix: cap drag_opt max_iters to keep optimization runner ≤ 6h

### DIFF
--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -424,14 +424,9 @@ problem.add_experiment(
     },
     optim={
         "lr": 5e-4,
-        # CI budget cap (≤ 6h per matrix runner): at N=32 with steps=400 the
-        # slowest registered solver (PICT) takes ~44 s/iter on the GPU runner,
-        # so a 250-iter ceiling keeps `optimization | ns-grid | gpu` under
-        # ~3h45m total wall (PICT 3h05m + PhiFlow 35m + XLB 1m). The
-        # previous max_iters=500 made PICT run ~6h08m and the whole runner
-        # 7h34m — over the workflow's 6h budget. Adam on this problem has
-        # historically not converged within either budget, so the cut just
-        # truncates a non-converging tail.
+        # max_iters=250 keeps the GPU runner under the 6h CI budget; Adam
+        # doesn't converge within either budget here, so 250 just truncates a
+        # non-converging tail.
         "max_iters": 250,
         "patience": 50,
         "flow_penalty_weight": 50.0,

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -424,8 +424,16 @@ problem.add_experiment(
     },
     optim={
         "lr": 5e-4,
-        "max_iters": 500,
-        "patience": 100,
+        # CI budget cap (≤ 6h per matrix runner): at N=32 with steps=400 the
+        # slowest registered solver (PICT) takes ~44 s/iter on the GPU runner,
+        # so a 250-iter ceiling keeps `optimization | ns-grid | gpu` under
+        # ~3h45m total wall (PICT 3h05m + PhiFlow 35m + XLB 1m). The
+        # previous max_iters=500 made PICT run ~6h08m and the whole runner
+        # 7h34m — over the workflow's 6h budget. Adam on this problem has
+        # historically not converged within either budget, so the cut just
+        # truncates a non-converging tail.
+        "max_iters": 250,
+        "patience": 50,
         "flow_penalty_weight": 50.0,
         "snap_interval": 20,
     },


### PR DESCRIPTION
## Summary

The `optimization | ns-grid | gpu` matrix runner is the **only one currently over the 6h workflow budget**. From the existing prod `wall_time_s` data under `mosaic-results/`:

| experiment | solver | wall |
|---|---|---:|
| drag_opt | PICT | 6h 08m |
| drag_opt | PhiFlow | 1h 24m |
| drag_opt | XLB | 1m 07s |
| **runner total** | | **7h 34m** ⚠ >6h |

PICT runs at ~44 s/iter on the N=32 grid (steps=400), so it hits the 6h ceiling at ~500 iters and the optimizer never converges. Cutting `optim.max_iters` from 500 to 250 (and `patience` from 100 to 50) just truncates that non-converging tail — the convergence curves up to iter 250 are unchanged.

Expected after this change (linear in iter count):

| experiment | solver | new wall |
|---|---|---:|
| drag_opt | PICT | ~3h 04m |
| drag_opt | PhiFlow | ~42m |
| drag_opt | XLB | ~34s |
| **new runner total** | | **~3h 47m** |

## Why not touch other runners

I audited every `(suite, problem, hardware)` runner against the registered-experiment set (orphan legacy result.json files filtered out). Sorted runners:

| problem | suite | hw | total |
|---|---|---|---:|
| ns-grid | optimization | gpu | **7h 34m** ⚠ |
| thermal-mesh | cost | cpu | 3h 46m |
| ns-3d-grid | gradient | gpu | 2h 21m |
| thermal-mesh | cost | gpu | 1h 17m |
| ns-3d-grid | gradient | cpu | 1h 16m |
| ns-grid | gradient | gpu | 1h 13m |
| ns-3d-grid | optimization | gpu | 1h 09m |
| (everything else) | | | < 1h |

Only `ns-grid / optimization / gpu` is over the 6h budget. Trimming the others would be premature.

## Why not exclude PICT / lower N

- **N=32**: kept as-is — the existing comment in `config.py` (lines 410-412) documents that N=64 breaks IBM hard-masking in jax-cfd; the constraint is independent of iter count.
- **PICT exclusion**: PICT is a legitimate solver in this benchmark; it just doesn't converge fast on this problem. Excluding it would lose comparison data. Capping iters keeps the comparison, drops the dead tail.

## How I produced these numbers

- `mosaic timing-report --top 50` (from PR #55) over `mosaic-results/` — gives per-cell wall times.
- A small analysis script that buckets cells into the (problem, suite, hardware) matrix runners, restricted to currently-registered experiments + currently-registered solvers (filtering out orphan `_debug` dirs and legacy lower-case solver names from before the rename).
- Cross-checked against the in-flight time-audit workflow on PR #55 — debug-mode timing showed the same cell ordering (drag_opt PICT slowest by far).

## Test plan

- [x] `pytest tests/` — 295 passed (unchanged)
- [x] Diff is config-only, no harness/kernel changes
- [ ] Once merged: kick off a full Benchmark run on main; confirm `optimization | ns-grid | gpu` finishes under 4h

🤖 Generated with [Claude Code](https://claude.com/claude-code)