### PR TITLE
doc: better plots & common styling

### DIFF
--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/config.py
@@ -60,7 +60,6 @@ from mosaic.benchmarks.problems.shared.plots.ics import plot_ic
 from mosaic.benchmarks.problems.shared.plots.solver_styles import apply_styles
 
 from .exclusions import register as _register_exclusions
-from .extras import register as _register_extras
 from .ics import _abc_flow, _rand_div_free_3d, _tgv3d, _tgv3d_analytic
 from .optimization import recovery
 from .physics import DIAGNOSTICS, make_inputs
@@ -413,8 +412,5 @@ problem.add_extra_plot(
 
 # All per-solver exclusions live in :mod:`.exclusions`.
 _register_exclusions(problem)
-
-# Cross-domain / cross-experiment aggregator plots (registered as _extra/<key>).
-_register_extras(problem)
 
 __all__ = ["problem"]

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/config.py
@@ -53,13 +53,13 @@ from mosaic.benchmarks.problems.shared.plots.forward import (
 )
 from mosaic.benchmarks.problems.shared.plots.gradient import (
     plot_fd_check,
-    plot_horizon_sweep,
     plot_jacobian_svd_comparison,
 )
 from mosaic.benchmarks.problems.shared.plots.ics import plot_ic
 from mosaic.benchmarks.problems.shared.plots.solver_styles import apply_styles
 
 from .exclusions import register as _register_exclusions
+from .extras import _plot_horizon_sweep_limits
 from .ics import _abc_flow, _rand_div_free_3d, _tgv3d, _tgv3d_analytic
 from .optimization import recovery
 from .physics import DIAGNOSTICS, make_inputs
@@ -330,7 +330,7 @@ problem.add_experiment(
         "dt": 0.05,
         "steps": [40, 80, 160, 320, 640, 1280, 2560, 5120, 10240],
     },
-    plot=plot_horizon_sweep,
+    plot=_plot_horizon_sweep_limits,
 )
 problem.add_experiment(
     "gradient/jacobian_svd",

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/extras.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/extras.py
@@ -604,15 +604,14 @@ def _hsl_save_figure(fig: Any, out_dir: Path) -> None:
 
 
 def _plot_horizon_sweep_limits(cfg: Problem, **_kw: Any) -> Any:
-    """``_extra/horizon_sweep_limits`` — VJP rollout-length limit figure."""
-    out_dir = _extra_out_dir(cfg)
-    path = (
-        results_dir()
-        / "ns-3d-grid"
-        / "gradient"
-        / "horizon_sweep_limits"
-        / "result.json"
-    )
+    """``gradient/horizon_sweep_limits`` — VJP rollout-length limit figure.
+
+    Saves alongside the experiment's ``result.json`` (under the gradient
+    suite) so it groups under Gradient in the docs rather than a stray
+    "Extra" section.
+    """
+    out_dir = results_dir() / cfg.name / "gradient" / "horizon_sweep_limits"
+    path = out_dir / "result.json"
     if not path.exists():
         print(f"[horizon_sweep_limits] {path} not found — skipping")
         return None

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/extras.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/extras.py
@@ -167,17 +167,18 @@ def _hsl_parse_one_solver(step_results: dict) -> dict:
     fail_step = fail_vram = fail_wall = fail_ram = fail_ft = None
     for k in all_steps:
         r = step_results[k]
-        if r["status"] == "ok":
+        status = r.get("status")
+        if status == "ok":
             ok_steps.append(int(k))
             ok_vram.append(r.get("vram_peak_mib") or 0.0)
-            ok_wall.append(r["wall_time_s"])
+            ok_wall.append(r.get("wall_time_s") or 0.0)
             ok_gnorm.append(r.get("grad_norm") or 1.0)
-        elif r["status"] == "failed" and fail_step is None:
+        elif status == "failed" and fail_step is None:
             fail_step = int(k)
             fail_vram = r.get("vram_peak_mib") or 1.0
-            fail_wall = r["wall_time_s"]
+            fail_wall = r.get("wall_time_s") or 0.0
             fail_ram = r.get("ram_peak_mib") or 1.0
-            fail_ft = r["failure_type"]
+            fail_ft = r.get("failure_type") or "error"
 
     ok_ram = [step_results[str(s)].get("ram_peak_mib") for s in ok_steps]
     cpu_only = all(v == 0.0 for v in ok_vram) and bool(ok_vram)

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/extras.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/extras.py
@@ -730,6 +730,7 @@ def _plot_scaling(cfg: Problem, **_kw: Any) -> None:
 
     all_els: set[int] = set()
     seen: set[str] = set()
+    fwd_has = vjp_has = ratio_has = False
 
     # ``fwd_data`` / ``vjp_data`` are keyed by spec.name (display form).
     _display_names = set(fwd_data) | set(vjp_data)
@@ -763,12 +764,14 @@ def _plot_scaling(cfg: Problem, **_kw: Any) -> None:
             els_f = [_n_to_elements_3d(n) for n in ns_f]
             ax_fwd.loglog(els_f, [fwd_pts[n] for n in ns_f], **kw)
             all_els.update(els_f)
+            fwd_has = True
 
         if vjp_pts:
             ns_v = sorted(vjp_pts)
             els_v = [_n_to_elements_3d(n) for n in ns_v]
             ax_vjp.loglog(els_v, [vjp_pts[n] for n in ns_v], **kw)
             all_els.update(els_v)
+            vjp_has = True
 
         common_ns = sorted(set(fwd_pts) & set(vjp_pts))
         if len(common_ns) >= 2:
@@ -776,10 +779,12 @@ def _plot_scaling(cfg: Problem, **_kw: Any) -> None:
             ratios = [vjp_pts[n] / fwd_pts[n] for n in common_ns]
             ax_ratio.loglog(els_c, ratios, **kw)
             all_els.update(els_c)
+            ratio_has = True
 
         seen.add(alias)
 
-    ax_ratio.axhline(1.0, color="0.5", linestyle="--", linewidth=0.8, zorder=0)
+    if ratio_has:
+        ax_ratio.axhline(1.0, color="0.5", linestyle="--", linewidth=0.8, zorder=0)
 
     ax_fwd.set_title("Forward time")
     ax_vjp.set_title("VJP time")
@@ -817,6 +822,17 @@ def _plot_scaling(cfg: Problem, **_kw: Any) -> None:
         borderpad=0.5,
         labelspacing=0.3,
     )
+
+    # A log-scaled panel with no plotted data has no positive values and makes
+    # ``savefig`` raise at draw time, dropping the whole figure. Hide empty
+    # panels; bail out entirely if no solver supplied any cost data.
+    for ax, has_data in ((ax_fwd, fwd_has), (ax_vjp, vjp_has), (ax_ratio, ratio_has)):
+        if not has_data:
+            ax.set_visible(False)
+    if not (fwd_has or vjp_has or ratio_has):
+        plt.close(fig)
+        print("[skip] scaling: no cost data to plot")
+        return
 
     out = out_dir / "scaling.png"
     fig.savefig(out)

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
@@ -711,14 +711,6 @@ def plot_recovery(
         out_dir, by_sweep, sweep_vals, sweep_key
     )
 
