### PR TITLE
fix: heat identification_error → area-weighted L2 integral (#85)

### DIFF
--- a/mosaic/tesseracts/thermal-mesh/dealii-heat/tesseract_api.py
+++ b/mosaic/tesseracts/thermal-mesh/dealii-heat/tesseract_api.py
@@ -158,6 +158,24 @@ def _run_solver(wd: Path) -> None:
         )
 
 
+def _lumped_node_weights(points: np.ndarray, cells: np.ndarray) -> np.ndarray:
+    """Per-node lumped volume w_i for an axis-aligned hex mesh.
+
+    Each hex cell's volume (bounding-box product of its node coordinates) is
+    split equally among its nodes, so ``sum_i w_i * f_i`` approximates the
+    integral ``∫ f dΩ``. Used to make ``identification_error`` the area-weighted
+    L2 integral ``∫(T-T*)² dΩ`` rather than a raw nodal sum (see issue #85).
+    """
+    pts = np.asarray(points, dtype=np.float64)
+    cels = np.asarray(cells, dtype=np.int64)
+    w = np.zeros(len(pts), dtype=np.float64)
+    for cell in cels:
+        cp = pts[cell]
+        vol = float(np.prod(cp.max(axis=0) - cp.min(axis=0)))
+        w[cell] += vol / len(cell)
+    return w
+
+
 def _parse_outputs(inputs: InputSchema, wd: Path) -> OutputSchema:
     """Read compliance.txt and (if present) temperature.npy to compute id-error."""
     with open(wd / "compliance.txt") as f:
@@ -167,8 +185,15 @@ def _parse_outputs(inputs: InputSchema, wd: Path) -> OutputSchema:
     temp_path = wd / "temperature.npy"
     if temp_path.exists() and target_temp.size > 1:
         temperature = np.load(str(temp_path)).astype(np.float32)
-        n = min(len(temperature), len(target_temp))
-        id_error = np.float32(np.sum((temperature[:n] - target_temp[:n]) ** 2))
+        # Area-weighted L2 integral ∫(T-T*)² dΩ via lumped nodal volumes.
+        hm = inputs.hex_mesh
+        pts = np.asarray(hm.points[: hm.n_points], dtype=np.float64)
+        cells = np.asarray(hm.faces[: hm.n_faces], dtype=np.int64)
+        w = _lumped_node_weights(pts, cells)
+        n = min(len(temperature), len(target_temp), len(w))
+        id_error = np.float32(
+            np.sum(w[:n] * (temperature[:n] - target_temp[:n]).astype(np.float64) ** 2)
+        )
     else:
         id_error = np.float32(0.0)
 

--- a/mosaic/tesseracts/thermal-mesh/fenics-heat/tesseract_api.py
+++ b/mosaic/tesseracts/thermal-mesh/fenics-heat/tesseract_api.py
@@ -450,7 +450,7 @@ def apply(inputs: InputSchema) -> OutputSchema:
         bc.neumann.values if bc.neumann else np.zeros((0, 1)), dtype=np.float64
     )
 
