### PR TITLE
fix: stop overlapping text in topopt_3d figure (#87)

### DIFF
--- a/mosaic/benchmarks/problems/structural_mesh/plots.py
+++ b/mosaic/benchmarks/problems/structural_mesh/plots.py
@@ -432,7 +432,10 @@ def _plot_topopt_3d(
 
     n = len(panels)
     fig = plt.figure(figsize=(TEXTWIDTH, TEXTWIDTH / max(1, n) * 1.05), dpi=300)
-    gs = fig.add_gridspec(1, n, wspace=0.05, top=0.80, bottom=0.02)
+    # wspace gives adjacent per-panel titles horizontal breathing room (they
+    # overlapped at 0.05); top leaves a clear band below the suptitle for the
+    # two-line "<label> / C = ..." titles.
+    gs = fig.add_gridspec(1, n, wspace=0.30, top=0.78, bottom=0.02)
 
     for col, (j, name) in enumerate(panels):
         ax = fig.add_subplot(gs[0, col], projection="3d")
@@ -469,7 +472,7 @@ def _plot_topopt_3d(
         title = label
         if compliance_val is not None:
             title += f"\n$C = {compliance_val:.3e}$"
-        ax.set_title(title, fontsize=7.5, pad=2)
+        ax.set_title(title, fontsize=7, pad=6)
         ax.view_init(elev=_ELEV, azim=_AZIM)
         ax.set_axis_off()
 


### PR DESCRIPTION
Closes #87.

## Problem

In `_plot_topopt_3d` ([structural_mesh/plots.py](mosaic/benchmarks/problems/structural_mesh/plots.py)), the row of 3D voxel panels used `wspace=0.05`, and each panel has a **two-line** title (`<solver label>` + `$C = <compliance>$`) drawn with `pad=2`. Adjacent titles collided horizontally, and the second title line sat cramped against the panel.

## Fix

- `wspace` `0.05 → 0.30` — horizontal room so neighbouring titles don't overlap
- gridspec `top` `0.80 → 0.78` — clear band below the suptitle for the two-line titles
- title `pad` `2 → 6`, `fontsize` `7.5 → 7` — clearance for the second line

## Note on verification

I can't render `topopt_3d.png` here (needs the benchmark `npz` outputs + full plotting stack), so these are layout-parameter adjustments validated by `py_compile` only. **Please eyeball the regenerated figure on the next docs build** — if any pair of titles is still tight at high solver counts, `wspace` is the knob to nudge further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)