### PR TITLE
doc: fix solver reference pages dropping all canonical IO fields (#84)

### DIFF
--- a/docs/generate.py
+++ b/docs/generate.py
@@ -186,7 +186,6 @@ def _canonical_schema_source(physics_dir: str) -> str | None:
         schema_path = (
             ROOT
             / "mosaic"
-            / "tesseracts"
             / "mosaic_shared"
             / "problems"
             / module

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -184,12 +184,7 @@ def _canonical_schema_source(physics_dir: str) -> str | None:
         return None
     if module not in _CANONICAL_CACHE:
         schema_path = (
-            ROOT
-            / "mosaic"
-            / "mosaic_shared"
-            / "problems"
-            / module
-            / "schemas.py"
+            ROOT / "mosaic" / "mosaic_shared" / "problems" / module / "schemas.py"
         )
         if not schema_path.exists():
             _CANONICAL_CACHE[module] = ""


### PR DESCRIPTION
Closes #84.

## Problem

Each solver subclasses the canonical `InputSchema`/`OutputSchema` via `make_differentiable(...)` and declares only its *additional* fields, so the solver reference pages were showing just those extras — and for solvers that add no fields of their own, an **empty** table.

## Root cause

`_canonical_schema_source()` in [`docs/generate.py`](docs/generate.py) built the path with a stray `tesseracts/` segment:

```
mosaic/tesseracts/mosaic_shared/problems/<domain>/schemas.py   # does not exist
```

The canonical schemas actually live at:

```
mosaic/mosaic_shared/problems/<domain>/schemas.py
```

So the path never resolved, `_canonical_schema_source()` returned `None`, and `parse_schema()` fell back to solver-only fields.

## Fix

Drop the `tesseracts/` segment. One line.

## Verification

Exercised the parser against `thermal-mesh/firedrake-heat` before/after:

| | Before (solver-only) | After (canonical merged) |
|---|---|---|
| **Inputs** | `k_max, p_exp` | `rho, source, target_temperature, boundary_conditions, hex_mesh, k_max, p_exp` |
| **Outputs** | *(empty)* | `thermal_compliance, identification_error` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)