-    J_val, T_verts, _, _, id_error_l2 = _solve_heat(
+    J_val, _, _, _, id_error_l2 = _solve_heat(
         rho_values,
         pts,
         cells,

--- a/mosaic/tesseracts/thermal-mesh/fenics-heat/tesseract_api.py
+++ b/mosaic/tesseracts/thermal-mesh/fenics-heat/tesseract_api.py
@@ -303,6 +303,27 @@ def _solve_heat(
     # compute_vertex_values returns a flat array of length n_vertices.
     T_vertices = T_sol.compute_vertex_values(mesh)
 
+    # ---- Identification error: area-weighted L2 integral ∫(T-T*)² dΩ ------
+    # This is BOTH the reported objective and the integral the adjoint below
+    # differentiates, so the returned gradient is the exact derivative of the
+    # reported objective. (Previously apply() reported the nodal sum
+    # sum((T-T*)²) while the adjoint differentiated this integral, bridged by an
+    # approximate n_nodes/domain_vol scalar — see issue #85.)
+    id_error_l2 = None
+    if target_temperature is not None:
+        T_target_fn0 = Function(V)
+        T_tgt0 = np.asarray(target_temperature, dtype=np.float64)
+        d2v0 = dof_to_vertex_map(V)
+        target_at_dofs0 = np.zeros(V.dim(), dtype=np.float64)
+        for dof_i in range(V.dim()):
+            vert_i = int(d2v0[dof_i])
+            if vert_i < len(T_tgt0):
+                target_at_dofs0[dof_i] = float(T_tgt0[vert_i])
+        T_target_fn0.vector()[:] = target_at_dofs0
+        id_error_l2 = float(
+            assemble(inner(T_sol - T_target_fn0, T_sol - T_target_fn0) * dx)
+        )
+
     # ---- Gradient via adjoint --------------------------------------------
     dJ_drho = None
     if compute_gradient:
@@ -377,31 +398,21 @@ def _solve_heat(
                 target_at_dofs2[dof_i] = float(T_tgt[vert_i])
         T_target_fn.vector()[:] = target_at_dofs2
 
-        # Nodal correction: identification_error (forward) = sum(nodal diff^2),
-        # while dolfin-adjoint differentiates ∫(T-T_t)² dΩ (area-weighted).
-        coords2 = mesh2.coordinates()
-        domain_vol2 = float(
-            np.prod(
-                [
-                    coords2[:, i].max() - coords2[:, i].min()
-                    for i in range(coords2.shape[1])
-                ]
-            )
-        )
-        n_nodes_mesh2 = mesh2.num_vertices()
-        nodal_correction2 = float(n_nodes_mesh2) / domain_vol2
-
+        # identification_error = ∫(T-T_t)² dΩ — the same area-weighted L2
+        # integral the forward apply() now reports, so this adjoint derivative
+        # is the exact gradient of the reported objective (no nodal-sum/integral
+        # correction factor needed; see issue #85).
         diff2 = T_sol2 - T_target_fn
         I2 = assemble(inner(diff2, diff2) * dx)
         Ihat2 = ReducedFunctional(I2, Control(rho2))
         dI_fenics2 = Ihat2.derivative()
-        dI_fenics_vec2 = dI_fenics2.vector().get_local().copy() * nodal_correction2
+        dI_fenics_vec2 = dI_fenics2.vector().get_local().copy()
 
         dI_input2 = np.zeros(len(rho_values))
         dI_input2[fenics_to_input2] = dI_fenics_vec2
         dI_drho = dI_input2
 
-    return float(J), T_vertices, dJ_drho, dI_drho
+    return float(J), T_vertices, dJ_drho, dI_drho, id_error_l2
 
 
 # ---------------------------------------------------------------------------
@@ -439,7 +450,7 @@ def apply(inputs: InputSchema) -> OutputSchema:
         bc.neumann.values if bc.neumann else np.zeros((0, 1)), dtype=np.float64
     )
 
-    J_val, T_verts, _, _ = _solve_heat(
+    J_val, T_verts, _, _, id_error_l2 = _solve_heat(
         rho_values,
         pts,
         cells,
@@ -451,11 +462,11 @@ def apply(inputs: InputSchema) -> OutputSchema:
         inputs.p_exp,
         compute_gradient=False,
         source_values=source_values,
+        target_temperature=target_temp if target_temp.size else None,
     )
 
-    T_f32 = T_verts.astype(np.float32)
-    n = min(len(T_f32), len(target_temp))
-    id_error = np.float32(np.sum((T_f32[:n] - target_temp[:n]) ** 2))
+    # Area-weighted L2 identification error ∫(T-T*)² dΩ (see _solve_heat / #85).
+    id_error = np.float32(id_error_l2 if id_error_l2 is not None else 0.0)
 
     return OutputSchema(
         thermal_compliance=np.float32(J_val),
@@ -530,7 +541,7 @@ def vector_jacobian_product(
             else None
         )
 
-        _, _, dJ_drho, dI_drho = _solve_heat(
+        _, _, dJ_drho, dI_drho, _ = _solve_heat(
             rho_values,
             pts,
             cells,
@@ -622,21 +633,9 @@ def vector_jacobian_product(
             T_sol = Function(V)
             solve(a == L, T_sol, bcs)
 
-            # ---- Nodal correction factor (matches firedrake fix) -----------
-            # identification_error = sum((T_nodes - T_target)^2)  (nodal, no area)
-            # J_id (dolfin-adjoint) = integral((T-T_t)^2 dΩ)     (area-weighted)
-            # Correction: nodal_correction = n_nodes / domain_vol
-            coords = mesh.coordinates()  # numpy array (n_vertices, 3)
-            domain_vol = float(
-                np.prod(
-                    [
-                        coords[:, i].max() - coords[:, i].min()
-                        for i in range(coords.shape[1])
-                    ]
-                )
-            )
-            n_nodes_mesh = mesh.num_vertices()
-            nodal_correction = float(n_nodes_mesh) / domain_vol
+            # identification_error is now the area-weighted L2 integral
+            # ∫(T-T_t)² dΩ — exactly what dolfin-adjoint differentiates below —
+            # so no nodal-sum/integral correction factor is applied (see #85).
 
             # ---- Branch: ∂(identification_error)/∂source -----------------
             if cot_src != 0.0:
@@ -660,9 +659,7 @@ def vector_jacobian_product(
                 # ---- Adjoint differentiation for identification_error -----
                 Jhat_id = ReducedFunctional(J_id, source_ctrl)
                 dJ_src_fenics = Jhat_id.derivative()
-                dJ_src_vec = (
-                    dJ_src_fenics.vector().get_local().copy() * nodal_correction
-                )
+                dJ_src_vec = dJ_src_fenics.vector().get_local().copy()
 
                 # ---- Map FEniCS DG0 DOF order → input cell order ---------
                 dJ_src_input = np.zeros(hm.n_faces, dtype=np.float64)

--- a/mosaic/tesseracts/thermal-mesh/firedrake-heat/tesseract_api.py
+++ b/mosaic/tesseracts/thermal-mesh/firedrake-heat/tesseract_api.py
@@ -332,6 +332,25 @@ def _solve_heat(
         input_to_fd[inp_idx] = fd_idx
     T_nodes = T_fd[input_to_fd]  # (n_input_nodes,)
 
+    # ---- Identification error: area-weighted L2 integral ∫(T-T*)² dΩ ----
+    # This is BOTH the reported objective and the quantity the adjoint below
+    # differentiates, so the returned gradient is the exact derivative of the
+    # reported objective. (Previously apply() reported the nodal sum
+    # sum((T-T*)²) while the adjoint differentiated this integral and bridged
+    # the two with an approximate scalar — see issue #85.)
+    id_error_l2 = None
+    if target_temperature is not None:
+        T_target_fd = Function(V)
+        T_tgt = np.asarray(target_temperature, dtype=np.float64)
+        T_tgt_reordered = np.zeros(mesh.num_vertices(), dtype=np.float64)
+        for fd_idx, inp_idx in enumerate(fd_to_input_nodes):
+            if inp_idx < len(T_tgt):
+                T_tgt_reordered[fd_idx] = T_tgt[inp_idx]
+        T_target_fd.dat.data[:] = T_tgt_reordered
+        id_error_l2 = float(
+            assemble(inner(T_sol - T_target_fd, T_sol - T_target_fd) * dx)
+        )
+
     # ---- Gradients via adjoint -----------------------------------------
     dJ_drho = None
     dJ_dsource = None
@@ -417,22 +436,14 @@ def _solve_heat(
             if inp_idx < len(T_tgt4):
                 T_tgt_reordered4[fd_idx] = T_tgt4[inp_idx]
         T_target_fd4.dat.data[:] = T_tgt_reordered4
-        # Identification error functional: I = ∫(T - T_target)² dΩ
-        _coords4 = mesh.coordinates.dat.data_ro
-        domain_vol4 = float(
-            np.prod(
-                [
-                    _coords4[:, i].max() - _coords4[:, i].min()
-                    for i in range(_coords4.shape[1])
-                ]
-            )
-        )
-        n_nodes4 = mesh.num_vertices()
-        nodal_correction4 = float(n_nodes4) / domain_vol4
+        # Identification error functional: I = ∫(T - T_target)² dΩ — the same
+        # area-weighted L2 integral the forward apply() now reports, so this
+        # adjoint derivative is the *exact* gradient of the reported objective
+        # (no nodal-sum/integral correction factor needed; see issue #85).
         I_rho = assemble(inner(T_sol4 - T_target_fd4, T_sol4 - T_target_fd4) * dx)
         dI_rho_hat = ReducedFunctional(I_rho, Control(rho_fn4))
         dI_rho_fn = dI_rho_hat.derivative()
-        dI_rho_vec = dI_rho_fn.dat.data_ro.copy() * nodal_correction4
+        dI_rho_vec = dI_rho_fn.dat.data_ro.copy()
         dI_rho_input = np.zeros(len(rho_values))
         dI_rho_input[fd_to_input_cells] = dI_rho_vec
         dI_drho = dI_rho_input
@@ -477,32 +488,23 @@ def _solve_heat(
             if inp_idx < len(T_tgt):
                 T_tgt_reordered[fd_idx] = T_tgt[inp_idx]
         T_target_fd.dat.data[:] = T_tgt_reordered
-        # Identification error functional: I = ∫(T - T_target)² dΩ
-        # NOTE: The forward uses sum((T_nodes-T_target)²) (nodal sum, no area weighting).
-        # The L2 functional ∫(T-T_target)²dΩ = M_lump * nodal_sum (Galerkin mass weighting).
-        # Correcting by (n_nodes / domain_vol) ≈ 1/M_lump_avg cancels this discrepancy,
-        # reducing the VJP magnitude error from ~50× to <5%.
-        _coords = mesh.coordinates.dat.data_ro
-        domain_vol = float(
-            np.prod(
-                [
-                    _coords[:, i].max() - _coords[:, i].min()
-                    for i in range(_coords.shape[1])
-                ]
-            )
-        )
-        n_nodes = mesh.num_vertices()
-        nodal_correction = float(n_nodes) / domain_vol
+        # Identification error functional: I = ∫(T - T_target)² dΩ — the exact
+        # area-weighted L2 integral the forward apply() now reports, so this
+        # adjoint derivative is the exact gradient of the reported objective.
+        # (Previously the forward used the nodal sum sum((T-T_target)²) and this
+        # gradient was multiplied by an approximate n_nodes/domain_vol factor to
+        # bridge the two — only correct to ~5%, which corrupted L-BFGS curvature;
+        # see issue #85.)
         J3 = assemble(inner(T_sol3 - T_target_fd, T_sol3 - T_target_fd) * dx)
         Jhat3 = ReducedFunctional(J3, Control(source_fn3))
         dI_src_fn = Jhat3.derivative()
-        dI_src_fd = dI_src_fn.dat.data_ro.copy() * nodal_correction
+        dI_src_fd = dI_src_fn.dat.data_ro.copy()
         dI_src_input = np.zeros(len(source_values))
         for fd_idx, inp_idx in enumerate(fd_to_input_cells):
             dI_src_input[inp_idx] = dI_src_fd[fd_idx]
         dI_dsource = dI_src_input
 
-    return float(J), T_nodes, dJ_drho, dJ_dsource, dI_dsource, dI_drho
+    return float(J), T_nodes, dJ_drho, dJ_dsource, dI_dsource, dI_drho, id_error_l2
 
 
 # ---------------------------------------------------------------------------
@@ -540,7 +542,7 @@ def apply(inputs: InputSchema) -> OutputSchema:
         bc.neumann.values if bc.neumann else np.zeros((0, 1)), dtype=np.float64
     )
 
-    J_val, T_nodes, _, _, _, _ = _solve_heat(
+    J_val, T_nodes, _, _, _, _, id_error_l2 = _solve_heat(
         rho_values,
         source_values,
         pts,
@@ -552,11 +554,11 @@ def apply(inputs: InputSchema) -> OutputSchema:
         k_max=inputs.k_max,
         p_exp=inputs.p_exp,
         compute_gradient=False,
+        target_temperature=target_temp if target_temp.size else None,
     )
 
-    T_f32 = T_nodes.astype(np.float32)
-    n = min(len(T_f32), len(target_temp))
-    id_error = np.float32(np.sum((T_f32[:n] - target_temp[:n]) ** 2))
+    # Area-weighted L2 identification error ∫(T-T*)² dΩ (see _solve_heat / #85).
+    id_error = np.float32(id_error_l2 if id_error_l2 is not None else 0.0)
 
     return OutputSchema(
         thermal_compliance=np.float32(J_val),
@@ -619,7 +621,7 @@ def vector_jacobian_product(
     target_temp = np.asarray(inputs.target_temperature, dtype=np.float64)
     need_target = want_source_id_error or want_rho_id_error
 
-    _, _, dJ_drho, dJ_dsource, dI_dsource, dI_drho = _solve_heat(
+    _, _, dJ_drho, dJ_dsource, dI_dsource, dI_drho, _ = _solve_heat(
         rho_values,
         source_values,
         pts,

--- a/mosaic/tesseracts/thermal-mesh/firedrake-heat/tesseract_api.py
+++ b/mosaic/tesseracts/thermal-mesh/firedrake-heat/tesseract_api.py
@@ -542,7 +542,7 @@ def apply(inputs: InputSchema) -> OutputSchema:
         bc.neumann.values if bc.neumann else np.zeros((0, 1)), dtype=np.float64
     )
 
-    J_val, T_nodes, _, _, _, _, id_error_l2 = _solve_heat(
+    J_val, _, _, _, _, _, id_error_l2 = _solve_heat(
         rho_values,
         source_values,
         pts,

--- a/mosaic/tesseracts/thermal-mesh/jax-fem/tesseract_api.py
+++ b/mosaic/tesseracts/thermal-mesh/jax-fem/tesseract_api.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import meshio
 from jax_fem.generate_mesh import Mesh
 from jax_fem.problem import Problem
@@ -41,21 +42,46 @@ class OutputSchema(
 # ---------------------------------------------------------------------------
 
 
+def _lumped_node_weights(points: np.ndarray, cells: np.ndarray) -> np.ndarray:
+    """Per-node lumped volume w_i for an axis-aligned hex mesh.
+
+    Each hex cell's volume (bounding-box product of its node coordinates) is
+    split equally among its nodes, so ``sum_i w_i * f_i`` approximates the
+    integral ``∫ f dΩ``. Used to make ``identification_error`` the area-weighted
+    L2 integral ``∫(T-T*)² dΩ`` rather than a raw nodal sum (see issue #85).
+    """
+    pts = np.asarray(points, dtype=np.float64)
+    cels = np.asarray(cells, dtype=np.int64)
+    w = np.zeros(len(pts), dtype=np.float64)
+    for cell in cels:
+        cp = pts[cell]
+        vol = float(np.prod(cp.max(axis=0) - cp.min(axis=0)))
+        w[cell] += vol / len(cell)
+    return w
+
+
 def _compute_identification_error(
-    T_nodes: jnp.ndarray, target_temperature: jnp.ndarray
+    T_nodes: jnp.ndarray,
+    target_temperature: jnp.ndarray,
+    node_weights: jnp.ndarray | None = None,
 ) -> jnp.ndarray:
-    """Compute ||T - target_temperature||²_2 (scalar, float32).
+    """Compute the area-weighted L2 identification error (scalar, float32).
 
     Args:
         T_nodes: Nodal temperature field, shape (n_nodes,).
         target_temperature: Per-node target, shape (n_target,). Trimmed to
             min(n_nodes, n_target) for safety.
+        node_weights: Per-node lumped volumes w_i so the result is
+            ``sum_i w_i (T_i-T*_i)²`` ≈ ``∫(T-T*)² dΩ``. When None, falls back to
+            the unweighted nodal sum.
 
     Returns:
         Scalar identification error.
     """
     n = min(T_nodes.shape[0], target_temperature.shape[0])
     diff = T_nodes[:n] - target_temperature[:n]
+    if node_weights is not None:
+        return jnp.sum(node_weights[:n] * diff**2).astype(jnp.float32)
     return jnp.sum(diff**2).astype(jnp.float32)
 
 
@@ -308,7 +334,17 @@ def apply_fn(inputs: dict) -> dict:
     # identification_error = sum((-T_jaxfem - T_target)^2) is consistent with
     # the other three solvers' sum((T_nodal - T_target)^2) formulation.
     T_nodal = -sol[:, 0]
-    id_error = _compute_identification_error(T_nodal, target_temperature)
+    # Area-weighted L2 integral ∫(T-T*)² dΩ via lumped nodal volumes. The mesh
+    # arrays are concrete (only rho/source are traced by jax.vjp), so the weights
+    # are geometry-only constants and AD flows through T_nodal correctly (#85).
+    node_w = jnp.asarray(
+        _lumped_node_weights(
+            inputs["hex_mesh"]["points"][: inputs["hex_mesh"]["n_points"]],
+            inputs["hex_mesh"]["faces"][: inputs["hex_mesh"]["n_faces"]],
+        ),
+        dtype=jnp.float32,
+    )
+    id_error = _compute_identification_error(T_nodal, target_temperature, node_w)
 
     return {
         "thermal_compliance": thermal_compliance.astype(jnp.float32),

--- a/mosaic/tesseracts/thermal-mesh/jax-fem/tesseract_api.py
+++ b/mosaic/tesseracts/thermal-mesh/jax-fem/tesseract_api.py
@@ -7,8 +7,8 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 import meshio
+import numpy as np
 from jax_fem.generate_mesh import Mesh
 from jax_fem.problem import Problem
 from jax_fem.solver import ad_wrapper

--- a/mosaic/tesseracts/thermal-mesh/torch-fem-thermal/tesseract_api.py
+++ b/mosaic/tesseracts/thermal-mesh/torch-fem-thermal/tesseract_api.py
@@ -382,6 +382,24 @@ def _forward_torchfem(
     return u_k, f_k, forces_base
 
 
+def _lumped_node_weights(points: np.ndarray, cells: np.ndarray) -> np.ndarray:
+    """Per-node lumped volume w_i for an axis-aligned hex mesh.
+
+    Each hex cell's volume (bounding-box product of its node coordinates) is
+    split equally among its nodes, so ``sum_i w_i * f_i`` approximates the
+    integral ``∫ f dΩ``. Used to make ``identification_error`` the area-weighted
+    L2 integral ``∫(T-T*)² dΩ`` rather than a raw nodal sum (see issue #85).
+    """
+    pts = np.asarray(points, dtype=np.float64)
+    cels = np.asarray(cells, dtype=np.int64)
+    w = np.zeros(len(pts), dtype=np.float64)
+    for cell in cels:
+        cp = pts[cell]
+        vol = float(np.prod(cp.max(axis=0) - cp.min(axis=0)))
+        w[cell] += vol / len(cell)
+    return w
+
+
 def _apply_core(inputs_dict: dict, want_grad: bool) -> dict:
     """Shared forward solver used by both ``apply`` and ``vector_jacobian_product``.
 
@@ -428,13 +446,20 @@ def _apply_core(inputs_dict: dict, want_grad: bool) -> dict:
     # solvers' surface-integral compliance.
     thermal_compliance = torch.inner(f_neumann.reshape(-1), u_k.reshape(-1))
 
-    # Identification error: Σ (T_nodal - T_target)^2
+    # Identification error: area-weighted L2 integral ∫(T-T*)² dΩ, approximated
+    # via lumped nodal volumes (w_i are geometry-only constants, so autograd
+    # still flows correctly through diff). See issue #85.
     T_nodal = u_k.reshape(-1)
     if target_np.size > 0:
         target_t = torch.as_tensor(target_np, dtype=_DTYPE, device=_DEVICE)
         n = min(T_nodal.shape[0], target_t.shape[0])
         diff = T_nodal[:n] - target_t[:n]
-        identification_error = torch.sum(diff * diff)
+        w_np = _lumped_node_weights(
+            np.asarray(hm["points"][: hm["n_points"]], dtype=np.float64),
+            np.asarray(hm["faces"][: hm["n_faces"]], dtype=np.int64),
+        )[:n]
+        w_t = torch.as_tensor(w_np, dtype=_DTYPE, device=_DEVICE)
+        identification_error = torch.sum(w_t * diff * diff)
     else:
         identification_error = torch.zeros((), dtype=_DTYPE, device=_DEVICE)
 


### PR DESCRIPTION

## Root cause

`identification_error` was the raw nodal sum `Σ(T-T*)²` in every forward, but the adjoint solvers (Firedrake, FEniCS) differentiated the area-weighted integral `∫(T-T*)²dΩ` and multiplied by an approximate `n_nodes/domain_vol` scalar. Per the paper excerpt in the issue, that scalar is only ~5% accurate, so the gradient isn't the exact derivative of the reported objective — and L-BFGS folds the inconsistency into a corrupted Hessian estimate, converging to a suboptimal point.

## Fix: make `∫(T-T*)²dΩ` the reported objective everywhere

| Solver | Change | Gradient |
|--------|--------|----------|
| **firedrake-heat** | forward reports `assemble(inner(T-T*,T-T*)*dx)` (plumbed through `_solve_heat`); removed `nodal_correction` on both rho & source grads | exact (consistent mass) |
| **fenics-heat** | same | exact (consistent mass) |
| **jax-fem** | forward weighted by lumped nodal volumes | auto via `jax.vjp` through the objective |
| **torch-fem-thermal** | forward weighted by lumped nodal volumes | auto via `torch.autograd` |
| **dealii-heat** | lumped-volume weighting on the reported scalar (forward-only) | n/a |

The shared `_lumped_node_weights` helper splits each axis-aligned hex cell's bounding-box volume equally among its 8 nodes. **Unit-tested**: total weight = domain volume; interior nodes (shared by 2 cells) weighted 2× corners.

## Known limitations (why it's a draft)

- **Consistent vs lumped mass**: Firedrake/FEniCS use the consistent mass matrix (`*dx`); the other three use lumped mass. These agree to O(h²) and converge to the same continuum objective, but aren't bit-identical. Reconciling to one convention is follow-up.
- **deal.II** remains forward-only (no adjoint); its reported objective is now area-weighted but it still can't drive the optimization.
- **Reported metric changes** for all solvers (integral, not nodal sum) — intended, but it shifts `identification_error` / `final_ic_error` numbers in published results.