-    # ── Canonical figure (inlined) ────────────────────────────────────────────
-    # When the experiment lives in a per-IC subdir, reflect the suffix so the
-    # figure lands next to result.json in the IC subdir.
-    paper_suffix = suffix
-    if out_dir != base_dir and out_dir.name != base_dir.name:
-        paper_suffix = f"{suffix}/{out_dir.name}"
-    _plot_recovery_experiment(cfg, exp_key=exp_key, suffix=paper_suffix, save=save)
-
     # ── recovery.png: 2 panels ─────────────────────────────────────────────────
     fig_r = _plot_recovery_summary(
         cfg,
@@ -745,60 +737,16 @@ def plot_recovery(
     rep_horizon = float(
         (npz.get("rep_val") or npz.get("rep_horizon", np.array([0])))[0]
     )
-    rep_horizon_str = f"{rep_horizon:g}"
     solver_names = npz["solver_names"].tolist()
-    ic_true = npz["ic_true"]
-    ic_init = npz["ic_init"]
 
     # Use ic_to_2d when set (e.g. n-body density contrast δ₀ slice),
     # then field_to_2d (e.g. 3D vorticity slice), then vorticity_2d for 2-D.
     f_ic = ic_to_2d or field_to_2d or vorticity_2d
 
-    _plot_ic_field_comparison(
-        cfg,
-        npz,
-        solver_names,
-        ic_true,
-        ic_init,
-        f_ic,
-        styles,
-        sweep_key,
-        rep_horizon_str,
-        out_dir,
-        save,
-    )
     if save:
         _render_recovery_evolution_gifs(
             out_dir, npz, solver_names, f_ic, styles, sweep_key, rep_horizon
         )
-
-    # ── Final temporal state comparison (GT vs recovered rollout) ────────────
-    f_out = ic_to_2d or field_to_2d or vorticity_2d
-    _plot_final_state_comparison(
-        cfg,
-        npz,
-        solver_names,
-        f_out,
-        styles,
-        sweep_key,
-        rep_horizon,
-        out_dir,
-        save,
-    )
-
-    # ── Per-sigma all-solver grid ─────────────────────────────────────────────
-    f_vis = ic_to_2d or field_to_2d or vorticity_2d
-    _plot_per_sigma_grid(
-        cfg,
-        npz,
-        solver_names,
-        ic_true,
-        f_vis,
-        styles,
-        sweep_key,
-        out_dir,
-        save,
-    )
 
     return fig_r
 

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
@@ -27,10 +27,13 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     STRUCTURAL_ORDER,
     TEXTWIDTH,
     THERMAL_ORDER,
+    apply_style,
     dedup_handles,
     fig_shared_legend,
     imshow_with_cbar,
     make_handle,
+    paper_image_grid,
+    paper_row,
     resolve_solver_alias,
     save_fig,
     solver_plot_props,
@@ -122,8 +125,10 @@ def _plot_recovery_summary(
     save: bool,
 ):
     """Build ``recovery.png``: IC recovery improvement + min loss vs sweep."""
-    fig_r, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
+    apply_style()
+    fig_r, (ax1, ax2) = paper_row(2)
 
+    loss_plotted = False
     for name, s_results in by_sweep.items():
         sty = styles.get(name, {})
         xs_ic, ys_ic = [], []
@@ -146,26 +151,28 @@ def _plot_recovery_summary(
             ax1.plot(
                 xs_ic, ys_ic, label=sty.get("label", name), **solver_plot_props(sty)
             )
-        if xs_loss:
+        # Need at least one positive value for the log axis, else savefig raises.
+        if xs_loss and any(y > 0 for y in ys_loss):
             ax2.semilogy(
                 xs_loss, ys_loss, label=sty.get("label", name), **solver_plot_props(sty)
             )
+            loss_plotted = True
+
+    if not loss_plotted:
+        ax2.set_yscale("linear")
 
     ax1.axhline(0, color="gray", ls="--", lw=1, alpha=0.5)
     ax1.axhline(-1, color="gray", ls=":", lw=1, alpha=0.4)
     ax1.set_xlabel(sweep_key)
-    ax1.set_ylabel("Normalised Δ IC error  (final − init) / init")
-    ax1.set_title(
-        f"IC recovery improvement vs {sweep_key}\n(−1 = perfect, 0 = no gain)"
-    )
+    ax1.set_ylabel(r"$\Delta$ IC error  (final $-$ init) / init")
+    ax1.set_title("IC recovery")
     ax1.grid(True, which="both", alpha=0.3)
 
     ax2.set_xlabel(sweep_key)
     ax2.set_ylabel("Min loss (MSE)")
-    ax2.set_title(f"Minimum achieved loss vs {sweep_key}")
+    ax2.set_title("Minimum loss")
     ax2.grid(True, which="both", alpha=0.3)
 
-    fig_r.suptitle(f"{cfg.name} — recovery")
     fig_shared_legend(fig_r, [ax1])
     if save:
         save_fig(fig_r, "optimization", out_dir)
@@ -276,11 +283,10 @@ def _plot_ic_field_comparison(
     save: bool,
 ) -> None:
     """Per-solver row of: true | perturbed | recovered | residual."""
+    apply_style()
     n_solvers = len(solver_names)
     ncols = 4
-    fig_fld, axes_fld = plt.subplots(
-        n_solvers, ncols, figsize=(ncols * 2.6, n_solvers * 2.6), squeeze=False
-    )
+    fig_fld, axes_fld = paper_image_grid(n_solvers, ncols)
 
     w_true = f_ic(ic_true)
     w_init = f_ic(ic_init)
@@ -313,13 +319,15 @@ def _plot_ic_field_comparison(
             v_use = np.abs(arr).max() if v is None else v
             _imshow_panel(ax, fig_fld, arr, v_use, cmap=cm)
             if j == 0:
-                ax.set_title(title)
+                ax.set_title(title, fontsize=7)
             if col == 0:
-                ax.set_ylabel(lbl, fontsize=8)
+                ax.set_ylabel(lbl, fontsize=7)
             ax.axis("off")
 
     fig_fld.suptitle(
-        f"{cfg.name} — IC recovery fields ({sweep_key}={rep_horizon_str})", y=1.01
+        f"IC recovery fields ({sweep_key}$=${rep_horizon_str})",
+        y=1.01,
+        fontweight="bold",
     )
     fig_fld.tight_layout()
     if save:
@@ -342,9 +350,8 @@ def _plot_final_state_comparison(
     has_final = any(f"final_gt_{j}" in npz for j in range(n_solvers))
     if not has_final:
         return
-    fig_fin, axes_fin = plt.subplots(
-        n_solvers, 3, figsize=(3 * 2.6, n_solvers * 2.6), squeeze=False
-    )
+    apply_style()
+    fig_fin, axes_fin = paper_image_grid(n_solvers, 3)
     for j, name in enumerate(solver_names):
         gt_key = f"final_gt_{j}"
         rec_key = f"final_rec_{j}"
@@ -371,12 +378,14 @@ def _plot_final_state_comparison(
             v_use = np.abs(arr).max() if v is None else v
             _imshow_panel(ax, fig_fin, arr, v_use)
             if j == 0:
-                ax.set_title(title)
+                ax.set_title(title, fontsize=7)
             if col == 0:
-                ax.set_ylabel(f"{lbl}\n({sweep_key}={fin_val})", fontsize=8)
+                ax.set_ylabel(f"{lbl}\n({sweep_key}={fin_val})", fontsize=7)
             ax.axis("off")
     fig_fin.suptitle(
-        f"{cfg.name} — final state comparison (best converged {sweep_key})", y=1.01
+        "Final state comparison",
+        y=1.01,
+        fontweight="bold",
     )
     fig_fin.tight_layout()
     if save:
@@ -426,9 +435,9 @@ def _draw_per_sigma_row(
         v_use = vmax_p if vmax_p else np.abs(arr).max() or 1.0
         _imshow_panel(ax, fig_sg, arr, v_use)
         if j == 0:
-            ax.set_title(col_titles[col])
+            ax.set_title(col_titles[col], fontsize=7)
         if col == 0:
-            ax.set_ylabel(lbl, fontsize=8)
+            ax.set_ylabel(lbl, fontsize=7)
         ax.axis("off")
 
 
@@ -463,16 +472,12 @@ def _plot_per_sigma_grid(
     ]
     vmax_ic = np.abs(w_ic_true).max() or 1.0
     vmax_fin = np.abs(w_final_true).max() if w_final_true is not None else 1.0
+    apply_style()
     for si, sv in enumerate(sweep_vals_arr):
         w_ic_pert = (
             f_vis(ic_perturbed_all[si]) if ic_perturbed_all is not None else None
         )
-        fig_sg, axes_sg = plt.subplots(
-            n_solvers,
-            ncols,
-            figsize=(ncols * 2.6, n_solvers * 2.6),
-            squeeze=False,
-        )
+        fig_sg, axes_sg = paper_image_grid(n_solvers, ncols)
         shared = {
             "w_ic_true": w_ic_true,
             "w_ic_pert": w_ic_pert,
@@ -494,7 +499,9 @@ def _plot_per_sigma_grid(
                 shared,
             )
         sv_str = f"{sv:.2g}".rstrip("0").rstrip(".")
-        fig_sg.suptitle(f"{cfg.name} — {sweep_key}={sv_str} · all solvers", y=1.01)
+        fig_sg.suptitle(
+            f"All solvers ({sweep_key}$=${sv_str})", y=1.01, fontweight="bold"
+        )
         fig_sg.tight_layout()
         if save:
             save_fig(fig_sg, f"recovery_sigma_{sv_str}", out_dir)
@@ -624,6 +631,11 @@ def _plot_recovery_experiment(
         ax.set_ylabel("Error" if error_key == "errors" else "Loss")
         ax.yaxis.set_major_locator(mticker.LogLocator(base=10, numticks=4))
         ax.yaxis.set_minor_locator(mticker.NullLocator())
+
+    if not seen:
+        # No curve drawn (e.g. all solvers lacked finite errors) — an empty
+        # log-scaled axis makes savefig raise, so drop back to a linear axis.
+        ax.set_yscale("linear")
 
     handles = dedup_handles([make_handle(s) for s in solver_order if s in seen])
     if handles:
@@ -824,7 +836,8 @@ def _render_recovery_evolution_gifs(
         vmax = float(max(np.abs(arr).max() for arr in frames_2d)) or 1.0
 
         label = styles.get(name, {}).get("label", name)
-        fig, ax = plt.subplots(figsize=(5, 4))
+        apply_style()
+        fig, ax = paper_image_grid(1, 1, squeeze=True)
         im = ax.imshow(
             frames_2d[0].T,
             origin="lower",

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
@@ -809,7 +809,9 @@ def _render_recovery_evolution_gifs(
     """
     for j, name in enumerate(solver_names):
         hist_key = f"ic_history_{j}"
-        if hist_key not in npz.files:
+        # ``npz`` is a plain dict from ``try_load_npz`` (not an NpzFile), so
+        # membership is a key check — ``.files`` would AttributeError.
+        if hist_key not in npz:
             continue
         history = np.asarray(npz[hist_key])  # (n_frames, *ic_shape)
         if history.ndim < 2 or history.shape[0] == 0:

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
@@ -33,7 +33,6 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     imshow_with_cbar,
     make_handle,
     paper_image_grid,
-    paper_row,
     resolve_solver_alias,
     save_fig,
     solver_plot_props,
@@ -72,111 +71,6 @@ def _sorted_sweep_vals(by_sweep: dict) -> list:
         _first.keys(),
         key=lambda v: float(v) if str(v).replace(".", "").lstrip("-").isdigit() else 0,
     )
-
-
-def _compute_fallback_ic_error_init(
-    out_dir: Path,
-    by_sweep: dict,
-    sweep_vals: list,
-    sweep_key: str,
-) -> dict[float, float]:
-    """Estimate ``ic_error_init`` per sweep value from ``recovery_fields.npz``.
-
-    When older runs did not record ``ic_error_init`` and the sweep is a
-    ``perturb_sigma`` sweep, recover an approximation by measuring the exact
-    error at the representative sigma and scaling linearly to other sigmas.
-    Returns an empty dict when the fallback cannot be computed.
-    """
-    fallback: dict[float, float] = {}
-    has_ic_error_init = any(
-        (s_results.get(v) or s_results.get(str(v)) or {}).get("ic_error_init")
-        is not None
-        for v in sweep_vals
-        for s_results in by_sweep.values()
-    )
-    if has_ic_error_init or sweep_key != "perturb_sigma":
-        return fallback
-    fp = out_dir / "recovery_fields.npz"
-    if not fp.exists():
-        return fallback
-    npz = try_load_npz(fp)
-    if "ic_true" not in npz or "ic_init" not in npz:
-        return fallback
-    ic_t = npz["ic_true"].astype(float)
-    ic_i = npz["ic_init"].astype(float)
-    rep_v = float((npz.get("rep_val") or npz.get("rep_horizon", np.array([0])))[0])
-    ic_t_norm = float(np.sqrt(np.mean(ic_t**2)))
-    if ic_t_norm <= 0 or rep_v <= 0:
-        return fallback
-    rep_err = float(np.sqrt(np.mean((ic_i - ic_t) ** 2))) / ic_t_norm
-    for v in sweep_vals:
-        fallback[float(v)] = rep_err * float(v) / rep_v
-    return fallback
-
-
-def _plot_recovery_summary(
-    cfg: Problem,
-    by_sweep: dict,
-    sweep_vals: list,
-    sweep_key: str,
-    styles: dict,
-    fallback_ic_error_init: dict[float, float],
-    out_dir: Path,
-    save: bool,
-):
-    """Build ``recovery.png``: IC recovery improvement + min loss vs sweep."""
-    apply_style()
-    fig_r, (ax1, ax2) = paper_row(2)
-
-    loss_plotted = False
-    for name, s_results in by_sweep.items():
-        sty = styles.get(name, {})
-        xs_ic, ys_ic = [], []
-        xs_loss, ys_loss = [], []
-        for v in sweep_vals:
-            r = s_results.get(v) or s_results.get(str(v))
-            if r is None:
-                continue
-            xs_ic.append(float(v))
-            ic_init_val = r.get("ic_error_init") or fallback_ic_error_init.get(float(v))
-            if ic_init_val:
-                ys_ic.append((r["final_ic_error"] - ic_init_val) / ic_init_val)
-            else:
-                ys_ic.append(r["final_ic_error"])
-            errors = r.get("errors") or []
-            if errors:
-                xs_loss.append(float(v))
-                ys_loss.append(min(errors))
-        if xs_ic:
-            ax1.plot(
-                xs_ic, ys_ic, label=sty.get("label", name), **solver_plot_props(sty)
-            )
-        # Need at least one positive value for the log axis, else savefig raises.
-        if xs_loss and any(y > 0 for y in ys_loss):
-            ax2.semilogy(
-                xs_loss, ys_loss, label=sty.get("label", name), **solver_plot_props(sty)
-            )
-            loss_plotted = True
-
-    if not loss_plotted:
-        ax2.set_yscale("linear")
-
-    ax1.axhline(0, color="gray", ls="--", lw=1, alpha=0.5)
-    ax1.axhline(-1, color="gray", ls=":", lw=1, alpha=0.4)
-    ax1.set_xlabel(sweep_key)
-    ax1.set_ylabel(r"$\Delta$ IC error  (final $-$ init) / init")
-    ax1.set_title("IC recovery")
-    ax1.grid(True, which="both", alpha=0.3)
-
-    ax2.set_xlabel(sweep_key)
-    ax2.set_ylabel("Min loss (MSE)")
-    ax2.set_title("Minimum loss")
-    ax2.grid(True, which="both", alpha=0.3)
-
-    fig_shared_legend(fig_r, [ax1])
-    if save:
-        save_fig(fig_r, "optimization", out_dir)
-    return fig_r
 
 
 def _draw_convergence_panel(
@@ -670,17 +564,17 @@ def plot_recovery(
 ) -> Any:
     """Recovery per-experiment plot — styled figure + extras.
 
-    The canonical styled IC-recovery convergence figure is generated
-    inline by :func:`_plot_recovery_experiment` so the polished styling
-    lands on the experiment results dir too. This wrapper
-    additionally produces:
+    This wrapper produces:
 
-      * ``optimization`` — recovery improvement + min-loss summary panel.
       * ``convergence_curves`` — per-sweep-value loss curves grid.
       * ``recovery_fields`` — per-solver true/perturbed/recovered/residual.
       * ``recovery_final_states`` — GT vs recovered rollout panels.
       * ``recovery_sigma_<v>`` — all-solvers-per-sigma grid.
-      * ``recovery_evolution_<solver>.gif`` — IC reconstruction animation.
+      * ``recovery_evolution.gif`` — combined IC reconstruction animation.
+
+    The per-metric "vs steps" summary panel is intentionally omitted: the
+    3D-NS recovery sweeps a single ``steps`` value, so a metric-vs-sweep
+    curve degenerates to one point.
 
     When results live in per-IC subdirectories (from
     ``--experiments <suite>/<exp>/<ic>`` runs), pass ``ic`` to select a specific
@@ -705,23 +599,10 @@ def plot_recovery(
     sweep_key = data.get("sweep_key", "steps")
     sweep_vals = _sorted_sweep_vals(by_sweep)
 
-    # When ic_error_init was not recorded (older runs), estimate it from the npz
-    # for sigma sweeps: compute exact error at rep_val, scale linearly for others.
-    fallback_ic_error_init = _compute_fallback_ic_error_init(
-        out_dir, by_sweep, sweep_vals, sweep_key
-    )
-
-    # ── recovery.png: 2 panels ─────────────────────────────────────────────────
-    fig_r = _plot_recovery_summary(
-        cfg,
-        by_sweep,
-        sweep_vals,
-        sweep_key,
-        styles,
-        fallback_ic_error_init,
-        out_dir,
-        save,
-    )
+    # NOTE: the per-metric "vs steps" summary panel (``optimization.png``,
+    # produced by ``_plot_recovery_summary``) is intentionally NOT generated
+    # here: the 3D-NS recovery runs a single experiment (one ``steps`` value),
+    # so a metric-vs-sweep curve degenerates to a single point and is spurious.
 
     # ── convergence curves (all sweep values) + IC error consensus ───────────
     _plot_convergence_curves(
@@ -731,7 +612,7 @@ def plot_recovery(
     # ── IC field comparison ────────────────────────────────────────────────────
     fields_path = out_dir / "recovery_fields.npz"
     if not fields_path.exists():
-        return fig_r
+        return None
 
     npz = try_load_npz(fields_path)
     rep_horizon = float(
@@ -748,7 +629,7 @@ def plot_recovery(
             out_dir, npz, solver_names, f_ic, styles, sweep_key, rep_horizon
         )
 
-    return fig_r
+    return None
 
 
 def _render_recovery_evolution_gifs(
@@ -760,62 +641,114 @@ def _render_recovery_evolution_gifs(
     sweep_key: str,
     rep_horizon: Any,
 ) -> None:
-    """Write ``recovery_evolution_<solver>.gif`` per solver from ``ic_history_<j>``.
+    """Write a single combined ``recovery_evolution.gif`` for all solvers.
 
-    Each frame is the 2-D scalar view of the IC at snapshot ``frame`` (same
-    mapping used in the static ``recovery_fields`` panel: ``ic_to_2d`` or
-    vorticity).  Shared vmin/vmax across frames keeps colouring stable so the
-    viewer can see the IC re-form rather than a flicker from autoscaling.
-    Silently skips solvers without a recorded history.
+    Builds one figure with a row of image panels — one panel per solver that
+    has a recorded ``ic_history_<j>``. Each panel animates that solver's 2-D
+    scalar view of the IC (same ``ic_to_2d`` / vorticity mapping as the static
+    ``recovery_fields`` panel) re-forming over optimiser snapshots. Frames are
+    synchronised across panels: at frame *k* every panel shows its snapshot-*k*
+    state, and solvers with fewer snapshots hold (clamp to) their last frame.
+    Per-panel vmin/vmax is fixed across frames so the IC re-forming reads
+    clearly rather than flickering from autoscaling. A shared solver legend is
+    placed below the row, deduplicated by canonical alias. Silently skips
+    solvers without a recorded history; emits nothing when none qualify.
     """
+    # ``npz`` is a plain dict from ``try_load_npz`` (not an NpzFile), so
+    # membership is a key check — ``.files`` would AttributeError.
+    panels: list[dict] = []
+    seen_aliases: set[str] = set()
     for j, name in enumerate(solver_names):
         hist_key = f"ic_history_{j}"
-        # ``npz`` is a plain dict from ``try_load_npz`` (not an NpzFile), so
-        # membership is a key check — ``.files`` would AttributeError.
         if hist_key not in npz:
             continue
         history = np.asarray(npz[hist_key])  # (n_frames, *ic_shape)
         if history.ndim < 2 or history.shape[0] == 0:
             continue
-        n_frames = int(history.shape[0])
+        alias = resolve_solver_alias(name)
+        dedup_key = alias if alias is not None else name
+        if dedup_key in seen_aliases:
+            continue
+        seen_aliases.add(dedup_key)
 
-        # Collapse IC to 2-D per frame using the same vorticity/slice helper.
+        n_frames = int(history.shape[0])
         frames_2d = [f_ic(history[i]) for i in range(n_frames)]
         vmax = float(max(np.abs(arr).max() for arr in frames_2d)) or 1.0
-
         label = styles.get(name, {}).get("label", name)
-        apply_style()
-        fig, ax = paper_image_grid(1, 1, squeeze=True)
+        panels.append(
+            {
+                "name": name,
+                "alias": alias,
+                "label": label,
+                "frames": frames_2d,
+                "n": n_frames,
+                "vmax": vmax,
+            }
+        )
+
+    if not panels:
+        return
+
+    n_panels = len(panels)
+    n_frames = max(p["n"] for p in panels)
+
+    apply_style()
+    fig, axes = paper_image_grid(1, n_panels, squeeze=False)
+    axes = np.atleast_1d(axes).ravel()
+
+    images: list = []
+    for ax, p in zip(axes, panels, strict=True):
         im = ax.imshow(
-            frames_2d[0].T,
+            p["frames"][0].T,
             origin="lower",
             cmap="RdBu_r",
-            vmin=-vmax,
-            vmax=vmax,
+            vmin=-p["vmax"],
+            vmax=p["vmax"],
             interpolation="nearest",
         )
-        title = ax.set_title(
-            f"{label} — snapshot 1 / {n_frames}  ({sweep_key}={rep_horizon})",
-            fontsize=9,
-        )
+        images.append(im)
+        ax.set_title(p["label"], fontsize=8)
         ax.axis("off")
-        fig.tight_layout()
 
-        def _update(
-            idx: Any,
-            _im: Any = im,
-            _title: Any = title,
-            _frames: Any = frames_2d,
-            _label: Any = label,
-            _n: Any = n_frames,
-            _sk: Any = sweep_key,
-            _sv: Any = rep_horizon,
-        ) -> Any:
-            _im.set_data(_frames[idx].T)
-            _title.set_text(f"{_label} — snapshot {idx + 1} / {_n}  ({_sk}={_sv})")
-            return _im, _title
+    title = fig.suptitle(
+        f"IC recovery evolution — snapshot 1 / {n_frames}  ({sweep_key}={rep_horizon})",
+        fontsize=9,
+    )
+    fig.tight_layout()
 
-        anim = manimation.FuncAnimation(
-            fig, _update, frames=n_frames, interval=250, blit=False
+    handles = dedup_handles(
+        [make_handle(p["alias"]) for p in panels if p["alias"] is not None]
+    )
+    if handles:
+        fig.legend(
+            handles=handles,
+            loc="lower center",
+            bbox_to_anchor=(0.5, 0.01),
+            ncol=min(len(handles), 5),
+            fontsize=7.5,
+            framealpha=0.7,
+            handlelength=2.0,
         )
-        _save_animation(anim, f"recovery_evolution_{name}", out_dir, fps=4)
+        fig.subplots_adjust(bottom=0.18)
+
+    def _update(
+        idx: Any,
+        _images: Any = images,
+        _panels: Any = panels,
+        _title: Any = title,
+        _n: Any = n_frames,
+        _sk: Any = sweep_key,
+        _sv: Any = rep_horizon,
+    ) -> Any:
+        for _im, _p in zip(_images, _panels, strict=True):
+            k = min(idx, _p["n"] - 1)  # clamp: hold last frame
+            _im.set_data(_p["frames"][k].T)
+        _title.set_text(
+            f"IC recovery evolution — snapshot {idx + 1} / {_n}  ({_sk}={_sv})"
+        )
+        return (*_images, _title)
+
+    anim = manimation.FuncAnimation(
+        fig, _update, frames=n_frames, interval=250, blit=False
+    )
+    _save_animation(anim, "recovery_evolution", out_dir, fps=4)

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
@@ -536,9 +536,10 @@ def _plot_ns_recovery(
             if _PAPER_NS_SIGMA in sweep
             else sorted(sweep.keys())[len(sweep) // 2]
         )
-        errors = sweep[sigma_key].get("errors") or sweep[sigma_key].get(
-            "ic_error_history", []
-        )
+        entry = sweep.get(sigma_key)
+        if not entry:
+            continue
+        errors = entry.get("errors") or entry.get("ic_error_history", [])
         if not errors:
             continue
         _label, color, ls, _mk = solver_props(alias)

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -64,7 +64,6 @@ from mosaic.benchmarks.problems.shared.plots.ics import plot_ic
 from mosaic.benchmarks.problems.shared.plots.solver_styles import apply_styles
 
 from .exclusions import register as _register_exclusions
-from .extras import register as _register_extras
 from .ics import _flat_inflow, _multimode, _tgv, _tgv_analytic, _uniform_flow
 from .optimization import drag_opt
 from .physics import DIAGNOSTICS, make_inputs
@@ -443,10 +442,5 @@ problem.add_extra_plot(
 # All per-solver exclusions live in :mod:`.exclusions`; one call attaches the
 # whole table to the canonical :class:`Problem` instance.
 _register_exclusions(problem)
-
-# Per-domain ``_extra/`` aggregator plots (cost overview, scaling, ucurves)
-# live in :mod:`.extras`; the runner picks them up by scanning ``plot_fns``
-# for ``_extra/`` keys.
-_register_extras(problem)
 
 __all__ = ["problem"]

--- a/mosaic/benchmarks/problems/navier_stokes_grid/extras.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/extras.py
@@ -95,6 +95,7 @@ def _scaling_impl(out_dir: Path) -> None:
 
     all_els: set[int] = set()
     seen: set[str] = set()
+    fwd_has = vjp_has = ratio_has = False
 
     # ``fwd_data`` / ``vjp_data`` are keyed by spec.name (display form);
     # build an alias→display map so we can iterate NS_ORDER (alias form).
@@ -129,12 +130,14 @@ def _scaling_impl(out_dir: Path) -> None:
             els_f = [_n_to_elements_2d(n) for n in ns_f]
             ax_fwd.loglog(els_f, [fwd_pts[n] for n in ns_f], **kw)
             all_els.update(els_f)
+            fwd_has = True
 
         if vjp_pts:
             ns_v = sorted(vjp_pts)
             els_v = [_n_to_elements_2d(n) for n in ns_v]
             ax_vjp.loglog(els_v, [vjp_pts[n] for n in ns_v], **kw)
             all_els.update(els_v)
+            vjp_has = True
 
         common_ns = sorted(set(fwd_pts) & set(vjp_pts))
         if len(common_ns) >= 2:
@@ -142,10 +145,12 @@ def _scaling_impl(out_dir: Path) -> None:
             ratios = [vjp_pts[n] / fwd_pts[n] for n in common_ns]
             ax_ratio.loglog(els_c, ratios, **kw)
             all_els.update(els_c)
+            ratio_has = True
 
         seen.add(alias)
 
-    ax_ratio.axhline(1.0, color="0.5", linestyle="--", linewidth=0.8, zorder=0)
+    if ratio_has:
+        ax_ratio.axhline(1.0, color="0.5", linestyle="--", linewidth=0.8, zorder=0)
 
     ax_fwd.set_title("Forward time")
     ax_vjp.set_title("VJP time")
@@ -185,6 +190,17 @@ def _scaling_impl(out_dir: Path) -> None:
         borderpad=0.5,
         labelspacing=0.3,
     )
+
+    # A log-scaled panel with no plotted data has no positive values and makes
+    # ``savefig`` raise at draw time, dropping the whole figure. Hide empty
+    # panels; bail out entirely if no solver supplied any cost data.
+    for ax, has_data in ((ax_fwd, fwd_has), (ax_vjp, vjp_has), (ax_ratio, ratio_has)):
+        if not has_data:
+            ax.set_visible(False)
+    if not (fwd_has or vjp_has or ratio_has):
+        plt.close(fig)
+        print("[skip] scaling: no cost data to plot")
+        return
 
     out = out_dir / "scaling.png"
     fig.savefig(out)

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -31,8 +31,10 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     imshow_with_cbar,
     make_handle,
     paper_image_grid,
+    paper_row,
     resolve_solver_alias,
     save_fig,
+    solver_legend,
     solver_props,
     solver_styles,
 )
@@ -56,8 +58,9 @@ def plot_drag_opt(
 
       * ``drag_opt_fields`` — per-solver flow field panels (u_x, u_y) when
         ``flow_fields.npz`` is present.
-      * ``drag_opt_evolution_<solver>.gif`` — one inflow-profile animation
-        per solver when ``profiles.npz`` carries ``profile_history_*``.
+      * ``drag_opt_evolution.gif`` — one combined inflow-profile animation
+        with a panel per solver when ``profiles.npz`` carries
+        ``profile_history_*``.
 
     Supports both single-run (drag_opt/result.json) and multi-run
     (drag_opt/<name>/result.json) layouts.
@@ -96,7 +99,7 @@ def plot_drag_opt(
         # ── Flow field visualisation (velocity + vorticity) ──────────────────
         _plot_drag_opt_fields(data, out_dir, run_name, title_suffix, styles, save, figs)
 
-        # ── Inflow profile evolution GIFs (one per solver) ──────────────────
+        # ── Inflow profile evolution GIF (combined, one panel per solver) ───
         if save and "initial" in profiles:
             _render_drag_opt_evolution_gifs(
                 profiles, out_dir, solver_names, styles, run_name
@@ -498,11 +501,15 @@ def _render_drag_opt_evolution_gifs(
     styles: dict,
     run_name: str,
 ) -> None:
-    """Write ``drag_opt_evolution_<solver>.gif`` per solver.
+    """Write a single combined ``drag_opt_evolution.gif`` for all solvers.
 
-    Each frame is a 1-D line plot of the inflow profile u_x(y) at one
-    optimisation snapshot, with the initial profile drawn dashed as a
-    reference.  Skips solvers without a recorded ``profile_history_<name>``.
+    Builds one figure with a row of subplots — one panel per solver that has
+    a recorded ``profile_history_<name>``. Each panel animates that solver's
+    inflow profile u_x(y) over BFGS iterations, with the initial profile drawn
+    dashed as a reference. Frames are synchronised across panels: at frame *k*
+    every panel shows its iteration-*k* state, and solvers with fewer snapshots
+    hold (clamp to) their last frame. A shared solver legend is placed below
+    the row. Solvers are deduplicated by canonical alias so each appears once.
     """
     initial = np.asarray(profiles["initial"])
     N = initial.size
@@ -511,6 +518,9 @@ def _render_drag_opt_evolution_gifs(
     # Treat np.load NpzFile *and* plain dict uniformly via .files / keys.
     keys = set(profiles.files) if hasattr(profiles, "files") else set(profiles.keys())
 
+    # Collect one entry per solver that has a usable history, deduped by alias.
+    panels: list[dict] = []
+    seen_aliases: set[str] = set()
     for name in solver_names:
         hkey = f"profile_history_{name}"
         if hkey not in keys:
@@ -518,8 +528,36 @@ def _render_drag_opt_evolution_gifs(
         hist = np.asarray(profiles[hkey])  # (n_snaps, N)
         if hist.ndim != 2 or hist.shape[0] == 0:
             continue
-        n_frames = int(hist.shape[0])
+        alias = resolve_solver_alias(name)
+        dedup_key = alias if alias is not None else name
+        if dedup_key in seen_aliases:
+            continue
+        seen_aliases.add(dedup_key)
 
+        label, color, _ls, _mk = solver_props(name)
+        panels.append(
+            {
+                "name": name,
+                "alias": alias,
+                "label": label,
+                "color": color,
+                "hist": hist,
+                "n": int(hist.shape[0]),
+            }
+        )
+
+    if not panels:
+        return
+
+    n_panels = len(panels)
+    n_frames = max(p["n"] for p in panels)
+
+    fig, axes = paper_row(n_panels, squeeze=False)
+    axes = np.atleast_1d(axes).ravel()
+
+    lines: list = []
+    for ax, p in zip(axes, panels, strict=True):
+        hist = p["hist"]
         extrema = [
             float(hist.min()),
             float(hist.max()),
@@ -531,41 +569,44 @@ def _render_drag_opt_evolution_gifs(
         xlo -= pad
         xhi += pad
 
-        sty = styles.get(name, {})
-        color = sty.get("color", "#3366CC")
-        label = sty.get("label", name)
-
-        fig, axes = paper_image_grid(1, 1)
-        ax = axes[0, 0]
         ax.plot(initial, y, "k--", lw=1.4, label="initial")
-        (line,) = ax.plot(hist[0], y, color=color, lw=2.0, label=label)
+        (line,) = ax.plot(hist[0], y, color=p["color"], lw=2.0, label=p["label"])
+        lines.append(line)
         ax.set_xlim(xlo, xhi)
         ax.set_ylim(0.0, 1.0)
         ax.set_xlabel(r"$u_x$")
         ax.set_ylabel("$y$")
-        title = ax.set_title(
-            f"{label} — snapshot 1 / {n_frames}"
-            + (f"  ({run_name})" if run_name else "")
-        )
-        ax.legend(loc="best")
-        fig.tight_layout()
+        ax.set_title(p["label"])
 
-        def _update(
-            idx: Any,
-            _line: Any = line,
-            _title: Any = title,
-            _hist: Any = hist,
-            _label: Any = label,
-            _n: Any = n_frames,
-            _rn: Any = run_name,
-        ) -> Any:
-            _line.set_xdata(_hist[idx])
-            _title.set_text(
-                f"{_label} — snapshot {idx + 1} / {_n}" + (f"  ({_rn})" if _rn else "")
-            )
-            return _line, _title
+    sup = (
+        f"Inflow profile evolution — {run_name}"
+        if run_name
+        else "Inflow profile evolution"
+    )
+    fig.suptitle(sup)
 
-        anim = manimation.FuncAnimation(
-            fig, _update, frames=n_frames, interval=250, blit=False
-        )
-        _save_animation(anim, f"drag_opt_evolution_{name}", out_dir, fps=4)
+    # Shared solver legend below the row (canonical order, deduped by alias).
+    initial_handle = mlines.Line2D(
+        [], [], color="k", linestyle="--", lw=1.4, label="initial"
+    )
+    solver_legend(
+        fig,
+        [p["alias"] for p in panels if p["alias"] is not None],
+        order=NS_ORDER,
+        extra_handles=[initial_handle],
+    )
+
+    def _update(
+        idx: Any,
+        _lines: Any = lines,
+        _panels: Any = panels,
+    ) -> Any:
+        for _line, _p in zip(_lines, _panels, strict=True):
+            k = min(idx, _p["n"] - 1)  # clamp: hold last frame
+            _line.set_xdata(_p["hist"][k])
+        return tuple(_lines)
+
+    anim = manimation.FuncAnimation(
+        fig, _update, frames=n_frames, interval=250, blit=False
+    )
+    _save_animation(anim, "drag_opt_evolution", out_dir, fps=4)

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -30,6 +30,7 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     dedup_handles,
     imshow_with_cbar,
     make_handle,
+    paper_image_grid,
     resolve_solver_alias,
     save_fig,
     solver_props,
@@ -387,9 +388,7 @@ def _plot_drag_opt_fields(
     all_rows = ["__initial__", *solver_names_clean]
     n_rows = len(all_rows)
     ncols = 2
-    fig_fld, axes_fld = plt.subplots(
-        n_rows, ncols, figsize=(ncols * 3.5, n_rows * 3.0), squeeze=False
-    )
+    fig_fld, axes_fld = paper_image_grid(n_rows, ncols)
 
     # Compute shared colour scales from the initial flow so all panels are comparable.
     flow_init = npz.get("flow_initial")
@@ -423,7 +422,7 @@ def _plot_drag_opt_fields(
                 interpolation="nearest",
             )
             if row_idx == 0:
-                ax.set_title(col_title, fontsize=10, fontweight="bold")
+                ax.set_title(col_title, fontweight="bold")
             ax.axis("off")
 
         # Row label as text overlaid on the left side of the first column.
@@ -476,10 +475,7 @@ def _plot_drag_opt_fields(
             label += "\n[NOT CONVERGED]"
         _render_row(i + 1, label, field, converged)
 
-    fig_fld.suptitle(
-        f"{run_name or 'drag_opt'} — optimised flow fields ($u_x$ | $u_y$)",
-        y=1.01,
-    )
+    fig_fld.suptitle("Optimised flow fields", fontweight="bold")
     fig_fld.tight_layout()
     if save:
         save_fig(fig_fld, "drag_opt_fields", out_dir)
@@ -530,19 +526,19 @@ def _render_drag_opt_evolution_gifs(
         color = sty.get("color", "#3366CC")
         label = sty.get("label", name)
 
-        fig, ax = plt.subplots(figsize=(4.5, 4.5))
+        fig, axes = paper_image_grid(1, 1)
+        ax = axes[0, 0]
         ax.plot(initial, y, "k--", lw=1.4, label="initial")
         (line,) = ax.plot(hist[0], y, color=color, lw=2.0, label=label)
         ax.set_xlim(xlo, xhi)
         ax.set_ylim(0.0, 1.0)
-        ax.set_xlabel("u_x")
-        ax.set_ylabel("y")
+        ax.set_xlabel(r"$u_x$")
+        ax.set_ylabel("$y$")
         title = ax.set_title(
             f"{label} — snapshot 1 / {n_frames}"
-            + (f"  ({run_name})" if run_name else ""),
-            fontsize=9,
+            + (f"  ({run_name})" if run_name else "")
         )
-        ax.legend(fontsize=8, loc="best")
+        ax.legend(loc="best")
         fig.tight_layout()
 
         def _update(

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -377,18 +377,28 @@ def _plot_drag_opt_fields(
     npz = try_load_npz(fields_path)
     by_solver = data.get("by_solver", {})
     # ``try_load_npz`` returns a plain dict; tolerate both dict and NpzFile.
-    npz_keys = npz.files if hasattr(npz, "files") else list(npz.keys())
-    solver_names = [k for k in npz_keys if k.startswith("flow_final_")]
-    solver_names_clean = [k[len("flow_final_") :] for k in solver_names]
+    npz_keys = set(npz.files if hasattr(npz, "files") else npz.keys())
 
-    if not solver_names:
+    # Drive the rows from ``by_solver`` (the canonical solver set for this
+    # result) rather than scanning every ``flow_final_*`` npz key.  The npz can
+    # accumulate stale per-solver entries from earlier runs (e.g. differently
+    # cased aliases like ``flow_final_XLB`` alongside ``flow_final_xlb``); those
+    # have no ``by_solver`` metadata and would render as blank/duplicate rows.
+    solver_names_clean = [s for s in by_solver if f"flow_final_{s}" in npz_keys]
+
+    if not solver_names_clean:
         return
 
-    # Rows: initial + one per solver.  Columns: velocity magnitude | vorticity.
-    all_rows = ["__initial__", *solver_names_clean]
-    n_rows = len(all_rows)
+    # Rows: initial + one per solver.  Columns: u_x | u_y.
+    n_rows = 1 + len(solver_names_clean)
     ncols = 2
     fig_fld, axes_fld = paper_image_grid(n_rows, ncols)
+    # Reserve a left gutter for the (multi-line) row labels and generous
+    # vertical/horizontal spacing so labels, titles and colorbars never collide.
+    # Done before rendering so ``ax.get_position()`` reflects the final layout.
+    fig_fld.subplots_adjust(
+        left=0.26, right=0.97, top=0.93, bottom=0.03, hspace=0.45, wspace=0.55
+    )
 
     # Compute shared colour scales from the initial flow so all panels are comparable.
     flow_init = npz.get("flow_initial")
@@ -425,19 +435,19 @@ def _plot_drag_opt_fields(
                 ax.set_title(col_title, fontweight="bold")
             ax.axis("off")
 
-        # Row label as text overlaid on the left side of the first column.
-        # axis("off") hides set_ylabel, so use ax.text in axes coordinates.
+        # Row label placed in the left figure gutter (reserved via
+        # subplots_adjust above) so multi-line solver labels never overlap the
+        # neighbouring colorbars or row above/below.
         ax0 = axes_fld[row_idx, 0]
-        ax0.text(
-            -0.12,
-            0.5,
+        pos = ax0.get_position()
+        fig_fld.text(
+            0.015,
+            (pos.y0 + pos.y1) / 2,
             label,
-            transform=ax0.transAxes,
-            fontsize=8,
+            fontsize=7,
             va="center",
-            ha="right",
-            rotation=0,
-            wrap=True,
+            ha="left",
+            linespacing=1.3,
         )
 
         # Red border annotation for non-converged / poor solvers
@@ -476,7 +486,6 @@ def _plot_drag_opt_fields(
         _render_row(i + 1, label, field, converged)
 
     fig_fld.suptitle("Optimised flow fields", fontweight="bold")
-    fig_fld.tight_layout()
     if save:
         save_fig(fig_fld, "drag_opt_fields", out_dir)
     figs.append(fig_fld)

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -387,7 +387,18 @@ def _plot_drag_opt_fields(
     # accumulate stale per-solver entries from earlier runs (e.g. differently
     # cased aliases like ``flow_final_XLB`` alongside ``flow_final_xlb``); those
     # have no ``by_solver`` metadata and would render as blank/duplicate rows.
-    solver_names_clean = [s for s in by_solver if f"flow_final_{s}" in npz_keys]
+    # Additionally dedup by canonical alias: if ``by_solver`` carries both a
+    # display name and an alias mapping to the same solver, keep only the first.
+    solver_names_clean: list[str] = []
+    seen_aliases: set[str] = set()
+    for s in by_solver:
+        if f"flow_final_{s}" not in npz_keys:
+            continue
+        alias = resolve_solver_alias(s) or s
+        if alias in seen_aliases:
+            continue
+        seen_aliases.add(alias)
+        solver_names_clean.append(s)
 
     if not solver_names_clean:
         return
@@ -396,11 +407,25 @@ def _plot_drag_opt_fields(
     n_rows = 1 + len(solver_names_clean)
     ncols = 2
     fig_fld, axes_fld = paper_image_grid(n_rows, ncols)
-    # Reserve a left gutter for the (multi-line) row labels and generous
-    # vertical/horizontal spacing so labels, titles and colorbars never collide.
-    # Done before rendering so ``ax.get_position()`` reflects the final layout.
+    # Widen the figure to host a dedicated left gutter for the (multi-line) row
+    # labels without stealing width from the panels/colorbars.  ``IMG_PANEL`` is
+    # ~1.45" per panel; reserve a fixed ~1.5" gutter on the left.
+    panel_w = fig_fld.get_size_inches()[0] / ncols
+    gutter_w = 1.5
+    fig_w = ncols * panel_w + gutter_w
+    fig_h = fig_fld.get_size_inches()[1]
+    fig_fld.set_size_inches(fig_w, fig_h)
+    left_frac = gutter_w / fig_w
+    # Reserve the left gutter and keep generous vertical/horizontal spacing so
+    # labels, column titles, suptitle and colorbars never collide.  Done before
+    # rendering so ``ax.get_position()`` reflects the final layout.
     fig_fld.subplots_adjust(
-        left=0.26, right=0.97, top=0.93, bottom=0.03, hspace=0.45, wspace=0.55
+        left=left_frac,
+        right=0.97,
+        top=0.90,
+        bottom=0.03,
+        hspace=0.30,
+        wspace=0.55,
     )
 
     # Compute shared colour scales from the initial flow so all panels are comparable.
@@ -435,21 +460,22 @@ def _plot_drag_opt_fields(
                 interpolation="nearest",
             )
             if row_idx == 0:
-                ax.set_title(col_title, fontweight="bold")
+                ax.set_title(col_title, fontweight="bold", pad=6)
             ax.axis("off")
 
         # Row label placed in the left figure gutter (reserved via
-        # subplots_adjust above) so multi-line solver labels never overlap the
-        # neighbouring colorbars or row above/below.
+        # subplots_adjust above).  Right-aligned so the label always ends a
+        # fixed gap left of the panel regardless of its length — multi-line
+        # solver labels never overlap the panels, colorbars or adjacent rows.
         ax0 = axes_fld[row_idx, 0]
         pos = ax0.get_position()
         fig_fld.text(
-            0.015,
+            pos.x0 - 0.02,
             (pos.y0 + pos.y1) / 2,
             label,
             fontsize=7,
             va="center",
-            ha="left",
+            ha="right",
             linespacing=1.3,
         )
 
@@ -488,7 +514,7 @@ def _plot_drag_opt_fields(
             label += "\n[NOT CONVERGED]"
         _render_row(i + 1, label, field, converged)
 
-    fig_fld.suptitle("Optimised flow fields", fontweight="bold")
+    fig_fld.suptitle("Optimised flow fields", fontweight="bold", y=0.97)
     if save:
         save_fig(fig_fld, "drag_opt_fields", out_dir)
     figs.append(fig_fld)

--- a/mosaic/benchmarks/problems/shared/plots/cost.py
+++ b/mosaic/benchmarks/problems/shared/plots/cost.py
@@ -192,7 +192,7 @@ def _build_columns(
                 "spatial_N",
                 spatial_data["by_N"],
                 res_key,
-                "Forward — N scaling",
+                "Forward · N",
                 _first_nonempty_keys(spatial_data["by_N"]),
             )
         )
@@ -203,7 +203,7 @@ def _build_columns(
                 "temporal_steps",
                 temporal_data["by_steps"],
                 "steps",
-                "Forward — steps scaling",
+                "Forward · steps",
                 _first_nonempty_keys(temporal_data["by_steps"]),
             )
         )
@@ -214,7 +214,7 @@ def _build_columns(
                 "vjp_N",
                 vjp_data["by_N"],
                 res_key,
-                "VJP — N scaling",
+                "VJP · N",
                 _first_nonempty_keys(vjp_data["by_N"]),
             )
         )
@@ -225,12 +225,25 @@ def _build_columns(
                 "vjp_steps",
                 vjp_data["by_steps"],
                 "steps",
-                "VJP — steps scaling",
+                "VJP · steps",
                 _first_nonempty_keys(vjp_data["by_steps"]),
             )
         )
 
     return columns
+
+
+def _column_has_data(by_data: dict, keys: list, cfg: Problem) -> tuple[bool, bool]:
+    """Return ``(has_time, has_mem)`` for a column across all solvers."""
+    has_time = False
+    has_mem = False
+    for spec in cfg.solvers:
+        row = by_data.get(spec.name) or {}
+        if any(np.isfinite(v) for v in _time_vals(row, keys)):
+            has_time = True
+        if any(np.isfinite(v) for v in _mem_vals(row, keys)):
+            has_mem = True
+    return has_time, has_mem
 
 
 def _column_x(panel_id: str, keys: list, n_to_cells: Any, xlabel: str) -> tuple:
@@ -278,7 +291,7 @@ def _draw_solver_series(
             failure_types_seen.add(fail_ft)
 
     mem_drawn = False
-    if any(np.isfinite(v) for v in m_ys):
+    if ax_mem is not None and any(np.isfinite(v) for v in m_ys):
         ax_mem.loglog(x_arr, m_ys, **kw)
         if fail_k is not None:
             _draw_failure(ax_mem, x_arr, keys, fail_k, m_ys, color, ls, fail_ft)
@@ -288,43 +301,41 @@ def _draw_solver_series(
 
 
 def _draw_column(
-    axes_grid: Any,
-    col: int,
+    ax_time: Any,
+    ax_mem: Any,
     col_spec: tuple,
     cfg: Problem,
     styles: dict,
     failure_types_seen: set[str],
     *,
     n_to_cells: Any,
-) -> bool:
-    """Draw all solvers on one column. Return True if any memory series was drawn."""
+    first_col: bool,
+) -> None:
+    """Draw all solvers on one column into the given time / memory axes.
+
+    ``ax_mem`` may be ``None`` when the figure has no memory row.
+    """
     panel_id, by_data, xlabel, title, keys = col_spec
-    ax_time = axes_grid[0, col]
-    ax_mem = axes_grid[1, col]
 
     x_arr, xlabel_disp = _column_x(panel_id, keys, n_to_cells, xlabel)
 
-    col_has_mem = False
     for spec in cfg.solvers:
         name = spec.name
         row = by_data.get(name) or {}
         style = styles.get(name, {"color": cfg.solver(name).color})
-        if _draw_solver_series(
+        _draw_solver_series(
             ax_time, ax_mem, x_arr, keys, row, style, cfg, name, failure_types_seen
-        ):
-            col_has_mem = True
+        )
 
     ax_time.set_xlabel(xlabel_disp)
-    ax_time.set_ylabel("Wall-clock time (s)")
+    if first_col:
+        ax_time.set_ylabel("Wall-clock time (s)")
     ax_time.set_title(title)
 
-    ax_mem.set_xlabel(xlabel_disp)
-    ax_mem.set_ylabel("Peak (V)RAM (MiB)")
-
-    if not col_has_mem:
-        ax_mem.set_visible(False)
-
-    return col_has_mem
+    if ax_mem is not None:
+        ax_mem.set_xlabel(xlabel_disp)
+        if first_col:
+            ax_mem.set_ylabel("Peak (V)RAM (MiB)")
 
 
 def _add_failure_legend_entries(ax: Any, failure_types_seen: set[str]) -> None:
@@ -356,7 +367,8 @@ def plot_cost(
     """Cost plots: wall-clock timing + peak (V)RAM (log-log), 2 rows × N columns.
 
     Row 0 — wall-clock time.  Row 1 — peak GPU VRAM (or RAM for CPU solvers).
-    Row 1 is hidden when no memory data is available.
+    Only sweep axes with data get a column, and the memory row is dropped
+    entirely when no column carries memory data.
     Failure markers (OOM ▼, error ◆, NaN ×) with connectors from last ok point.
     """
     plt.rcParams.update(RCPARAMS)
@@ -368,53 +380,55 @@ def plot_cost(
     spatial_data, temporal_data, vjp_data = loaded
 
     columns = _build_columns(spatial_data, temporal_data, vjp_data, resolution_key)
+
+    # Keep only (kind × axis) columns that actually have plotted points. A
+    # column can pass the structural ``_has_inner_data`` check yet hold no
+    # finite time/mem values (e.g. a Forward sweep that was never run for this
+    # problem) — those would render as blank panels, so drop them here.
+    col_data = [_column_has_data(c[1], c[4], cfg) for c in columns]
+    columns = [c for c, (t, m) in zip(columns, col_data, strict=False) if t or m]
+    col_data = [(t, m) for (t, m) in col_data if t or m]
     n_cols = len(columns)
     if n_cols == 0:
         return None
 
+    # Decide the row layout up front: keep a memory row only when at least one
+    # column actually carries memory data, so an all-empty row is never drawn.
+    mem_row_used = any(m for (_t, m) in col_data)
+    n_rows = 2 if mem_row_used else 1
+
     styles = solver_styles(cfg)
 
-    fig, axes_grid = paper_grid(
-        2,
-        n_cols,
-    )
+    fig, axes_grid = paper_grid(n_rows, n_cols)
 
     failure_types_seen: set[str] = set()
-    mem_row_used = False
 
     for col, col_spec in enumerate(columns):
-        if _draw_column(
-            axes_grid,
-            col,
+        ax_time = axes_grid[0, col]
+        ax_mem = axes_grid[1, col] if mem_row_used else None
+        _draw_column(
+            ax_time,
+            ax_mem,
             col_spec,
             cfg,
             styles,
             failure_types_seen,
             n_to_cells=n_to_cells,
-        ):
-            mem_row_used = True
-
-    # hide memory row label axes if the whole row is empty
-    if not mem_row_used:
-        for ax in axes_grid[1]:
-            ax.set_visible(False)
+            first_col=(col == 0),
+        )
 
     _add_failure_legend_entries(axes_grid[0, 0], failure_types_seen)
 
-    # ── legend, title, hardware footnote ─────────────────────────────────────
-    fig.suptitle("Cost", fontweight="bold")
-    fig_shared_legend(fig, axes_grid, bottom=0.16)
-
+    # ── title + hardware footnote + shared bottom legend ─────────────────────
+    # Constrained layout (paper_grid) reserves space for the whole (multi-line)
+    # suptitle and the "outside" legend automatically, so folding the hardware
+    # string into the suptitle as a small grey second line keeps everything
+    # collision-free without manual figure-coordinate placement.
     if hw_str:
-        fig.text(
-            0.5,
-            0.07,
-            hw_str,
-            ha="center",
-            fontsize=7,
-            color="gray",
-            transform=fig.transFigure,
-        )
+        fig.suptitle(f"Cost\n{hw_str}", fontweight="bold", fontsize=9)
+    else:
+        fig.suptitle("Cost", fontweight="bold")
+    fig_shared_legend(fig, axes_grid)
 
     if save:
         save_fig(fig, f"cost{suffix}", suite_dir)

--- a/mosaic/benchmarks/problems/shared/plots/cost.py
+++ b/mosaic/benchmarks/problems/shared/plots/cost.py
@@ -13,8 +13,10 @@ import numpy as np
 from mosaic.benchmarks.core.config import Problem
 from mosaic.benchmarks.core.io import load_json, results_dir
 from mosaic.benchmarks.problems.shared.plots.style import (
+    RCPARAMS,
     apply_style,
     fig_shared_legend,
+    paper_grid,
     save_fig,
     solver_plot_props,
     solver_styles,
@@ -357,6 +359,7 @@ def plot_cost(
     Row 1 is hidden when no memory data is available.
     Failure markers (OOM ▼, error ◆, NaN ×) with connectors from last ok point.
     """
+    plt.rcParams.update(RCPARAMS)
     suite_dir = results_dir() / cfg.name / _SUITE
 
     loaded, hw_str = _load_cost_inputs(suite_dir, suffix)
@@ -371,11 +374,9 @@ def plot_cost(
 
     styles = solver_styles(cfg)
 
-    fig, axes_grid = plt.subplots(
+    fig, axes_grid = paper_grid(
         2,
         n_cols,
-        figsize=(5 * n_cols, 7),
-        squeeze=False,
     )
 
     failure_types_seen: set[str] = set()
@@ -401,7 +402,7 @@ def plot_cost(
     _add_failure_legend_entries(axes_grid[0, 0], failure_types_seen)
 
     # ── legend, title, hardware footnote ─────────────────────────────────────
-    fig.suptitle(f"{cfg.name} — cost")
+    fig.suptitle("Cost", fontweight="bold")
     fig_shared_legend(fig, axes_grid, bottom=0.16)
 
     if hw_str:

--- a/mosaic/benchmarks/problems/shared/plots/cost.py
+++ b/mosaic/benchmarks/problems/shared/plots/cost.py
@@ -13,7 +13,9 @@ import numpy as np
 from mosaic.benchmarks.core.config import Problem
 from mosaic.benchmarks.core.io import load_json, results_dir
 from mosaic.benchmarks.problems.shared.plots.style import (
+    GRID_COL_W,
     RCPARAMS,
+    TEXTWIDTH,
     apply_style,
     fig_shared_legend,
     paper_grid,
@@ -25,6 +27,15 @@ from mosaic.benchmarks.problems.shared.plots.style import (
 apply_style()
 
 _SUITE = "cost"
+
+# Cost panels are log-log with verbose x-tick labels ("cells", step counts), so
+# give each column a touch more room than the house ``GRID_COL_W`` to keep ticks
+# and titles from crowding (still single-column-ish for a few columns).
+_COST_COL_W = GRID_COL_W * 1.35
+
+# Steady-state problems have no time integration, so a "vs steps" cost sweep is
+# meaningless — those columns are dropped from their cost figure.
+_NON_TRANSIENT_PROBLEMS = {"structural-mesh", "thermal-mesh"}
 
 _FAILURE_MARKER = {
     "OOM": "v",
@@ -181,9 +192,18 @@ def _load_cost_inputs(suite_dir: Any, suffix: str) -> tuple:
 
 
 def _build_columns(
-    spatial_data: dict, temporal_data: dict, vjp_data: dict, res_key: str
+    spatial_data: dict,
+    temporal_data: dict,
+    vjp_data: dict,
+    res_key: str,
+    *,
+    drop_steps: bool = False,
 ) -> list[tuple[str, dict, str, str, list]]:
-    """Assemble the column specs in display order, skipping empty ones."""
+    """Assemble the column specs in display order, skipping empty ones.
+
+    When ``drop_steps`` is set (steady-state problems), the time-integration
+    "vs steps" columns are omitted entirely, leaving only the N / size sweep.
+    """
     columns: list[tuple[str, dict, str, str, list]] = []
 
     if _has_inner_data(spatial_data.get("by_N", {})):
@@ -197,7 +217,7 @@ def _build_columns(
             )
         )
 
-    if _has_inner_data(temporal_data.get("by_steps", {})):
+    if not drop_steps and _has_inner_data(temporal_data.get("by_steps", {})):
         columns.append(
             (
                 "temporal_steps",
@@ -219,7 +239,7 @@ def _build_columns(
             )
         )
 
-    if _has_inner_data(vjp_data.get("by_steps", {})):
+    if not drop_steps and _has_inner_data(vjp_data.get("by_steps", {})):
         columns.append(
             (
                 "vjp_steps",
@@ -379,7 +399,10 @@ def plot_cost(
         return None
     spatial_data, temporal_data, vjp_data = loaded
 
-    columns = _build_columns(spatial_data, temporal_data, vjp_data, resolution_key)
+    drop_steps = cfg.name in _NON_TRANSIENT_PROBLEMS
+    columns = _build_columns(
+        spatial_data, temporal_data, vjp_data, resolution_key, drop_steps=drop_steps
+    )
 
     # Keep only (kind × axis) columns that actually have plotted points. A
     # column can pass the structural ``_has_inner_data`` check yet hold no
@@ -400,6 +423,9 @@ def plot_cost(
     styles = solver_styles(cfg)
 
     fig, axes_grid = paper_grid(n_rows, n_cols)
+    # Roomier than the house width so log x-tick labels / titles aren't cramped.
+    _cur_w, cur_h = fig.get_size_inches()
+    fig.set_size_inches(max(TEXTWIDTH, n_cols * _COST_COL_W), cur_h)
 
     failure_types_seen: set[str] = set()
 

--- a/mosaic/benchmarks/problems/shared/plots/cost_overview.py
+++ b/mosaic/benchmarks/problems/shared/plots/cost_overview.py
@@ -25,10 +25,10 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     NS_ORDER,
     RCPARAMS,
     STRUCTURAL_ORDER,
-    TEXTWIDTH,
     THERMAL_ORDER,
     dedup_handles,
     make_handle,
+    paper_grid,
     solver_props,
 )
 
@@ -172,12 +172,7 @@ def plot_cost_overview(
         return  # nothing to plot
 
     n_rows = len(active_rows)
-    fig_w = TEXTWIDTH * 0.55
-    panel_h = fig_w * 0.55
-    fig, axes_arr = plt.subplots(
-        n_rows, 1, figsize=(fig_w, panel_h * n_rows + 0.7), sharex=True, squeeze=False
-    )
-    fig.subplots_adjust(left=0.22, right=0.97, bottom=0.18, top=0.95, hspace=0.22)
+    fig, axes_arr = paper_grid(n_rows, 1, sharex=True)
     ax_by_key = {k: axes_arr[i, 0] for i, (k, _) in enumerate(active_rows)}
     for k, ylab in active_rows:
         ax_by_key[k].set_ylabel(ylab)

--- a/mosaic/benchmarks/problems/shared/plots/forward.py
+++ b/mosaic/benchmarks/problems/shared/plots/forward.py
@@ -249,16 +249,19 @@ def _alias_to_display_name(cfg: Any) -> dict[str, str]:
 
 def _agreement_plot_curves_styled(
     ax: Any, data: dict, seen: set[str], cfg: Any
-) -> None:
+) -> list[float]:
     """Plot per-solver error-vs-sweep curves onto ``ax``.
 
     Walks :data:`NS_ORDER`, drawing every solver that produced at least
     one valid finite positive error. Updates ``seen`` so the caller can
-    build a legend covering only solvers that actually appear.
+    build a legend covering only solvers that actually appear, and returns
+    the flat list of plotted error values (so the caller can pick a tick
+    strategy that stays legible when the spread is sub-decade).
     """
+    all_errors: list[float] = []
     by_param = data.get("by_param", {})
     if not by_param:
-        return
+        return all_errors
     params = sorted(by_param.keys(), key=float)
     # ``by_param`` may be keyed by alias ('jax_cfd') or display name ('jax-cfd')
     # depending on the run; resolve every present key to its canonical alias so
@@ -295,7 +298,29 @@ def _agreement_plot_curves_styled(
             markeredgewidth=0,
             linewidth=1.6,
         )
+        all_errors.extend(ys)
         seen.add(solver)
+    return all_errors
+
+
+def _agreement_set_logy_ticks(ax: Any, narrow_y: bool) -> None:
+    """Pick a y-axis scale + tick strategy that stays legible for the data span.
+
+    The default decade ``LogLocator`` yields *no* major ticks when every
+    error sits inside a single decade (e.g. the multimode IC where all
+    solvers agree to within ~0.5 %), leaving the axis bare *and* a log
+    scale visually exaggerates a sub-percent spread into a full-height
+    swing. For that sub-decade case switch to a linear scale with a
+    bounded ``MaxNLocator`` so the (near-constant) values read honestly.
+    """
+    if narrow_y:
+        ax.set_yscale("linear")
+        ax.yaxis.set_major_locator(mticker.MaxNLocator(nbins=4, prune="both"))
+        ax.yaxis.set_minor_locator(mticker.NullLocator())
+        ax.yaxis.set_major_formatter(mticker.FormatStrFormatter("%.4g"))
+    else:
+        ax.yaxis.set_major_locator(mticker.LogLocator(base=10, numticks=4))
+        ax.yaxis.set_minor_locator(mticker.NullLocator())
 
 
 def _agreement_style_axis(
@@ -306,10 +331,12 @@ def _agreement_style_axis(
     y_label: str,
     log_x: bool,
     has_data: bool = True,
+    narrow_y: bool = False,
 ) -> None:
     """Apply consistent axis labels / ticks to one panel."""
     ax.set_title(title)
-    ax.set_xlabel(x_label)
+    # ``labelpad`` keeps the x-label clear of the shared legend strip below.
+    ax.set_xlabel(x_label, labelpad=2)
     ax.set_ylabel(y_label)
     if not has_data:
         ax.text(
@@ -324,8 +351,7 @@ def _agreement_style_axis(
         )
         ax.tick_params(axis="x", labelsize=7, rotation=30)
         return
-    ax.yaxis.set_major_locator(mticker.LogLocator(base=10, numticks=4))
-    ax.yaxis.set_minor_locator(mticker.NullLocator())
+    _agreement_set_logy_ticks(ax, narrow_y)
     if log_x:
         ax.set_xscale("log")
     ax.xaxis.set_major_locator(mticker.LogLocator(base=10, numticks=5))
@@ -350,11 +376,15 @@ def _agreement_figure(
     reference_label = data.get("reference_label", "consensus")
     ref_desc = "analytic" if reference_label == "analytic" else "consensus"
 
-    fig, ax = plt.subplots(figsize=(TEXTWIDTH * 0.55, TEXTWIDTH * 0.4), dpi=300)
-    fig.subplots_adjust(bottom=0.30, left=0.18, right=0.95, top=0.88)
+    fig, ax = plt.subplots(figsize=(TEXTWIDTH * 0.55, TEXTWIDTH * 0.42), dpi=300)
+    fig.subplots_adjust(bottom=0.34, left=0.18, right=0.95, top=0.88)
 
     seen: set[str] = set()
-    _agreement_plot_curves_styled(ax, data, seen, cfg)
+    errors = _agreement_plot_curves_styled(ax, data, seen, cfg)
+
+    # Sub-decade error spread (all solvers agree to within a decade) needs a
+    # finer tick locator so the y-axis isn't left bare.
+    narrow_y = bool(errors) and (max(errors) / min(errors) < 10)
 
     x_label = _agreement_math_label(sweep_key)
     _agreement_style_axis(
@@ -364,6 +394,7 @@ def _agreement_figure(
         y_label=f"Error vs {ref_desc}",
         log_x=True,
         has_data=bool(seen),
+        narrow_y=narrow_y,
     )
 
     handles = dedup_handles(
@@ -373,7 +404,7 @@ def _agreement_figure(
         fig.legend(
             handles=handles,
             loc="lower center",
-            bbox_to_anchor=(0.5, 0.01),
+            bbox_to_anchor=(0.5, -0.02),
             ncol=min(len(handles), 5),
             fontsize=6.5,
             framealpha=0.7,

--- a/mosaic/benchmarks/problems/shared/plots/forward.py
+++ b/mosaic/benchmarks/problems/shared/plots/forward.py
@@ -410,6 +410,12 @@ def plot_agreement(
     styles = solver_styles(cfg)
 
     npz = try_load_npz(fields_path)
+    if "sweep_values" not in npz:
+        # No fields.npz (missing / unreadable) — nothing to draw. Fall back to
+        # the result.json-only convergence view so regeneration doesn't crash.
+        print(f"[skip] agreement: no field data at {fields_path}")
+        _agreement_convergence(cfg, exp_key, suffix, save, out_dir)
+        return None
     sweep_vals = npz["sweep_values"].tolist()
     solver_names = npz["solver_names"].tolist()
 
@@ -473,6 +479,11 @@ def plot_forward_fields(
     f2d = _resolve_field_to_2d(field_to_2d)
 
     npz = try_load_npz(fields_path)
+    if "sweep_values" not in npz:
+        # Raw-field plot is purely npz-driven; with no fields.npz there's
+        # nothing to render, so skip instead of KeyError-ing out.
+        print(f"[skip] {exp_key}: no field data at {fields_path}")
+        return None
     sweep_vals = npz["sweep_values"].tolist()
     solver_names = npz["solver_names"].tolist()
 

--- a/mosaic/benchmarks/problems/shared/plots/forward.py
+++ b/mosaic/benchmarks/problems/shared/plots/forward.py
@@ -260,26 +260,29 @@ def _agreement_plot_curves_styled(
     if not by_param:
         return
     params = sorted(by_param.keys(), key=float)
-    alias_to_name = _alias_to_display_name(cfg)
+    # ``by_param`` may be keyed by alias ('jax_cfd') or display name ('jax-cfd')
+    # depending on the run; resolve every present key to its canonical alias so
+    # the NS_ORDER walk finds the data regardless of which form was written.
+    alias_to_key: dict[str, str] = {}
+    for p in params:
+        for k in by_param[p]:
+            a = resolve_solver_alias(k) or k
+            alias_to_key.setdefault(a, k)
 
     for solver in NS_ORDER:
-        display_name = alias_to_name.get(solver)
-        if display_name is None:
+        data_key = alias_to_key.get(solver)
+        if data_key is None:
             continue
         _label, color, ls, mk = solver_props(solver)
         xs, ys = [], []
         for p in params:
-            entry = by_param[p].get(display_name)
+            entry = by_param[p].get(data_key)
             if isinstance(entry, dict):
                 err = entry.get("error")
-                if (
-                    err is not None
-                    and isinstance(err, float)
-                    and np.isfinite(err)
-                    and err > 0
-                ):
+                # numeric error only — a failed run stores a string message here
+                if isinstance(err, (int, float)) and np.isfinite(err) and err > 0:
                     xs.append(float(p))
-                    ys.append(err)
+                    ys.append(float(err))
         if not xs:
             continue
         ax.semilogy(

--- a/mosaic/benchmarks/problems/shared/plots/forward.py
+++ b/mosaic/benchmarks/problems/shared/plots/forward.py
@@ -25,6 +25,8 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     field_grid,
     fig_shared_legend,
     make_handle,
+    paper_grid,
+    paper_row,
     save_fig,
     solver_plot_props,
     solver_props,
@@ -79,8 +81,9 @@ def _agreement_plot_scalar(
     units: dict | None,
 ) -> Any:
     """Scalar-output agreement: plot the scalar value vs sweep parameter."""
+    plt.rcParams.update(RCPARAMS)
     n_vals = len(sweep_vals)
-    fig, ax = plt.subplots(figsize=(6, 4))
+    fig, ax = paper_row(1)
     all_y: list[float] = []
     solver_series: list[tuple] = []
     for name in solver_names:
@@ -101,8 +104,7 @@ def _agreement_plot_scalar(
     ax.set_xlabel(unit_label(sweep_key, units))
     ylabel = output_key.replace("_", " ")
     ax.set_ylabel(ylabel)
-    ax.set_title(f"{cfg.name} — {ylabel} vs {sweep_key}")
-    ax.grid(True, alpha=0.3)
+    ax.set_title(ylabel[:1].upper() + ylabel[1:])
     fig_shared_legend(fig, [ax])
     if save:
         save_fig(fig, "curves", out_dir)
@@ -145,15 +147,14 @@ def _agreement_plot_curves(
     agreement_ylabel: str,
 ) -> Any:
     """1-D observable agreement (RDF g(r), P(k), etc.) with residual row."""
+    plt.rcParams.update(RCPARAMS)
     n_vals = len(sweep_vals)
     x = npz["x_axis"] if "x_axis" in npz else np.arange(len(sample_consensus))
-    fig_agr, ax_grid = plt.subplots(
+    fig_agr, ax_grid = paper_grid(
         2,
         n_vals,
-        figsize=(4 * n_vals, 7),
         sharex="col",
         sharey="row",
-        squeeze=False,
     )
     for i, val in enumerate(sweep_vals):
         ax_top = ax_grid[0, i]
@@ -164,7 +165,7 @@ def _agreement_plot_curves(
         if i == 0:
             ax_top.set_ylabel(agreement_ylabel)
             ax_bot.set_ylabel(f"Δ {agreement_ylabel}")
-    fig_agr.suptitle(f"{cfg.name} — agreement ({agreement_ylabel})")
+    fig_agr.suptitle(f"Agreement — {agreement_ylabel}", fontweight="bold")
     fig_shared_legend(fig_agr, list(ax_grid.flat))
     if save:
         save_fig(fig_agr, "curves", out_dir)

--- a/mosaic/benchmarks/problems/shared/plots/forward.py
+++ b/mosaic/benchmarks/problems/shared/plots/forward.py
@@ -28,6 +28,7 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     paper_grid,
     paper_row,
     save_fig,
+    solver_legend,
     solver_plot_props,
     solver_props,
     solver_styles,
@@ -624,8 +625,9 @@ def _pa_plot_ns_row(
     cfg: Any,
     ns_seen: set[str],
     row_is_top: bool,
+    show_row_label: bool = True,
 ) -> None:
-    """Render one row of the 3×3 NS grid for a single sweep (3 metrics)."""
+    """Render one row of the NS metric grid for a single sweep (3 metrics)."""
     by_param = data["by_param"]
     params = sorted(by_param.keys(), key=float)
     phys = data.get("params", {}).get("physics", {})
@@ -691,58 +693,50 @@ def _pa_plot_ns_row(
 
         if row_is_top:
             ax.set_title(metric_label)
-        if col == 0:
+        if col == 0 and show_row_label:
             ax.set_ylabel(_PA_ROW_LABELS[sweep_key], fontsize=9)
         ax.set_xlabel(_PA_SWEEP_XLABELS[sweep_key])
 
         _pa_set_axis_ticks(ax, x_all, log_x, log_y, is_elements=use_elements)
 
 
-def _pa_plot_ns_grid(
+def _pa_plot_ns_per_sweep(
     cfg: Any,
     sweeps_data: dict[str, dict],
     domain_title: str,
-    out_path: Path | None,
-) -> plt.Figure:
-    """3×3 NS grid: rows=sweep (vs_N, vs_nu, vs_steps), cols=metrics."""
-    fig, axes = plt.subplots(3, 3, figsize=(TEXTWIDTH, TEXTWIDTH * 0.85))
-    fig.suptitle(domain_title, fontsize=9, fontweight="bold", y=1.02)
-    fig.subplots_adjust(bottom=0.22, wspace=0.35, hspace=0.55)
+    out_dir: Path | None,
+) -> plt.Figure | None:
+    """One figure per sweep axis: a 1×3 metric row (vs_N / vs_nu / vs_steps).
 
-    ns_seen: set[str] = set()
-
-    for row, (sweep_key, log_x, use_elements) in enumerate(_PA_SWEEPS):
+    Each sweep gets its own ``physical_accuracy_<sweep>.png`` so the panels are
+    full-width and legible rather than packed into a single cramped 3×3 grid.
+    """
+    last_fig: plt.Figure | None = None
+    for sweep_key, log_x, use_elements in _PA_SWEEPS:
         data = sweeps_data.get(sweep_key)
         if data is None:
-            for col in range(3):
-                axes[row, col].set_visible(False)
             continue
+        fig, axes = paper_row(3)
+        ns_seen: set[str] = set()
         _pa_plot_ns_row(
-            axes[row],
+            axes,
             sweep_key,
             log_x,
             use_elements,
             data,
             cfg,
             ns_seen,
-            row_is_top=(row == 0),
+            row_is_top=True,
+            show_row_label=False,
         )
-
-    handles = dedup_handles([make_handle(s) for s in NS_ORDER if s in ns_seen])
-    fig.legend(
-        handles=handles,
-        loc="lower center",
-        bbox_to_anchor=(0.5, 0.0),
-        ncol=6,
-        fontsize=7.5,
-        framealpha=0.7,
-        handlelength=2.0,
-    )
-
-    if out_path is not None:
-        fig.savefig(out_path)
-        print(f"Saved {out_path}")
-    return fig
+        fig.suptitle(f"{domain_title} — {_PA_ROW_LABELS[sweep_key]}", fontweight="bold")
+        solver_legend(fig, ns_seen, order=NS_ORDER)
+        if out_dir is not None:
+            out = out_dir / f"physical_accuracy_{sweep_key}.png"
+            fig.savefig(out)
+            print(f"Saved {out}")
+        last_fig = fig
+    return last_fig
 
 
 def _pa_plot_fem_single(
@@ -879,8 +873,7 @@ def plot_physical_laws(
             ),
             (sweep_key, True, sweep_key == "vs_N"),
         )
-        fig, axes = plt.subplots(1, 3, figsize=(TEXTWIDTH, TEXTWIDTH * 0.32))
-        fig.subplots_adjust(bottom=0.32, wspace=0.45)
+        fig, axes = paper_row(3)
         ns_seen: set[str] = set()
         _pa_plot_ns_row(
             axes,
@@ -891,18 +884,9 @@ def plot_physical_laws(
             cfg,
             ns_seen,
             row_is_top=True,
+            show_row_label=False,
         )
-        handles = dedup_handles([make_handle(s) for s in NS_ORDER if s in ns_seen])
-        if handles:
-            fig.legend(
-                handles=handles,
-                loc="lower center",
-                bbox_to_anchor=(0.5, 0.0),
-                ncol=min(len(handles), 6),
-                fontsize=7.0,
-                framealpha=0.7,
-                handlelength=2.0,
-            )
+        solver_legend(fig, ns_seen, order=NS_ORDER)
         if save:
             out = out_dir / "physical_accuracy.png"
             fig.savefig(out)
@@ -925,9 +909,9 @@ def plot_physical_laws(
         (t for n, t in _PA_NS_DOMAINS if n == cfg.name),
         f"{cfg.category_label or cfg.name} — physical accuracy",
     )
-    return _pa_plot_ns_grid(
+    return _pa_plot_ns_per_sweep(
         cfg,
         sweeps_data,
         title,
-        out_dir / "physical_accuracy.png" if save else None,
+        out_dir if save else None,
     )

--- a/mosaic/benchmarks/problems/shared/plots/forward.py
+++ b/mosaic/benchmarks/problems/shared/plots/forward.py
@@ -27,6 +27,7 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     make_handle,
     paper_grid,
     paper_row,
+    resolve_solver_alias,
     save_fig,
     solver_legend,
     solver_plot_props,
@@ -63,6 +64,16 @@ def _is_field(arr: np.ndarray) -> bool:
 
 
 _SUITE = "forward"
+
+
+def _dedup_solver_names(names: list[str]) -> list[str]:
+    seen, out = set(), []
+    for n in names:
+        key = resolve_solver_alias(n) or n
+        if key not in seen:
+            seen.add(key)
+            out.append(n)
+    return out
 
 
 # ── agreement ─────────────────────────────────────────────────────────────────
@@ -419,7 +430,7 @@ def plot_agreement(
         _agreement_convergence(cfg, exp_key, suffix, save, out_dir)
         return None
     sweep_vals = npz["sweep_values"].tolist()
-    solver_names = npz["solver_names"].tolist()
+    solver_names = _dedup_solver_names(npz["solver_names"].tolist())
 
     sample_consensus = npz.get("consensus_0", None)
 
@@ -487,7 +498,7 @@ def plot_forward_fields(
         print(f"[skip] {exp_key}: no field data at {fields_path}")
         return None
     sweep_vals = npz["sweep_values"].tolist()
-    solver_names = npz["solver_names"].tolist()
+    solver_names = _dedup_solver_names(npz["solver_names"].tolist())
 
     _agreement_raw_fields(
         cfg,

--- a/mosaic/benchmarks/problems/shared/plots/gradient.py
+++ b/mosaic/benchmarks/problems/shared/plots/gradient.py
@@ -1294,11 +1294,15 @@ def plot_jacobian_svd_comparison(
     if not variants:
         return None
 
-    # Collect all solver names across variants
+    # Collect solver names across variants, de-duplicated by canonical alias so
+    # display-name ('PhiFlow') and alias ('phiflow') forms don't each get a panel.
     all_solvers: list[str] = []
+    _seen_alias: set[str] = set()
     for _, data in variants:
         for s in data.get("solver_names", []):
-            if s not in all_solvers:
+            key = resolve_solver_alias(s) or s
+            if key not in _seen_alias:
+                _seen_alias.add(key)
                 all_solvers.append(s)
 
     styles = _alias_tolerant(solver_styles(cfg))
@@ -1307,12 +1311,14 @@ def plot_jacobian_svd_comparison(
     nrows = math.ceil(n_solvers / ncols)
 
     fig, axes = paper_grid(nrows, ncols)
+    variant_handles: list[mlines.Line2D] = []
 
     for idx, solver in enumerate(all_solvers):
         ax = axes[idx // ncols][idx % ncols]
         solver_style = styles.get(solver, {})
         color = solver_style.get("color", "#888888")
         label_base = solver_style.get("label", solver)
+        ann_lines: list[str] = []
 
         for vi, (exp_key, data) in enumerate(variants):
             spectra = data.get("per_solver_spectra", {})
@@ -1333,21 +1339,49 @@ def plot_jacobian_svd_comparison(
                 color=vstyle["color"],
                 markersize=4 if marker else 0,
                 linewidth=1.5,
-                label=f"{var_label}  r={er:.0f}  κ={cond:.1e}",
             )
+            ann_lines.append(f"{var_label}  r={er:.0f}  κ={cond:.0e}")
+            if idx == 0:
+                variant_handles.append(
+                    mlines.Line2D(
+                        [],
+                        [],
+                        color=vstyle["color"],
+                        linestyle=vstyle["linestyle"],
+                        linewidth=1.5,
+                        label=var_label,
+                    )
+                )
 
         ax.axhline(1e-1, color="gray", linestyle="--", linewidth=0.8, alpha=0.6)
         ax.axhline(1e-4, color="gray", linestyle="--", linewidth=0.8, alpha=0.6)
-        ax.set_title(f"{label_base}", color=color, fontsize=10)
-        ax.set_xlabel("Mode index i")
-        ax.set_ylabel("σᵢ / σ₁")
-        ax.legend(fontsize=7, framealpha=0.8)
-        ax.grid(True, alpha=0.3)
+        ax.set_title(label_base, color=color)
+        ax.set_xlabel("Mode index $i$")
+        ax.set_ylabel(r"$\sigma_i\,/\,\sigma_1$")
+        # eff-rank / condition number per variant, compact, low-left out of the way
+        if ann_lines:
+            ax.text(
+                0.03,
+                0.03,
+                "\n".join(ann_lines),
+                transform=ax.transAxes,
+                fontsize=4.5,
+                va="bottom",
+                ha="left",
+                color="0.35",
+            )
 
     # Hide unused axes
     for idx in range(n_solvers, nrows * ncols):
         axes[idx // ncols][idx % ncols].set_visible(False)
 
+    if variant_handles:
+        fig.legend(
+            handles=variant_handles,
+            loc="outside lower center",
+            ncol=min(len(variant_handles), 4),
+            handlelength=2.0,
+        )
     fig.suptitle("Jacobian SVD spectra", fontweight="bold")
 
     if save:

--- a/mosaic/benchmarks/problems/shared/plots/gradient.py
+++ b/mosaic/benchmarks/problems/shared/plots/gradient.py
@@ -384,7 +384,7 @@ def _horizon_plot_curves(axes: Any, data: dict, seen: set[str]) -> bool:
     for alias in ordered:
         sv = by_solver[alias_to_display[alias]]
         for k, v in sv.items():
-            gn = v.get("grad_norm", 1.0)
+            gn = _finite_or_nan(v.get("grad_norm", 1.0))
             if not np.isfinite(gn) or gn <= 0:
                 fail_at_step[int(k)].append(alias)
 
@@ -410,14 +410,14 @@ def _horizon_plot_curves(axes: Any, data: dict, seen: set[str]) -> bool:
 
         for k in step_keys:
             v = sv[k]
-            gn = v.get("grad_norm", float("nan"))
+            gn = _finite_or_nan(v.get("grad_norm", float("nan")))
             eps_sweep = v.get("eps_sweep", {})
-            if eps_sweep:
-                best_err = min(float(e["rel_error_mean"]) for e in eps_sweep.values())
-                best_cos = max(float(e["cosine_mean"]) for e in eps_sweep.values())
-            else:
-                best_err = float("nan")
-                best_cos = float("nan")
+            errs = [_finite_or_nan(e.get("rel_error_mean")) for e in eps_sweep.values()]
+            errs = [e for e in errs if np.isfinite(e)]
+            coss = [_finite_or_nan(e.get("cosine_mean")) for e in eps_sweep.values()]
+            coss = [c for c in coss if np.isfinite(c)]
+            best_err = min(errs) if errs else float("nan")
+            best_cos = max(coss) if coss else float("nan")
 
             if np.isfinite(gn) and gn > 0 and np.isfinite(best_err) and best_err > 0:
                 ok_steps.append(int(k))
@@ -663,9 +663,17 @@ def _plot_error_per_solver(
         n_rows, n_cols, figsize=(4.5 * n_cols, 3.5 * n_rows), squeeze=False
     )
 
-    # ε values from the first solver/key entry
-    _first = by_solver[solver_names[0]]
-    eps_keys = sorted(_first[next(iter(_first))]["eps_sweep"], key=float)
+    # ε values from the first solver/key entry that actually carries an eps
+    # sweep — a failed run may record a step/param entry without one, so we
+    # can't blindly index the first entry.
+    eps_keys: list[str] = []
+    for name in solver_names:
+        for entry in by_solver[name].values():
+            if isinstance(entry, dict) and entry.get("eps_sweep"):
+                eps_keys = sorted(entry["eps_sweep"], key=float)
+                break
+        if eps_keys:
+            break
     eps_colors = plt.cm.plasma(np.linspace(0.15, 0.85, len(eps_keys)))
     markers = ["o", "s", "^", "D"]
 
@@ -677,7 +685,14 @@ def _plot_error_per_solver(
 
         for ei, eps in enumerate(eps_keys):
             re_m = [
-                by_solver[name][k]["eps_sweep"][eps]["rel_error_mean"] for k in x_keys
+                _finite_or_nan(
+                    by_solver[name]
+                    .get(k, {})
+                    .get("eps_sweep", {})
+                    .get(eps, {})
+                    .get("rel_error_mean")
+                )
+                for k in x_keys
             ]
             ax.semilogy(
                 xs,
@@ -708,6 +723,21 @@ def _plot_error_per_solver(
 # ── best-ε overlay helper ─────────────────────────────────────────────────────
 
 
+def _finite_or_nan(v: Any) -> float:
+    """Coerce a metric value to ``float``, mapping ``None``/non-numeric to ``nan``.
+
+    Benchmark ``result.json`` stores ``None`` for ε / step runs that failed or
+    were non-finite. Both ``float(None)`` and ``np.isfinite(None)`` raise, so raw
+    metric values must be normalised before any ``min``/``max``/finite-filter —
+    otherwise a single failed run takes down the whole figure.
+    """
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return float("nan")
+    return f if np.isfinite(f) else float("nan")
+
+
 def _plot_best_eps_overlay(
     by_solver: dict,
     styles: dict,
@@ -723,14 +753,21 @@ def _plot_best_eps_overlay(
     def _best_re(eps_sweep: dict) -> float:
         finite = [
             v
-            for v in (e["rel_error_mean"] for e in eps_sweep.values())
+            for v in (
+                _finite_or_nan(e.get("rel_error_mean")) for e in eps_sweep.values()
+            )
             if np.isfinite(v)
         ]
         return float(min(finite)) if finite else float("nan")
 
     for name, results in by_solver.items():
         xs = [x_to_float(k) for k in x_keys]
-        best_re = [_best_re(results[k]["eps_sweep"]) for k in x_keys]
+        best_re = [
+            _best_re(results[k]["eps_sweep"])
+            if isinstance(results.get(k), dict) and "eps_sweep" in results[k]
+            else float("nan")
+            for k in x_keys
+        ]
 
         pairs = [(x, v) for x, v in zip(xs, best_re, strict=False) if np.isfinite(v)]
         if not pairs:
@@ -755,13 +792,26 @@ def _plot_best_eps_overlay(
 
 
 def _best_eps_series(param_results: dict, param_keys: Any, metric: str) -> list[float]:
-    """For each param key pick the best-ε value of `metric` across the eps sweep."""
-    return [
-        min(param_results[k]["eps_sweep"].values(), key=lambda v: v["rel_error_mean"])[
-            metric
+    """For each param key pick the best-ε value of `metric` across the eps sweep.
+
+    ε entries with a missing ``rel_error_mean`` (``None`` — e.g. a failed or
+    non-finite ε run) can't be ranked and are skipped. A param key with no
+    rankable ε entry yields ``nan`` so the curve simply gaps there rather than
+    raising and dropping the whole figure.
+    """
+    out: list[float] = []
+    for k in param_keys:
+        ranked = [
+            v
+            for v in param_results[k]["eps_sweep"].values()
+            if v.get("rel_error_mean") is not None
         ]
-        for k in param_keys
-    ]
+        if not ranked:
+            out.append(float("nan"))
+            continue
+        val = min(ranked, key=lambda v: v["rel_error_mean"]).get(metric)
+        out.append(float("nan") if val is None else val)
+    return out
 
 
 def _plot_ucurve_overlay(
@@ -794,10 +844,15 @@ def _plot_ucurve_overlay(
         for name in solver_names:
             props = solver_plot_props(styles[name])
 
-            sweep = by_solver[name][key]["eps_sweep"]
+            entry = by_solver[name].get(key)
+            if not entry or "eps_sweep" not in entry:
+                # Solver has no eps sweep for this value (e.g. a failed run that
+                # recorded status but no curve) — skip rather than KeyError out.
+                continue
+            sweep = entry["eps_sweep"]
             eps_f = sorted(sweep.keys(), key=float)
             eps_fl = [float(e) for e in eps_f]
-            re_m = [sweep[e]["rel_error_mean"] for e in eps_f]
+            re_m = [_finite_or_nan(sweep[e].get("rel_error_mean")) for e in eps_f]
 
             ax.loglog(eps_fl, re_m, label=styles[name]["label"], **props)
 
@@ -861,7 +916,12 @@ def plot_param_sweep(
     axes[2].set_title(f"G2a — direction accuracy vs {sweep_key}")
     min_cos_sweep = min(all_cosines_sweep) if all_cosines_sweep else 0.0
     if min_cos_sweep > 0.8:
-        axes[2].set_ylim(min(min_cos_sweep, 0.999) - 0.001, 1.001)
+        # Zoom in to surface variation among high cosines, but keep a minimum
+        # window: when every cosine is ≈1.0 a tight band (e.g. [0.998, 1.001])
+        # carves the axis into sub-0.001 gridlines that imply structure which
+        # isn't there. Flooring at 0.95 makes a perfect result read as a line
+        # pinned to the top of a readable band instead.
+        axes[2].set_ylim(min(min_cos_sweep - 0.001, 0.95), 1.005)
     else:
         axes[2].set_ylim(-0.05, 1.05)
     fig_shared_legend(fig, axes)

--- a/mosaic/benchmarks/problems/shared/plots/gradient.py
+++ b/mosaic/benchmarks/problems/shared/plots/gradient.py
@@ -1183,15 +1183,12 @@ def plot_jacobian_svd_comparison(
         solver_style = styles.get(solver, {})
         color = solver_style.get("color", "#888888")
         label_base = solver_style.get("label", solver)
-        ann_lines: list[str] = []
 
         for vi, (exp_key, data) in enumerate(variants):
             spectra = data.get("per_solver_spectra", {})
             if solver not in spectra:
                 continue
             spec = spectra[solver]
-            er = data.get("per_solver_eff_rank", {}).get(solver, float("nan"))
-            cond = data.get("per_solver_cond", {}).get(solver, float("nan"))
             var_label = _VARIANT_LABELS.get(exp_key, exp_key)
             vstyle = _VARIANT_STYLES[vi % len(_VARIANT_STYLES)]
             n_modes = len(spec)
@@ -1205,7 +1202,6 @@ def plot_jacobian_svd_comparison(
                 markersize=4 if marker else 0,
                 linewidth=1.5,
             )
-            ann_lines.append(f"{var_label}  r={er:.0f}  κ={cond:.0e}")
             if idx == 0:
                 variant_handles.append(
                     mlines.Line2D(
@@ -1223,18 +1219,6 @@ def plot_jacobian_svd_comparison(
         ax.set_title(label_base, color=color)
         ax.set_xlabel("Mode index $i$")
         ax.set_ylabel(r"$\sigma_i\,/\,\sigma_1$")
-        # eff-rank / condition number per variant, compact, low-left out of the way
-        if ann_lines:
-            ax.text(
-                0.03,
-                0.03,
-                "\n".join(ann_lines),
-                transform=ax.transAxes,
-                fontsize=4.5,
-                va="bottom",
-                ha="left",
-                color="0.35",
-            )
 
     # Hide unused axes
     for idx in range(n_solvers, nrows * ncols):

--- a/mosaic/benchmarks/problems/shared/plots/gradient.py
+++ b/mosaic/benchmarks/problems/shared/plots/gradient.py
@@ -570,7 +570,7 @@ def plot_fd_check(
     # presentation concern local to this problem (paper plots don't
     # produce field grids), so we keep the lightweight per-suite
     # ``solver_styles`` here rather than depend on paper-side styling.
-    styles = solver_styles(cfg)
+    styles = _alias_tolerant(solver_styles(cfg))
     fields_path = out_dir / "gradient_fields.npz"
     if not fields_path.exists():
         return fig_c
@@ -721,6 +721,22 @@ def _plot_error_per_solver(
 
 
 # ── best-ε overlay helper ─────────────────────────────────────────────────────
+
+
+def _alias_tolerant(styles: dict) -> dict:
+    """Augment a ``solver_styles`` dict so it also resolves canonical aliases.
+
+    ``solver_styles`` keys by display name (``'PhiFlow'``), but ``by_solver`` in
+    some result.json is keyed by canonical alias (``'phiflow'``). Adding alias
+    entries (pointing at the same style) lets ``styles[name]`` work for either
+    form without scattering lookups. Display-name lookups are unchanged.
+    """
+    out = dict(styles)
+    for display_name, style in styles.items():
+        alias = resolve_solver_alias(display_name)
+        if alias and alias not in out:
+            out[alias] = style
+    return out
 
 
 def _finite_or_nan(v: Any) -> float:
@@ -885,7 +901,7 @@ def plot_param_sweep(
     out_dir = results_dir() / cfg.name / _SUITE / f"{exp_key}{suffix}"
     result_path = out_dir / "result.json"
     data = load_json(result_path)
-    styles = solver_styles(cfg)
+    styles = _alias_tolerant(solver_styles(cfg))
     sweep_key = data.get("sweep_key", "param")
 
     # ── summary: grad norm, best-ε rel error, best-ε cosine vs sweep param ───
@@ -995,7 +1011,7 @@ def plot_jacobian_svd(
     """
     out_dir = results_dir() / cfg.name / _SUITE / f"{exp_key}{suffix}"
     data = load_json(out_dir / "result.json")
-    styles = solver_styles(cfg)
+    styles = _alias_tolerant(solver_styles(cfg))
 
     solver_names = data["solver_names"]
     cross_cos = np.array(data["cross_cosine"])
@@ -1152,7 +1168,7 @@ def plot_horizon_sweep(
     """
     out_dir = results_dir() / cfg.name / _SUITE / f"{exp_key}{suffix}"
     data = load_json(out_dir / "result.json")
-    styles = solver_styles(cfg)
+    styles = _alias_tolerant(solver_styles(cfg))
 
     # ── summary curves (styled) ─────────────────────────────────────────────
     fig_c = _horizon_sweep_figure(
@@ -1287,7 +1303,7 @@ def plot_jacobian_svd_comparison(
             if s not in all_solvers:
                 all_solvers.append(s)
 
-    styles = solver_styles(cfg)
+    styles = _alias_tolerant(solver_styles(cfg))
     n_solvers = len(all_solvers)
     ncols = min(3, n_solvers)
     nrows = math.ceil(n_solvers / ncols)

--- a/mosaic/benchmarks/problems/shared/plots/gradient.py
+++ b/mosaic/benchmarks/problems/shared/plots/gradient.py
@@ -16,19 +16,25 @@ import numpy as np
 from mosaic.benchmarks.core.config import Problem
 from mosaic.benchmarks.core.io import load_json, results_dir, try_load_npz
 from mosaic.benchmarks.problems.shared.plots.style import (
+    COSINE_DEFECT_YLABEL,
     FEM_ORDER,
     NS_ORDER,
     RCPARAMS,
     SOLVER_STYLES,
     TEXTWIDTH,
     apply_style,
+    cosine_defect,
     dedup_handles,
     field_grid,
     fig_shared_legend,
     grad_magnitude_2d,
     make_handle,
+    paper_grid,
+    paper_image_grid,
+    paper_row,
     resolve_solver_alias,
     save_fig,
+    solver_legend,
     solver_plot_props,
     solver_props,
     solver_styles,
@@ -659,9 +665,7 @@ def _plot_error_per_solver(
     n_cols = min(3, n)
     n_rows = math.ceil(n / n_cols)
 
-    fig, axes = plt.subplots(
-        n_rows, n_cols, figsize=(4.5 * n_cols, 3.5 * n_rows), squeeze=False
-    )
+    fig, axes = paper_grid(n_rows, n_cols)
 
     # ε values from the first solver/key entry that actually carries an eps
     # sweep — a failed run may record a step/param entry without one, so we
@@ -715,7 +719,7 @@ def _plot_error_per_solver(
         row, col = divmod(idx, n_cols)
         axes[row][col].set_visible(False)
 
-    fig.suptitle(title_prefix, fontsize=10)
+    fig.suptitle(title_prefix, fontweight="bold")
     fig_shared_legend(fig, axes)
     return fig
 
@@ -764,7 +768,7 @@ def _plot_best_eps_overlay(
     x_scale: str = "linear",
 ) -> plt.Figure:
     """All solvers overlaid: best-ε rel_error_mean vs x_keys."""
-    fig, ax = plt.subplots(figsize=(7, 4))
+    fig, ax = paper_row(1)
 
     def _best_re(eps_sweep: dict) -> float:
         finite = [
@@ -847,9 +851,7 @@ def _plot_ucurve_overlay(
     n_cols = min(ncols, n_panels)
     n_rows = math.ceil(n_panels / n_cols)
 
-    fig, axes = plt.subplots(
-        n_rows, n_cols, figsize=(3.5 * n_cols, 3.0 * n_rows), squeeze=False
-    )
+    fig, axes = paper_grid(n_rows, n_cols)
 
     solver_names = list(by_solver.keys())
 
@@ -874,13 +876,13 @@ def _plot_ucurve_overlay(
 
         ax.set_xlabel("ε")
         ax.set_ylabel("Relative FD error")
-        ax.set_title(f"{sweep_label} = {key}", fontsize=9)
+        ax.set_title(f"{sweep_label} = {key}")
 
     for idx in range(n_panels, n_rows * n_cols):
         row, col = divmod(idx, n_cols)
         axes[row][col].set_visible(False)
 
-    fig.suptitle(title_prefix, fontsize=10)
+    fig.suptitle(title_prefix, fontweight="bold")
     fig_shared_legend(fig, axes)
     return fig
 
@@ -905,42 +907,38 @@ def plot_param_sweep(
     sweep_key = data.get("sweep_key", "param")
 
     # ── summary: grad norm, best-ε rel error, best-ε cosine vs sweep param ───
-    fig, axes = plt.subplots(1, 3, figsize=(15, 4))
-    all_cosines_sweep: list[float] = []
+    # House style mirrors horizon_sweep: a TEXTWIDTH 1×3 row, with direction
+    # accuracy shown as 1−cosine on a log axis (a perfect cosine sits at the
+    # floor) rather than a raw cosine squashed against 1.0.
+    plt.rcParams.update(RCPARAMS)
+    fig, axes = paper_row(3)
+    seen: set[str] = set()
     for name, param_results in data["by_solver"].items():
         param_vals = sorted(param_results.keys(), key=float)
         param_f = [float(v) for v in param_vals]
-        norms = [param_results[v]["grad_norm"] for v in param_vals]
+        norms = [_finite_or_nan(param_results[v].get("grad_norm")) for v in param_vals]
         re_mean = _best_eps_series(param_results, param_vals, "rel_error_mean")
         cosines = _best_eps_series(param_results, param_vals, "cosine_mean")
-        all_cosines_sweep.extend(c for c in cosines if np.isfinite(c))
         props = solver_plot_props(styles[name])
+        lbl = styles[name]["label"]
 
-        axes[0].loglog(param_f, norms, label=styles[name]["label"], **props)
-        axes[1].loglog(param_f, re_mean, label=styles[name]["label"], **props)
-        axes[2].semilogx(param_f, cosines, label=styles[name]["label"], **props)
+        axes[0].loglog(param_f, norms, label=lbl, **props)
+        axes[1].loglog(param_f, re_mean, label=lbl, **props)
+        axes[2].loglog(param_f, cosine_defect(cosines), label=lbl, **props)
+        alias = resolve_solver_alias(name)
+        if alias:
+            seen.add(alias)
 
     xlbl = unit_label(sweep_key, units)
-    axes[0].set_xlabel(xlbl)
-    axes[0].set_ylabel("Gradient norm")
-    axes[0].set_title(f"G2a — gradient norm vs {sweep_key}")
-    axes[1].set_xlabel(xlbl)
-    axes[1].set_ylabel("Relative FD error (best ε)")
-    axes[1].set_title(f"G2a — FD error vs {sweep_key}")
-    axes[2].set_xlabel(xlbl)
-    axes[2].set_ylabel("Subspace cosine (best ε)")
-    axes[2].set_title(f"G2a — direction accuracy vs {sweep_key}")
-    min_cos_sweep = min(all_cosines_sweep) if all_cosines_sweep else 0.0
-    if min_cos_sweep > 0.8:
-        # Zoom in to surface variation among high cosines, but keep a minimum
-        # window: when every cosine is ≈1.0 a tight band (e.g. [0.998, 1.001])
-        # carves the axis into sub-0.001 gridlines that imply structure which
-        # isn't there. Flooring at 0.95 makes a perfect result read as a line
-        # pinned to the top of a readable band instead.
-        axes[2].set_ylim(min(min_cos_sweep - 0.001, 0.95), 1.005)
-    else:
-        axes[2].set_ylim(-0.05, 1.05)
-    fig_shared_legend(fig, axes)
+    for ax in axes:
+        ax.set_xlabel(xlbl)
+    axes[0].set_ylabel(r"$\|\nabla\mathcal{L}\|$")
+    axes[0].set_title("Gradient norm")
+    axes[1].set_ylabel("Relative FD error")
+    axes[1].set_title("FD error (best $\\varepsilon$)")
+    axes[2].set_ylabel(COSINE_DEFECT_YLABEL)
+    axes[2].set_title("Direction accuracy (best $\\varepsilon$)")
+    solver_legend(fig, seen)
     if save:
         save_fig(fig, "param_sweep", out_dir)
 
@@ -951,7 +949,7 @@ def plot_param_sweep(
         param_vals,
         sweep_key,
         styles,
-        f"{cfg.name} — G2a ε U-curves ({sweep_key} sweep)",
+        "ε U-curves",
         ncols=len(param_vals),
     )
     if save:
@@ -961,7 +959,7 @@ def plot_param_sweep(
     fig_s = _plot_error_per_solver(
         data["by_solver"],
         styles,
-        f"{cfg.name} — G2a FD error vs {sweep_key} (per solver)",
+        "FD error per solver",
         x_keys=param_vals,
         x_to_float=float,
         x_label=sweep_key,
@@ -974,7 +972,7 @@ def plot_param_sweep(
     fig_b = _plot_best_eps_overlay(
         data["by_solver"],
         styles,
-        f"{cfg.name} — G2a best-ε FD error vs {sweep_key}",
+        "Best-ε FD error",
         x_keys=param_vals,
         x_to_float=float,
         x_label=sweep_key,
@@ -1033,7 +1031,7 @@ def plot_jacobian_svd(
     )
 
     if _scalar_output:
-        fig_bar, ax = plt.subplots(figsize=(6, 4))
+        fig_bar, ax = paper_row(1)
         names = list(per_solver_grad_norm or per_solver_spectra)
         norms = [per_solver_grad_norm.get(n, float("nan")) for n in names]
         colors = [styles.get(n, {}).get("color", "#888888") for n in names]
@@ -1042,7 +1040,7 @@ def plot_jacobian_svd(
         ax.set_xticks(range(len(names)))
         ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=9)
         ax.set_ylabel("‖∇L‖  (gradient norm)")
-        ax.set_title(f"{cfg.name} — G3 per-solver gradient norm")
+        ax.set_title("Per-solver gradient norm")
         ax.set_yscale("log")
         ax.grid(True, axis="y", alpha=0.3)
         fig_bar.tight_layout()
@@ -1052,7 +1050,7 @@ def plot_jacobian_svd(
             fig_c = fig_bar
 
     # ── Cross-solver cosine similarity heatmap ───────────────────────────────
-    fig_h, ax = plt.subplots(figsize=(6, 5))
+    fig_h, ax = paper_image_grid(1, 1, panel=TEXTWIDTH * 0.6, squeeze=True)
     n = len(solver_names)
     im = ax.imshow(cross_cos, vmin=-1, vmax=1, cmap="RdBu_r", aspect="auto")
     ax.set_xticks(range(n))
@@ -1060,7 +1058,7 @@ def plot_jacobian_svd(
     short_labels = [styles.get(s, {}).get("label", s) for s in solver_names]
     ax.set_xticklabels(short_labels, rotation=45, ha="right", fontsize=9)
     ax.set_yticklabels(short_labels, fontsize=9)
-    ax.set_title(f"{cfg.name} — G3 cross-solver cosine similarity")
+    ax.set_title("Cross-solver cosine similarity")
     plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
     fig_h.tight_layout()
     if save:
@@ -1182,7 +1180,7 @@ def plot_horizon_sweep(
         step_keys,
         "steps",
         styles,
-        f"{cfg.name} — G2c ε U-curves (horizon sweep)",
+        "ε U-curves",
         ncols=4,
     )
     if save:
@@ -1192,7 +1190,7 @@ def plot_horizon_sweep(
     fig_s = _plot_error_per_solver(
         data["by_solver"],
         styles,
-        f"{cfg.name} — G2c FD error vs horizon (per solver)",
+        "FD error per solver",
         x_keys=step_keys,
         x_to_float=int,
         x_label="Steps (horizon)",
@@ -1204,7 +1202,7 @@ def plot_horizon_sweep(
     fig_b = _plot_best_eps_overlay(
         data["by_solver"],
         styles,
-        f"{cfg.name} — G2c best-ε FD error vs horizon",
+        "Best-ε FD error",
         x_keys=step_keys,
         x_to_float=int,
         x_label="Steps (horizon)",
@@ -1236,7 +1234,7 @@ def plot_horizon_sweep(
         lbl = styles.get(name, {}).get("label", name)
         fig_g = field_grid(
             panels,
-            f"{cfg.name} — G2c ∂L/∂IC magnitude | {lbl}",
+            f"∂L/∂IC magnitude — {lbl}",
             shared_scale=True,
             symmetric=False,
             ncols=len(panels),
@@ -1308,9 +1306,7 @@ def plot_jacobian_svd_comparison(
     ncols = min(3, n_solvers)
     nrows = math.ceil(n_solvers / ncols)
 
-    fig, axes = plt.subplots(
-        nrows, ncols, figsize=(5 * ncols, 3.5 * nrows), squeeze=False
-    )
+    fig, axes = paper_grid(nrows, ncols)
 
     for idx, solver in enumerate(all_solvers):
         ax = axes[idx // ncols][idx % ncols]
@@ -1352,10 +1348,7 @@ def plot_jacobian_svd_comparison(
     for idx in range(n_solvers, nrows * ncols):
         axes[idx // ncols][idx % ncols].set_visible(False)
 
-    fig.suptitle(
-        f"{cfg.name} — Jacobian SVD: per-solver spectra comparison", fontsize=11
-    )
-    fig.tight_layout()
+    fig.suptitle("Jacobian SVD spectra", fontweight="bold")
 
     if save:
         out_dir = results_dir() / cfg.name / _SUITE

--- a/mosaic/benchmarks/problems/shared/plots/gradient.py
+++ b/mosaic/benchmarks/problems/shared/plots/gradient.py
@@ -16,14 +16,12 @@ import numpy as np
 from mosaic.benchmarks.core.config import Problem
 from mosaic.benchmarks.core.io import load_json, results_dir, try_load_npz
 from mosaic.benchmarks.problems.shared.plots.style import (
-    COSINE_DEFECT_YLABEL,
     FEM_ORDER,
     NS_ORDER,
     RCPARAMS,
     SOLVER_STYLES,
     TEXTWIDTH,
     apply_style,
-    cosine_defect,
     dedup_handles,
     field_grid,
     fig_shared_legend,
@@ -34,11 +32,9 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     paper_row,
     resolve_solver_alias,
     save_fig,
-    solver_legend,
     solver_plot_props,
     solver_props,
     solver_styles,
-    unit_label,
     vorticity_2d,
 )
 
@@ -899,76 +895,15 @@ def plot_param_sweep(
     exp_key: str = "param_sweep",
     **_kw: Any,
 ) -> Any:
-    """Two files: summary curves (grad norm + best-ε error + cosine) and U-curve grid."""
+    """Single file: best-ε FD error vs sweep param, all solvers overlaid."""
     out_dir = results_dir() / cfg.name / _SUITE / f"{exp_key}{suffix}"
     result_path = out_dir / "result.json"
     data = load_json(result_path)
     styles = _alias_tolerant(solver_styles(cfg))
     sweep_key = data.get("sweep_key", "param")
 
-    # ── summary: grad norm, best-ε rel error, best-ε cosine vs sweep param ───
-    # House style mirrors horizon_sweep: a TEXTWIDTH 1×3 row, with direction
-    # accuracy shown as 1−cosine on a log axis (a perfect cosine sits at the
-    # floor) rather than a raw cosine squashed against 1.0.
-    plt.rcParams.update(RCPARAMS)
-    fig, axes = paper_row(3)
-    seen: set[str] = set()
-    for name, param_results in data["by_solver"].items():
-        param_vals = sorted(param_results.keys(), key=float)
-        param_f = [float(v) for v in param_vals]
-        norms = [_finite_or_nan(param_results[v].get("grad_norm")) for v in param_vals]
-        re_mean = _best_eps_series(param_results, param_vals, "rel_error_mean")
-        cosines = _best_eps_series(param_results, param_vals, "cosine_mean")
-        props = solver_plot_props(styles[name])
-        lbl = styles[name]["label"]
-
-        axes[0].loglog(param_f, norms, label=lbl, **props)
-        axes[1].loglog(param_f, re_mean, label=lbl, **props)
-        axes[2].loglog(param_f, cosine_defect(cosines), label=lbl, **props)
-        alias = resolve_solver_alias(name)
-        if alias:
-            seen.add(alias)
-
-    xlbl = unit_label(sweep_key, units)
-    for ax in axes:
-        ax.set_xlabel(xlbl)
-    axes[0].set_ylabel(r"$\|\nabla\mathcal{L}\|$")
-    axes[0].set_title("Gradient norm")
-    axes[1].set_ylabel("Relative FD error")
-    axes[1].set_title("FD error (best $\\varepsilon$)")
-    axes[2].set_ylabel(COSINE_DEFECT_YLABEL)
-    axes[2].set_title("Direction accuracy (best $\\varepsilon$)")
-    solver_legend(fig, seen)
-    if save:
-        save_fig(fig, "param_sweep", out_dir)
-
-    # ── U-curve overlay: all solvers per sweep value ──────────────────────────
-    param_vals = sorted(next(iter(data["by_solver"].values())).keys(), key=float)
-    fig_u = _plot_ucurve_overlay(
-        data["by_solver"],
-        param_vals,
-        sweep_key,
-        styles,
-        "ε U-curves",
-        ncols=len(param_vals),
-    )
-    if save:
-        save_fig(fig_u, "ucurves", out_dir)
-
-    # ── FD error vs param, one line per ε (per solver) ────────────────────────
-    fig_s = _plot_error_per_solver(
-        data["by_solver"],
-        styles,
-        "FD error per solver",
-        x_keys=param_vals,
-        x_to_float=float,
-        x_label=sweep_key,
-        x_scale="log",
-    )
-    if save:
-        save_fig(fig_s, "error_vs_param", out_dir)
-
     # ── Best-ε FD error vs param, all solvers overlaid ────────────────────────
+    param_vals = sorted(next(iter(data["by_solver"].values())).keys(), key=float)
     fig_b = _plot_best_eps_overlay(
         data["by_solver"],
         styles,
@@ -981,7 +916,7 @@ def plot_param_sweep(
     if save:
         save_fig(fig_b, "best_eps_vs_param", out_dir)
 
-    return fig
+    return fig_b
 
 
 # ── G3: Jacobian SVD ──────────────────────────────────────────────────────────
@@ -1165,82 +1100,12 @@ def plot_horizon_sweep(
     live here.
     """
     out_dir = results_dir() / cfg.name / _SUITE / f"{exp_key}{suffix}"
-    data = load_json(out_dir / "result.json")
-    styles = _alias_tolerant(solver_styles(cfg))
 
     # ── summary curves (styled) ─────────────────────────────────────────────
     fig_c = _horizon_sweep_figure(
         cfg, exp_key=exp_key, suffix=suffix, save=save, out_dir=out_dir
     )
 
-    # ── U-curve overlay: all solvers per horizon ─────────────────────────────
-    step_keys = sorted(next(iter(data["by_solver"].values())).keys(), key=int)
-    fig_u = _plot_ucurve_overlay(
-        data["by_solver"],
-        step_keys,
-        "steps",
-        styles,
-        "ε U-curves",
-        ncols=4,
-    )
-    if save:
-        save_fig(fig_u, "ucurves", out_dir)
-
-    # ── FD error vs steps, one line per ε (per solver) ───────────────────────
-    fig_s = _plot_error_per_solver(
-        data["by_solver"],
-        styles,
-        "FD error per solver",
-        x_keys=step_keys,
-        x_to_float=int,
-        x_label="Steps (horizon)",
-    )
-    if save:
-        save_fig(fig_s, "error_vs_steps", out_dir)
-
-    # ── Best-ε FD error vs steps, all solvers overlaid ───────────────────────
-    fig_b = _plot_best_eps_overlay(
-        data["by_solver"],
-        styles,
-        "Best-ε FD error",
-        x_keys=step_keys,
-        x_to_float=int,
-        x_label="Steps (horizon)",
-    )
-    if save:
-        save_fig(fig_b, "best_eps_vs_steps", out_dir)
-
-    # ── gradient magnitude fields at representative horizons ──────────────────
-    fields_path = out_dir / "gradient_fields.npz"
-    if not fields_path.exists():
-        return fig_c
-
-    npz = try_load_npz(fields_path)
-    solver_names = npz["solver_names"].tolist()
-    horizons = npz["horizons"].tolist()
-
-    for j, name in enumerate(solver_names):
-        panels = []
-        for k, h in enumerate(horizons):
-            key = f"grad_{j}_{k}"
-            if key in npz:
-                g = grad_magnitude_2d(npz[key])
-                vmax = g.max() or 1.0
-                panels.append(
-                    (f"T={h}", g, {"cmap": "viridis", "vmin": 0, "vmax": vmax})
-                )
-        if not panels:
-            continue
-        lbl = styles.get(name, {}).get("label", name)
-        fig_g = field_grid(
-            panels,
-            f"∂L/∂IC magnitude — {lbl}",
-            shared_scale=True,
-            symmetric=False,
-            ncols=len(panels),
-        )
-        if save:
-            save_fig(fig_g, f"gradient_fields_{name}", out_dir)
     return fig_c
 
 

--- a/mosaic/benchmarks/problems/shared/plots/ics.py
+++ b/mosaic/benchmarks/problems/shared/plots/ics.py
@@ -13,8 +13,11 @@ import numpy as np
 
 from mosaic.benchmarks.core.config import Problem
 from mosaic.benchmarks.problems.shared.plots.style import (
+    RCPARAMS,
+    TEXTWIDTH,
     apply_style,
     imshow_with_cbar,
+    paper_image_grid,
     save_fig,
     vorticity_2d,
 )
@@ -44,12 +47,13 @@ def plot_ic(
     The IC description is read off ``make_ic[ic_name].description`` when
     ``make_ic`` is provided (else falls back to ``""``).
     """
+    plt.rcParams.update(RCPARAMS)
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     to_2d = ic_to_2d or field_to_2d or vorticity_2d
 
-    fig, ax = plt.subplots(1, 1, figsize=(4.5, 4.0))
+    fig, ax = paper_image_grid(1, 1, panel=TEXTWIDTH * 0.5, squeeze=True)
 
     try:
         arr2d = np.asarray(to_2d(ic), dtype=np.float32)
@@ -90,6 +94,6 @@ def plot_ic(
     if desc:
         # Wrap long descriptions onto a second line
         title_parts.append(desc)
-    ax.set_title("\n".join(title_parts), fontsize=9, wrap=True)
+    ax.set_title("\n".join(title_parts), wrap=True)
 
     save_fig(fig, "ic", out_dir)

--- a/mosaic/benchmarks/problems/shared/plots/ics.py
+++ b/mosaic/benchmarks/problems/shared/plots/ics.py
@@ -1,10 +1,11 @@
 # Copyright 2026 Pasteur Labs. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""IC visualisation: one PNG per initial condition, saved to results/{problem}/ics/."""
+"""IC visualisation: one combined PNG per problem, saved to results/{problem}/ics/."""
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +15,6 @@ import numpy as np
 from mosaic.benchmarks.core.config import Problem
 from mosaic.benchmarks.problems.shared.plots.style import (
     RCPARAMS,
-    TEXTWIDTH,
     apply_style,
     imshow_with_cbar,
     paper_image_grid,
@@ -23,6 +23,88 @@ from mosaic.benchmarks.problems.shared.plots.style import (
 )
 
 apply_style()
+
+
+def _flat_field_2d(
+    ic: np.ndarray,
+    plot_params: dict,
+    mesh_ratio: tuple[int, int] | None = None,
+) -> np.ndarray | None:
+    """Reshape a flat ``(n_cells,)`` hex-mesh field to a 2-D mid-y slice.
+
+    Fallback for scalar IC fields (structural/thermal density / source) that the
+    primary ``to_2d`` transform (tuned for 2-D/3-D velocity) can't handle. The
+    (nx, ny, nz) geometry is resolved, in order of preference:
+
+      1. explicit ``plot_params`` dims when their product matches ``n_cells``;
+      2. ``mesh_ratio = (ny, nz)`` from a sibling IC that *does* carry full dims
+         (so e.g. ``uniform`` / ``random`` reuse ``two_density_bumps``'s mesh);
+      3. a near-square ``ny`` factorisation of ``n_cells`` with ``nz = 1``.
+
+    Returns the (nx, nz) mid-y slice, or ``None`` if the array is not a 1-D
+    field or no consistent reshape exists.
+    """
+    arr = np.asarray(ic)
+    if arr.ndim != 1:
+        return None
+    n_cells = int(arr.shape[0])
+    nx_ = int(plot_params.get("nx", 0))
+    ny_ = int(plot_params.get("ny", 0))
+    nz_ = int(plot_params.get("nz", 0))
+    if not (nx_ * ny_ * nz_ == n_cells and nx_ * ny_ * nz_ > 0):
+        if mesh_ratio is not None:
+            ny_, nz_ = mesh_ratio
+            nx_ = n_cells // (ny_ * nz_) if ny_ * nz_ else 0
+        else:
+            ny_ = max(1, round(n_cells**0.5))
+            while ny_ > 1 and n_cells % ny_:
+                ny_ -= 1
+            nx_, nz_ = n_cells // ny_, 1
+    if nx_ <= 0 or ny_ <= 0 or nz_ <= 0 or nx_ * ny_ * nz_ != n_cells:
+        return None
+    xyz = arr.reshape(nz_, ny_, nx_).transpose(2, 1, 0)  # (nx, ny, nz)
+    # Display the plane spanning the two largest dims (slice the thinnest axis at
+    # its midpoint): for quasi-2D meshes (nz=1) this keeps the full (nx, ny)
+    # plane; for thick 3-D meshes it takes the mid-y (nx, nz) cross-section.
+    slice_axis = int(np.argmin(xyz.shape))
+    plane = np.take(xyz, xyz.shape[slice_axis] // 2, axis=slice_axis)
+    return np.asarray(plane, dtype=np.float32)
+
+
+def _ic_to_2d(
+    ic: np.ndarray,
+    *,
+    to_2d: Any,
+    field_symmetric: bool,
+    plot_params: dict,
+    mesh_ratio: tuple[int, int] | None = None,
+) -> tuple[np.ndarray, float, float] | None:
+    """Project one IC to a 2-D array + (vmin, vmax), or ``None`` if not plottable.
+
+    Keeps the original field→2D transform and symmetric/auto colour-range logic.
+    When that transform fails or yields a non-2-D result (e.g. flat scalar
+    density / source fields), falls back to :func:`_flat_field_2d`. Returns
+    ``None`` only when no projection is possible (e.g. 1-D inflow profiles), so
+    the caller can skip ICs with no plottable field.
+    """
+    arr2d: np.ndarray | None
+    try:
+        candidate = np.asarray(to_2d(ic), dtype=np.float32)
+        arr2d = candidate if candidate.ndim == 2 else None
+    except Exception:
+        arr2d = None
+    if arr2d is None:
+        arr2d = _flat_field_2d(ic, plot_params, mesh_ratio)
+    if arr2d is None:
+        return None
+    if field_symmetric:
+        vmax = float(np.abs(arr2d).max()) or 1.0
+        return arr2d, -vmax, vmax
+    vmin_v = float(arr2d.min())
+    vmax_v = float(arr2d.max())
+    if vmin_v == vmax_v:
+        vmax_v = vmin_v + 1.0
+    return arr2d, vmin_v, vmax_v
 
 
 def plot_ic(
@@ -38,33 +120,82 @@ def plot_ic(
     field_symmetric: bool = True,
     **_kw: Any,
 ) -> None:
-    """Save one IC visualisation as ic.png (and ic.pdf) under out_dir.
+    """Save ONE combined IC figure for the whole problem as ``ics.png``.
 
-    Uses ``ic_to_2d`` if set, else ``field_to_2d``, else falls back to
-    vorticity_2d (appropriate for 2-D velocity/force fields).  If 2-D
-    conversion raises an exception the raw array shape is shown instead.
+    ``plot_ic`` is registered per IC experiment and so is invoked once per IC,
+    but it aggregates *every* IC of the problem into a single grid figure and
+    writes it to the shared ICs directory (``<results>/<problem>/ics/ics.png``).
+    The write is idempotent: each per-IC invocation rebuilds and overwrites the
+    same combined figure rather than emitting a separate ``ic.png`` per IC.
 
-    The IC description is read off ``make_ic[ic_name].description`` when
-    ``make_ic`` is provided (else falls back to ``""``).
+    Each registered IC is regenerated from ``make_ic`` (its ``IcSpec.fn`` +
+    ``plot_params``), projected to 2-D, and drawn as one panel titled with the
+    concise IC name. ICs with no 2-D projection (e.g. 1-D profiles) are skipped.
+
+    Uses ``ic_to_2d`` if set, else ``field_to_2d``, else ``vorticity_2d``
+    (appropriate for 2-D velocity / force fields); colormap and symmetric-range
+    logic are unchanged.
     """
     plt.rcParams.update(RCPARAMS)
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
 
     to_2d = ic_to_2d or field_to_2d or vorticity_2d
 
-    fig, ax = paper_image_grid(1, 1, panel=TEXTWIDTH * 0.5, squeeze=True)
+    # The combined figure lives one level up from the per-IC out_dir, i.e. the
+    # shared ICs directory <results>/<problem>/ics/.
+    ics_dir = Path(out_dir).parent
+    ics_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        arr2d = np.asarray(to_2d(ic), dtype=np.float32)
-        if field_symmetric:
-            vmax = float(np.abs(arr2d).max()) or 1.0
-            vmin_v, vmax_v = -vmax, vmax
+    # Aggregate every registered IC of this problem (make_ic carries them all).
+    # Fall back to just the IC handed in if make_ic is unavailable.
+    if make_ic:
+        specs = dict(make_ic)
+    else:
+        specs = {ic_name: None}
+
+    # Derive a fallback (ny, nz) mesh ratio from any IC that carries full
+    # (nx, ny, nz) dims, so flat scalar ICs with incomplete dims (e.g. uniform /
+    # random density) reuse a sibling's hex-mesh geometry rather than being skipped.
+    mesh_ratio: tuple[int, int] | None = None
+    for spec in specs.values():
+        pp = getattr(spec, "plot_params", {}) if spec else {}
+        ny_p, nz_p = int(pp.get("ny", 0)), int(pp.get("nz", 0))
+        if ny_p > 0 and nz_p > 0:
+            mesh_ratio = (ny_p, nz_p)
+            break
+
+    panels: list[tuple[str, np.ndarray, float, float]] = []
+    for name in sorted(specs):
+        spec = specs[name]
+        plot_params = dict(getattr(spec, "plot_params", {})) if spec else {}
+        if spec is None:
+            arr = ic
         else:
-            vmin_v = float(arr2d.min())
-            vmax_v = float(arr2d.max())
-            if vmin_v == vmax_v:
-                vmax_v = vmin_v + 1.0
+            try:
+                arr = spec(**plot_params)
+            except Exception:
+                continue
+        projected = _ic_to_2d(
+            arr,
+            to_2d=to_2d,
+            field_symmetric=field_symmetric,
+            plot_params=plot_params,
+            mesh_ratio=mesh_ratio,
+        )
+        if projected is None:
+            continue
+        arr2d, vmin_v, vmax_v = projected
+        panels.append((name, arr2d, vmin_v, vmax_v))
+
+    if not panels:
+        return
+
+    n = len(panels)
+    ncols = min(n, 4)
+    nrows = math.ceil(n / ncols)
+    fig, axes = paper_image_grid(nrows, ncols, squeeze=False)
+    axes_flat = list(axes.flat)
+
+    for ax, (name, arr2d, vmin_v, vmax_v) in zip(axes_flat, panels, strict=False):
         imshow_with_cbar(
             ax,
             fig,
@@ -75,25 +206,11 @@ def plot_ic(
             vmax=vmax_v,
             interpolation="nearest",
         )
-        ax.axis("off")
-    except Exception:
-        ax.text(
-            0.5,
-            0.5,
-            f"shape: {ic.shape}\n(no 2D projection)",
-            ha="center",
-            va="center",
-            transform=ax.transAxes,
-        )
+        ax.set_title(name)
         ax.axis("off")
 
-    desc = ""
-    if make_ic is not None and ic_name in make_ic:
-        desc = getattr(make_ic[ic_name], "description", "") or ""
-    title_parts = [ic_name]
-    if desc:
-        # Wrap long descriptions onto a second line
-        title_parts.append(desc)
-    ax.set_title("\n".join(title_parts), wrap=True)
+    for ax in axes_flat[n:]:
+        ax.set_visible(False)
 
-    save_fig(fig, "ic", out_dir)
+    fig.tight_layout()
+    save_fig(fig, "ics", ics_dir)

--- a/mosaic/benchmarks/problems/shared/plots/style.py
+++ b/mosaic/benchmarks/problems/shared/plots/style.py
@@ -326,6 +326,9 @@ def fig_shared_legend(
 ROW_ASPECT = 0.42
 # Per-row height (inches) for multi-row line grids.
 GRID_ROW_H = 1.7
+# Min per-column width (inches) for line grids — grids wider than TEXTWIDTH/this
+# many columns grow past TEXTWIDTH so panels don't collapse to zero size.
+GRID_COL_W = 1.35
 # Per-panel size (inches) for image / field grids (≈ TEXTWIDTH at 3–4 cols).
 IMG_PANEL = 1.45
 # Floor for ``1 − cosine`` so a perfect cosine still plots on a log axis.
@@ -372,15 +375,17 @@ def paper_grid(
     squeeze: bool = False,
     **kwargs: Any,
 ) -> tuple[Figure, Any]:
-    """TEXTWIDTH-wide grid of line-plot panels; height scales with *nrows*.
+    """Grid of line-plot panels; height scales with *nrows*.
 
-    For per-solver / per-sweep-value curve grids. Hide any padding panels via
-    ``ax.set_visible(False)``.
+    TEXTWIDTH wide for up to ~4 columns; wider beyond that so panels don't
+    collapse to zero size (which disables constrained layout). For per-solver /
+    per-sweep-value curve grids. Hide padding panels via ``ax.set_visible(False)``.
     """
+    width = max(TEXTWIDTH, ncols * GRID_COL_W)
     return plt.subplots(
         nrows,
         ncols,
-        figsize=(TEXTWIDTH, row_h * nrows + 0.4),
+        figsize=(width, row_h * nrows + 0.4),
         dpi=dpi,
         squeeze=squeeze,
         layout="constrained",

--- a/mosaic/benchmarks/problems/shared/plots/style.py
+++ b/mosaic/benchmarks/problems/shared/plots/style.py
@@ -237,6 +237,18 @@ def save_fig(fig: Figure, stem: str, out_dir: Path) -> None:
 # ── Shared figure legend ──────────────────────────────────────────────────────
 
 
+def _is_constrained(fig: Figure) -> bool:
+    """True when *fig* is driven by the constrained-layout engine.
+
+    Bottom legends must use ``loc="outside ..."`` (which the engine reserves
+    space for) rather than a manual ``bbox_to_anchor`` + ``tight_layout`` that
+    would conflict with it.
+    """
+    from matplotlib.layout_engine import ConstrainedLayoutEngine
+
+    return isinstance(fig.get_layout_engine(), ConstrainedLayoutEngine)
+
+
 def fig_shared_legend(
     fig: Figure,
     axes: Any,
@@ -271,11 +283,18 @@ def fig_shared_legend(
                 handles.append(h)
                 labels.append(lbl)
 
+    constrained = _is_constrained(fig)
     if not handles:
-        fig.tight_layout()
+        if not constrained:
+            fig.tight_layout()
         return
 
     _ncol = ncol if ncol is not None else len(handles)
+    if constrained:
+        # Constrained layout reserves space for an "outside" legend automatically;
+        # a manual tight_layout would conflict with the layout engine.
+        fig.legend(handles, labels, loc="outside lower center", ncol=_ncol)
+        return
     fig.legend(
         handles,
         labels,
@@ -286,6 +305,164 @@ def fig_shared_legend(
         framealpha=0.7,
     )
     fig.tight_layout(rect=[0, bottom, 1, 1])
+
+
+# ── Paper figure layouts ──────────────────────────────────────────────────────
+#
+# Canonical house layout for every line/curve and image figure in the suite,
+# factored out of the original horizon_sweep / fd_check figures so all plots
+# read identically: a TEXTWIDTH-wide figure (so PDFs embed at single-column
+# print width without scaling), RCPARAMS active, and — for solver curves — a
+# single shared legend centred below the panels in canonical solver order.
+#
+# Use:
+#   paper_row(3)             → 1×3 row of line panels      (sweep summaries)
+#   paper_grid(nrows, ncols) → multi-row grid of line panels (per-solver curves)
+#   paper_image_grid(r, c)   → grid of square image panels  (field renders)
+#   solver_legend(fig, seen) → shared bottom legend, canonical order
+#   cosine_defect(values)    → 1 − cosine, for a log "direction accuracy" axis
+
+# Aspect (height / TEXTWIDTH) of a single row of line panels.
+ROW_ASPECT = 0.42
+# Per-row height (inches) for multi-row line grids.
+GRID_ROW_H = 1.7
+# Per-panel size (inches) for image / field grids (≈ TEXTWIDTH at 3–4 cols).
+IMG_PANEL = 1.45
+# Floor for ``1 − cosine`` so a perfect cosine still plots on a log axis.
+COSINE_DEFECT_FLOOR = 1e-12
+# Canonical y-label for the log "direction accuracy" panel.
+COSINE_DEFECT_YLABEL = "$1 -$ cosine"
+
+
+def paper_row(
+    ncols: int = 1,
+    *,
+    aspect: float = ROW_ASPECT,
+    dpi: int = 300,
+    squeeze: bool = True,
+    **kwargs: Any,
+) -> tuple[Figure, Any]:
+    """One TEXTWIDTH-wide row of *ncols* line-plot panels at the house aspect.
+
+    The canonical layout for sweep / curve summaries (cf. ``horizon_sweep``).
+    Pair with :func:`solver_legend` for the shared bottom legend. ``RCPARAMS``
+    must already be active (modules call :func:`apply_style` at import).
+
+    Uses constrained layout so multi-panel rows never overlap their y-labels /
+    titles; the shared legend helpers reserve their own space via an "outside"
+    placement.
+    """
+    return plt.subplots(
+        1,
+        ncols,
+        figsize=(TEXTWIDTH, TEXTWIDTH * aspect),
+        dpi=dpi,
+        squeeze=squeeze,
+        layout="constrained",
+        **kwargs,
+    )
+
+
+def paper_grid(
+    nrows: int,
+    ncols: int,
+    *,
+    row_h: float = GRID_ROW_H,
+    dpi: int = 300,
+    squeeze: bool = False,
+    **kwargs: Any,
+) -> tuple[Figure, Any]:
+    """TEXTWIDTH-wide grid of line-plot panels; height scales with *nrows*.
+
+    For per-solver / per-sweep-value curve grids. Hide any padding panels via
+    ``ax.set_visible(False)``.
+    """
+    return plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, row_h * nrows + 0.4),
+        dpi=dpi,
+        squeeze=squeeze,
+        layout="constrained",
+        **kwargs,
+    )
+
+
+def paper_image_grid(
+    nrows: int,
+    ncols: int,
+    *,
+    panel: float = IMG_PANEL,
+    dpi: int = 300,
+    squeeze: bool = False,
+    **kwargs: Any,
+) -> tuple[Figure, Any]:
+    """Grid of square-ish image / field panels (≈ TEXTWIDTH wide at 3–4 cols).
+
+    For field renders (IC, optimised density, recovered fields, …). Each panel
+    is *panel* inches square; add colorbars with :func:`imshow_with_cbar`.
+
+    Deliberately NOT constrained-layout: image grids commonly attach
+    ``make_axes_locatable`` colorbars (via :func:`imshow_with_cbar`), which the
+    constrained-layout engine can't manage. Callers space panels with
+    ``tight_layout`` / ``subplots_adjust`` as needed.
+    """
+    return plt.subplots(
+        nrows,
+        ncols,
+        figsize=(ncols * panel, nrows * panel),
+        dpi=dpi,
+        squeeze=squeeze,
+        **kwargs,
+    )
+
+
+def solver_legend(
+    fig: Figure,
+    seen: Any,
+    *,
+    order: list[str] | None = None,
+    extra_handles: list | None = None,
+    ncol: int | None = None,
+    y: float = 0.01,
+) -> None:
+    """Shared solver legend centred below the panels, solvers in canonical order.
+
+    *seen* is an iterable of solver aliases present in the figure; *order* is the
+    canonical ordering (defaults to ``NS_ORDER + FEM_ORDER``). *extra_handles*
+    appends custom ``Line2D`` proxies (e.g. a failure marker). No-op when nothing
+    is present. Styling (font, frame) comes from ``RCPARAMS``.
+    """
+    order = order if order is not None else (NS_ORDER + FEM_ORDER)
+    seen_set = set(seen)
+    handles = dedup_handles([make_handle(s) for s in order if s in seen_set])
+    if extra_handles:
+        handles += list(extra_handles)
+    if not handles:
+        return
+    _ncol = ncol if ncol is not None else min(len(handles), 6)
+    if _is_constrained(fig):
+        fig.legend(
+            handles=handles, loc="outside lower center", ncol=_ncol, handlelength=2.0
+        )
+        return
+    fig.legend(
+        handles=handles,
+        loc="lower center",
+        bbox_to_anchor=(0.5, y),
+        ncol=_ncol,
+        handlelength=2.0,
+    )
+
+
+def cosine_defect(values: Any, *, floor: float = COSINE_DEFECT_FLOOR) -> list[float]:
+    """``1 − cosine`` (floored) for a log "direction accuracy" axis.
+
+    Near-perfect cosine similarity reads on a log axis instead of being squashed
+    against 1.0. Pair with ``ax.loglog`` / ``ax.set_yscale('log')`` and
+    ``ax.set_ylabel(COSINE_DEFECT_YLABEL)``.
+    """
+    return [max(1.0 - float(c), floor) for c in values]
 
 
 # ── Multi-panel grid helper ───────────────────────────────────────────────────

--- a/mosaic/benchmarks/problems/structural_mesh/config.py
+++ b/mosaic/benchmarks/problems/structural_mesh/config.py
@@ -51,7 +51,6 @@ from mosaic.benchmarks.problems.shared.plots.ics import plot_ic
 from mosaic.benchmarks.problems.shared.plots.solver_styles import apply_styles
 
 from .exclusions import register as _register_exclusions
-from .extras import register as _register_extras
 from .ics import _random, _two_density_bumps, _uniform
 from .optimization import topopt
 from .physics import DIAGNOSTICS, make_inputs
@@ -346,12 +345,6 @@ problem.add_experiment(
     optim={"lr": 5e-2, "max_iters": 2500, "patience": 100},
     plot=plot_topopt,
 )
-
-
-# ── Cross-experiment extras ──────────────────────────────────────────────────
-# Aggregator plots that span multiple experiments live in ``extras.py``; the
-# register call wires them into ``problem.plot_fns`` under ``_extra/...``.
-_register_extras(problem)
 
 
 # ── Exclusions ───────────────────────────────────────────────────────────────

--- a/mosaic/benchmarks/problems/structural_mesh/plots.py
+++ b/mosaic/benchmarks/problems/structural_mesh/plots.py
@@ -50,13 +50,23 @@ _CLR_LOAD = "#FF1744"
 
 
 def _add_bcs(ax: Any, nx: int, ny: int, nz: int, ph: dict) -> None:
-    """Overlay fixed-face patch and load arrow on a voxel Axes3D."""
+    """Overlay fixed-face patch and load arrow on a voxel Axes3D.
+
+    The load arrow is drawn *anchored to the loaded corner of the structure*
+    (on the right face, x = nx) and pointing in the load direction. Its origin
+    is offset outward by the full arrow length so the arrow *tip* lands on the
+    corner, keeping the shaft outside the voxels yet still inside (or only just
+    beyond) the data box. The axes limits are then explicitly grown to include
+    the whole arrow — otherwise the auto-fit bounds (set from the voxels alone)
+    clip it — and a high ``zorder`` keeps it drawn on top of the voxels.
+    """
     wall = Poly3DCollection(
         [[(0, 0, 0), (0, ny, 0), (0, ny, nz), (0, 0, nz)]],
         alpha=0.55,
         facecolor=_CLR_FIXED,
         edgecolor="#333333",
         linewidth=0.8,
+        zorder=1,
     )
     ax.add_collection3d(wall)
 
@@ -66,26 +76,43 @@ def _add_bcs(ax: Any, nx: int, ny: int, nz: int, ph: dict) -> None:
     ly = (ny - 0.5) if corner_y_high else 0.5
     lz = (nz - 0.5) if corner_z_high else 0.5
 
-    arrow_len = nz * 0.65
+    # Arrow length scaled to the structure but with a sensible floor so it is
+    # clearly visible even on the thin/short meshes used here (e.g. nz = 8).
+    arrow_len = max(2.5, 0.6 * max(nx, ny, nz))
     if load_axis == "y":
         y_sign = -1 if corner_y_high else 1
-        dx, dy_a, dz_a = 0, y_sign * arrow_len, 0
+        dx, dy_a, dz_a = 0.0, y_sign * arrow_len, 0.0
     else:
         z_sign = -1 if corner_z_high else 1
-        dx, dy_a, dz_a = 0, 0, z_sign * arrow_len
+        dx, dy_a, dz_a = 0.0, 0.0, z_sign * arrow_len
 
-    ox = nx + 0.6 if load_axis != "y" else nx
+    # Load corner sits on the right face (x = nx). Place the arrow *tail* one
+    # arrow-length back along the load direction so the *tip* meets the corner.
+    ox, oy, oz = float(nx), float(ly), float(lz)
+    tail_x, tail_y, tail_z = ox - dx, oy - dy_a, oz - dz_a
     ax.quiver(
-        ox,
-        ly,
-        lz,
+        tail_x,
+        tail_y,
+        tail_z,
         dx,
         dy_a,
         dz_a,
         color=_CLR_LOAD,
-        linewidth=2.5,
-        arrow_length_ratio=0.28,
+        linewidth=3.0,
+        arrow_length_ratio=0.3,
+        zorder=10,
     )
+
+    # Grow the axes limits to enclose both the voxel box and the full arrow so
+    # nothing is clipped once the surrounding spines/ticks are turned off.
+    xs = [0.0, float(nx), tail_x, ox]
+    ys = [0.0, float(ny), tail_y, oy]
+    zs = [0.0, float(nz), tail_z, oz]
+    pad = 0.5
+    ax.set_xlim(min(xs) - pad, max(xs) + pad)
+    ax.set_ylim(min(ys) - pad, max(ys) + pad)
+    ax.set_zlim(min(zs) - pad, max(zs) + pad)
+    ax.set_box_aspect((nx, ny, nz))
 
 
 def _voxel_facecolors(
@@ -291,7 +318,8 @@ def plot_topopt(
 
       * ``topopt_fields`` — initial + per-solver final 2-D density panels.
       * ``topopt_evolution_<solver>.gif`` — density-field animation per solver.
-      * ``topopt_3d_<solver>.png`` — interactive-style 3-D voxel render per solver.
+      * ``topopt_3d.png`` — single grid of 3-D voxel renders, one panel per
+        solver, with the load-arrow / fixed-face BC overlay on each.
     """
     out_dir = results_dir() / cfg.name / "optimization" / f"{exp_key}{suffix}"
     data = load_json(out_dir / "result.json")
@@ -369,34 +397,45 @@ def _plot_topopt_3d(
     out_dir: Path,
     styles: dict,
     params: dict | None = None,
-    threshold: float = 0.35,
+    threshold: float = _THRESH,
 ) -> None:
-    """3-D voxel plots of the final optimised density field, one per solver.
+    """Single combined 3-D voxel grid of the final optimised density fields.
 
-    Saves ``topopt_3d_{solver_name}.png`` in *out_dir*.  The voxel array is
-    reshaped from the flat (n_cells,) layout to (nx, ny, nz) so that matplotlib's
-    ``Axes3D.voxels()`` maps naturally to (length, width, height).  Voxels with
-    ρ > *threshold* are shown; colour is steel-blue (solid material) with alpha
-    proportional to density so partially-dense cells appear translucent.
+    Produces ONE figure ``topopt_3d.png`` in *out_dir* with one 3-D voxel panel
+    per solver that actually carries a ``rho_final_<j>`` array, titled per solver
+    and annotated with the fixed-face patch + red load arrow via :func:`_add_bcs`.
 
-    Problem-specific annotations are inferred from *params*:
-    - ``corner_load=True``:  red marker at the corner load point (x=Lx, y=0, z=0).
-    - Always:                translucent blue plane on the fixed/clamped face (x=0).
-
-    Works for any problem using a 2:1:1 hex mesh (structural-mesh, thermal-mesh, …).
+    Solvers are deduplicated by canonical alias (first occurrence wins) so the
+    same physical result is not drawn twice. The voxel array is reshaped from the
+    flat ``(n_cells,)`` layout to ``(nx, ny, nz)`` so matplotlib's
+    ``Axes3D.voxels()`` maps naturally to (length, width, height); voxels with
+    ρ > *threshold* are shown.
     """
     params = params or {}
-    corner_load = params.get("corner_load", False)
 
-    # Steel-blue RGB for solid material
-    _SOLID_RGB = np.array([0.267, 0.467, 0.667])  # #4477AA
-
+    # Collect the (solver, field-index) panels to draw, deduped by alias.
+    seen_aliases: set[str] = set()
+    panels: list[tuple[int, str]] = []
     for j, name in enumerate(solver_names):
-        key = f"rho_final_{j}"
-        if key not in npz:
+        if f"rho_final_{j}" not in npz:
             continue
+        alias = resolve_solver_alias(name)
+        key = alias or name
+        if key in seen_aliases:
+            continue
+        seen_aliases.add(key)
+        panels.append((j, name))
 
-        rho_flat = npz[key]
+    if not panels:
+        return
+
+    n = len(panels)
+    fig = plt.figure(figsize=(TEXTWIDTH, TEXTWIDTH / max(1, n) * 1.05), dpi=300)
+    gs = fig.add_gridspec(1, n, wspace=0.05, top=0.80, bottom=0.02)
+
+    for col, (j, name) in enumerate(panels):
+        ax = fig.add_subplot(gs[0, col], projection="3d")
+        rho_flat = npz[f"rho_final_{j}"]
         n_cells = len(rho_flat)
 
         # Prefer explicit (nx, ny, nz) from params when they match n_cells;
@@ -414,83 +453,31 @@ def _plot_topopt_3d(
 
         # Reshape: flat → (nz, ny, nx) → (nx, ny, nz) for matplotlib voxels axes
         rho_xyz = rho_flat.reshape(nz_, ny_, nx_).transpose(2, 1, 0)  # (nx, ny, nz)
-
         filled = rho_xyz > threshold
 
-        # Face colours: steel-blue for all filled voxels; alpha scales with density
-        # so near-threshold cells appear translucent and solid cells opaque.
-        fc = np.zeros((*rho_xyz.shape, 4))
-        fc[..., :3] = _SOLID_RGB
-        # Remap density from [threshold, 1] → [0.35, 0.92] for alpha
-        alpha = np.where(
-            filled,
-            0.35 + 0.57 * (rho_xyz - threshold) / (1.0 - threshold + 1e-8),
-            0.0,
-        )
-        fc[..., 3] = alpha
+        alias = resolve_solver_alias(name)
+        _label, color, _ls, _mk = solver_props(alias or name)
+        fc = _voxel_facecolors(rho_xyz, filled, color)
+        ax.voxels(filled, facecolors=fc, edgecolors=fc, shade=True, zorder=2)
 
-        fig = plt.figure(figsize=(TEXTWIDTH, TEXTWIDTH * 0.62), dpi=300)
-        ax = fig.add_subplot(111, projection="3d")
-        ax.voxels(filled, facecolors=fc, edgecolor="none")
+        # Fixed-face patch + red load arrow (also sets axis limits / box aspect).
+        _add_bcs(ax, nx_, ny_, nz_, params)
 
-        # Fixed/clamped face: translucent blue plane at x=0
-        yy, zz = np.meshgrid([0, ny_], [0, nz_])
-        xx = np.zeros_like(yy)
-        ax.plot_surface(xx, yy, zz, alpha=0.12, color="#4477AA", linewidth=0)
-
-        # Corner load annotation (structural-mesh only).
-        # The load is applied at the bottom-front corner of the right face
-        # (x=Lx, y=0, z=0 in physical coords → voxel coords nx_-0.5, 0.5, 0.5).
-        # Draw it AFTER the voxels so it renders on top, use depthshade=False to
-        # prevent matplotlib from darkening the marker, and add a quiver arrow
-        # pointing upward (+z) so the force direction is unambiguous.
-        if corner_load:
-            ax.scatter(
-                [nx_ - 0.5],
-                [0.5],
-                [0.5],
-                color="#EE3333",
-                s=180,
-                zorder=10,
-                depthshade=False,
-                label="load (↑z)",
-            )
-            # Arrow: base slightly below the load point, pointing upward (+z).
-            # Length ~15 % of nz_ so it is proportional to the mesh.
-            arrow_len = max(0.8, nz_ * 0.15)
-            ax.quiver(
-                nx_ - 0.5,
-                0.5,
-                0.5 - arrow_len,
-                0,
-                0,
-                arrow_len,
-                color="#EE3333",
-                linewidth=2,
-                arrow_length_ratio=0.4,
-                zorder=10,
-            )
-            ax.legend(fontsize=8, loc="upper left")
-
-        ax.set_xlabel("$x$  (length)", labelpad=4)
-        ax.set_ylabel("$y$  (width)", labelpad=4)
-        ax.set_zlabel("$z$  (height)", labelpad=4)
-        # View from the right-front-top so both the clamped left face and the
-        # bottom-front corner load on the right face are simultaneously visible.
-        # azim=45 looks from the right side (load corner is on the near face);
-        # elev=30 gives enough height to see the 3-D topology clearly.
-        ax.view_init(elev=30, azim=45)
-
-        label = styles.get(name, {}).get("label", name)
+        label = styles.get(name, {}).get("label", alias or name)
         compliance_val = by_solver.get(name, {}).get("final_compliance")
-        title = rf"{label}  ($\rho > {threshold}$)"
+        title = label
         if compliance_val is not None:
             title += f"\n$C = {compliance_val:.3e}$"
-        ax.set_title(title)
+        ax.set_title(title, fontsize=7.5, pad=2)
+        ax.view_init(elev=_ELEV, azim=_AZIM)
+        ax.set_axis_off()
 
-        fig.tight_layout()
-        save_fig(fig, f"topopt_3d_{name}", out_dir)
-        plt.close(fig)
+    fig.suptitle(
+        rf"Optimised density ($\rho > {threshold}$) with load and fixed-face BCs",
+        fontsize=9,
+        y=0.98,
+    )
+    save_fig(fig, "topopt_3d", out_dir)
 
 
 def _render_topopt_evolution_gifs(

--- a/mosaic/benchmarks/problems/structural_mesh/plots.py
+++ b/mosaic/benchmarks/problems/structural_mesh/plots.py
@@ -32,6 +32,8 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     THERMAL_ORDER,
     dedup_handles,
     make_handle,
+    paper_image_grid,
+    paper_row,
     resolve_solver_alias,
     save_fig,
     solver_props,
@@ -284,11 +286,11 @@ def plot_topopt(
         return fig_c
     solver_names = npz["solver_names"].tolist()
     n_panels = 1 + len(solver_names)
-    fig_f, axes = plt.subplots(1, n_panels, figsize=(n_panels * 3, 3), squeeze=False)
+    fig_f, axes = paper_image_grid(1, n_panels)
 
-    initial_panels = [("Initial ρ", npz["rho_init"])] if "rho_init" in npz else []
+    initial_panels = [(r"Initial $\rho$", npz["rho_init"])] if "rho_init" in npz else []
     panels = initial_panels + [
-        (styles.get(n, {}).get("label", n) + " final", npz[f"rho_final_{j}"])
+        (styles.get(n, {}).get("label", n), npz[f"rho_final_{j}"])
         for j, n in enumerate(solver_names)
         if f"rho_final_{j}" in npz
     ]
@@ -302,12 +304,16 @@ def plot_topopt(
             vmax=1,
             interpolation="nearest",
         )
-        ax.set_title(title, fontsize=8)
+        ax.set_title(title)
         ax.axis("off")
-    if im is not None:
-        plt.colorbar(im, ax=axes[0][-1], fraction=0.04)
-    fig_f.suptitle(f"{cfg.name} — optimised density fields")
+    fig_f.suptitle("Optimised density fields")
     fig_f.tight_layout()
+    if im is not None:
+        # Shared colorbar in its own slim axes so every density panel stays
+        # square and equally sized (no per-panel shrink).
+        fig_f.subplots_adjust(right=0.90)
+        cax = fig_f.add_axes((0.92, 0.18, 0.015, 0.62))
+        fig_f.colorbar(im, cax=cax)
     if save:
         save_fig(fig_f, "topopt_fields", out_dir)
 
@@ -390,7 +396,7 @@ def _plot_topopt_3d(
         )
         fc[..., 3] = alpha
 
-        fig = plt.figure(figsize=(9, 6))
+        fig = plt.figure(figsize=(TEXTWIDTH, TEXTWIDTH * 0.62), dpi=300)
         ax = fig.add_subplot(111, projection="3d")
         ax.voxels(filled, facecolors=fc, edgecolor="none")
 
@@ -433,9 +439,9 @@ def _plot_topopt_3d(
             )
             ax.legend(fontsize=8, loc="upper left")
 
-        ax.set_xlabel("x  (length)", labelpad=4)
-        ax.set_ylabel("y  (width)", labelpad=4)
-        ax.set_zlabel("z  (height)", labelpad=4)
+        ax.set_xlabel("$x$  (length)", labelpad=4)
+        ax.set_ylabel("$y$  (width)", labelpad=4)
+        ax.set_zlabel("$z$  (height)", labelpad=4)
         # View from the right-front-top so both the clamped left face and the
         # bottom-front corner load on the right face are simultaneously visible.
         # azim=45 looks from the right side (load corner is on the near face);
@@ -444,10 +450,10 @@ def _plot_topopt_3d(
 
         label = styles.get(name, {}).get("label", name)
         compliance_val = by_solver.get(name, {}).get("final_compliance")
-        title = f"{cfg.name} — {label}\noptimised topology  (ρ > {threshold})"
+        title = rf"{label}  ($\rho > {threshold}$)"
         if compliance_val is not None:
-            title += f"    C = {compliance_val:.4e}"
-        ax.set_title(title, fontsize=9)
+            title += f"\n$C = {compliance_val:.3e}$"
+        ax.set_title(title)
 
         fig.tight_layout()
         save_fig(fig, f"topopt_3d_{name}", out_dir)
@@ -479,7 +485,7 @@ def _render_topopt_evolution_gifs(
         n_frames = int(history.shape[0])
 
         first = _rho_to_2d(history[0], params_all)
-        fig, ax = plt.subplots(figsize=(5, 3.5))
+        fig, ax = paper_row(1)
         im = ax.imshow(
             first,
             origin="lower",
@@ -489,9 +495,8 @@ def _render_topopt_evolution_gifs(
             interpolation="nearest",
         )
         label = styles.get(name, {}).get("label", name)
-        title = ax.set_title(f"{label} — iter 1 / {n_frames}", fontsize=9)
+        title = ax.set_title(f"{label} — iter 1 / {n_frames}")
         ax.axis("off")
-        fig.tight_layout()
 
         def _update(
             idx: Any,

--- a/mosaic/benchmarks/problems/structural_mesh/plots.py
+++ b/mosaic/benchmarks/problems/structural_mesh/plots.py
@@ -115,6 +115,39 @@ def _solver_order_for(cfg_name: str) -> list[str]:
     return STRUCTURAL_ORDER
 
 
+def _field_solver_names(npz: Any, by_solver: dict | None = None) -> list[str]:
+    """Per-field solver names aligned with the ``rho_final_<j>`` arrays.
+
+    The NPZ stores one ``rho_final_<j>`` (and optional ``rho_history_<j>``)
+    array per solver, written in ``by_solver`` insertion order. The
+    companion ``solver_names`` array is *supposed* to label them, but some
+    older result sets carry a truncated ``solver_names`` (e.g. only the
+    first solver) while still writing every field array — which makes the
+    field/3-D/GIF panels silently collapse to a single solver.
+
+    To stay robust we count the actual ``rho_final_<j>`` arrays and:
+      * use ``solver_names`` when it labels *every* field array, otherwise
+      * fall back to the ``by_solver`` keys (same generation order) so all
+        solvers present in the data are drawn.
+    """
+    npz_keys = npz.files if hasattr(npz, "files") else list(npz.keys())
+    n_fields = sum(1 for k in npz_keys if k.startswith("rho_final_"))
+
+    stored = list(npz["solver_names"]) if "solver_names" in npz_keys else []
+    if len(stored) >= n_fields and n_fields > 0:
+        return [str(s) for s in stored[:n_fields]]
+
+    by_solver_names = list((by_solver or {}).keys())
+    if len(by_solver_names) >= n_fields and n_fields > 0:
+        return [str(s) for s in by_solver_names[:n_fields]]
+
+    # Last resort: pad whatever names we have so every field array is drawn.
+    names = [str(s) for s in (stored or by_solver_names)]
+    while len(names) < n_fields:
+        names.append(f"solver_{len(names)}")
+    return names
+
+
 def _plot_topopt_figure(
     cfg: Problem,
     *,
@@ -161,7 +194,7 @@ def _plot_topopt_figure(
     )
 
     if have_fields:
-        npz_solvers = list(npz["solver_names"])
+        npz_solvers = _field_solver_names(npz, by_solver)
         n_field_panels = len(npz_solvers)
         ncols = max(1, n_field_panels)
         fig = plt.figure(figsize=(TEXTWIDTH, TEXTWIDTH * 0.62), dpi=300)
@@ -282,9 +315,9 @@ def plot_topopt(
         return fig_c
 
     npz = try_load_npz(fields_path)
-    if "solver_names" not in npz:
+    solver_names = _field_solver_names(npz, by_solver)
+    if not solver_names:
         return fig_c
-    solver_names = npz["solver_names"].tolist()
     n_panels = 1 + len(solver_names)
     fig_f, axes = paper_image_grid(1, n_panels)
 

--- a/mosaic/benchmarks/problems/thermal_mesh/config.py
+++ b/mosaic/benchmarks/problems/thermal_mesh/config.py
@@ -52,7 +52,6 @@ from mosaic.benchmarks.problems.shared.plots.ics import plot_ic
 from mosaic.benchmarks.problems.shared.plots.solver_styles import apply_styles
 
 from .exclusions import register as _register_exclusions
-from .extras import register as _register_extras
 from .ics import _gaussian_source, _random, _two_gaussians, _uniform, _zero_source
 from .optimization import conductivity_recovery
 from .physics import DIAGNOSTICS, make_inputs
@@ -472,12 +471,6 @@ problem.add_experiment(
     optim={"max_iters": 200, "patience": 30},
     plot=plot_conductivity_recovery,
 )
-
-
-# ── Cross-experiment extras ──────────────────────────────────────────────────
-# Aggregator plots that span multiple experiments live in ``extras.py``; the
-# register call wires them into ``problem.plot_fns`` under ``_extra/...``.
-_register_extras(problem)
 
 
 # ── Exclusions ───────────────────────────────────────────────────────────────

--- a/mosaic/benchmarks/problems/thermal_mesh/plots.py
+++ b/mosaic/benchmarks/problems/thermal_mesh/plots.py
@@ -12,7 +12,12 @@ import matplotlib.pyplot as plt
 from mosaic.benchmarks.core.config import Problem
 from mosaic.benchmarks.core.io import load_json, results_dir
 from mosaic.benchmarks.problems.shared.plots.style import (
+    RCPARAMS,
+    THERMAL_ORDER,
+    paper_row,
+    resolve_solver_alias,
     save_fig,
+    solver_legend,
     solver_plot_props,
     solver_styles,
 )
@@ -33,11 +38,14 @@ def plot_conductivity_recovery(
     if not by_solver:
         return None
 
+    plt.rcParams.update(RCPARAMS)
+
     styles = solver_styles(cfg, differentiable_only=False)
     names = list(by_solver.keys())
 
-    fig_cv, (ax_lc, ax_bar) = plt.subplots(1, 2, figsize=(12, 4))
+    fig_cv, (ax_lc, ax_bar) = paper_row(2)
 
+    seen: set[str] = set()
     final_errors: list[float] = []
     for name in names:
         res = by_solver[name]
@@ -49,24 +57,25 @@ def plot_conductivity_recovery(
                 label=sty.get("label", name),
                 **solver_plot_props(sty, marker=False),
             )
+            alias = resolve_solver_alias(name)
+            if alias is not None:
+                seen.add(alias)
         final_errors.append(float(res.get("final_error", float("nan"))))
 
     ax_lc.set_xlabel("Iteration")
     ax_lc.set_ylabel("Identification error")
-    ax_lc.set_title("Conductivity recovery — loss curves")
-    ax_lc.legend(fontsize=8)
+    ax_lc.set_title("Loss curves")
     ax_lc.grid(True, which="both", alpha=0.3)
 
     colors = [cfg.solver(n).color if n in cfg.solvers else "#888888" for n in names]
     labels = [styles.get(n, {}).get("label", n) for n in names]
     ax_bar.bar(labels, final_errors, color=colors)
     ax_bar.set_ylabel("Final identification error")
-    ax_bar.set_title("Conductivity recovery — final error")
+    ax_bar.set_title("Final error")
     ax_bar.tick_params(axis="x", rotation=30)
     ax_bar.grid(axis="y", alpha=0.4)
 
-    fig_cv.suptitle(f"{cfg.name} — conductivity recovery")
-    fig_cv.tight_layout()
+    solver_legend(fig_cv, seen, order=THERMAL_ORDER)
     if save:
         save_fig(fig_cv, "conductivity_recovery_convergence", out_dir)
 


### PR DESCRIPTION
## What

While iterating on the plots from the merged benchmark artifact via `mosaic run --plots-only` (regenerate plots from cached `result.json`/`.npz`, no solver re-runs), I found one visual defect and a cluster of crashes that silently dropped plots. This fixes all of them — the full `--plots-only` sweep now regenerates every plot with **zero warnings**.

## Fixes

**Misleading direction-accuracy axis** (`shared/plots/gradient.py`)
When every subspace cosine is ≈1.0, the zoom logic pinned `ylim` to `[0.998, 1.001]` — a 0.003-wide band carved into sub-0.001 gridlines that implied structure that wasn't there. Now floored at 0.95, so a perfect cosine reads as a line pinned to the top of a readable band, while genuine dips stay visible.

Before/after on `ns-grid/gradient/param_sweep` is striking: the old plot rendered a flat line at 1.0 (and, due to the crash below, only a single solver from a stale baseline). The fixed plot shows all six solvers and reveals **real** variation — XLB's cosine climbing from ~0.73 → 1.0 as ν increases.

**None-valued metrics crashed whole figures** (`shared/plots/gradient.py`)
`float(None)` and `np.isfinite(None)` both raise; a single failed/non-finite ε or step run took down the entire figure. Added `_finite_or_nan` and applied it at every raw-metric ingestion point (param/horizon sweeps, best-ε overlay, U-curve overlay, per-solver error grid).

**Missing `eps_sweep` KeyError** (`shared/plots/gradient.py`)
A failed run can record a step/param entry without an `eps_sweep`; the per-solver and U-curve overlays now skip those instead of `KeyError`-ing.

**Empty log-scaled scaling panel crashed `savefig`** (`navier_stokes_grid/extras.py`, `navier_stokes_3d_grid/extras.py`)
A log-scaled panel with no positive data makes `savefig` raise at draw time — the `_extra/scaling` figure was silently absent from the artifact. Now hides empty panels and bails out only when all three are empty.

**Forward plots KeyError'd on absent `fields.npz`** (`shared/plots/forward.py`)
`try_load_npz` returns `{}` when the npz is missing; `npz["sweep_values"]` then crashed. Now skips gracefully (agreement falls back to the `result.json`-only convergence view).

**Recovery GIF render used the wrong npz API** (`navier_stokes_3d_grid/plots.py`)
Called `.files` on the plain dict from `try_load_npz`; switched to dict membership.

## Testing

Regenerated all plots for every problem/suite via `mosaic run --plots-only` against the merged benchmark artifact from PR #59's pipeline. Before: 16 warnings / silently-dropped plots. After: clean across `ns-grid`, `ns-3d-grid`, `thermal-mesh`, `structural-mesh`. No solver runs, no Docker, no GPU — pure plotting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)