### PR TITLE
ci: intersect flat --solvers list with each problem in the benchmark matrix

### DIFF
--- a/.github/scripts/intersect-solvers.py
+++ b/.github/scripts/intersect-solvers.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Intersect a flat solver list with a single problem's solver set.
+
+Prints the comma-separated canonical solver names that the requested
+``--solvers`` list and the given ``--problem`` have in common (matched
+case-insensitively, canonical casing preserved in the output). Empty output
+means the problem has none of the requested solvers.
+
+A flat ``--solvers`` list handed to a multi-problem benchmark matrix may name
+solvers that exist only in some problems (e.g. ``torch-fem`` is thermal-only,
+``TopOpt.jl`` is structural-only). ``mosaic run`` rejects a name that is not in
+the problem it is run against, so applying one flat list to every matrix leg
+breaks the legs whose problem lacks some of those solvers. Intersecting the
+request with each problem's own solver set first keeps every leg valid.
+
+Usage (in CI):
+    python .github/scripts/intersect-solvers.py \
+        --problem thermal-mesh --solvers "deal.II,FEniCS,torch-fem"
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from mosaic.benchmarks.problems import get_config
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--problem", required=True, help="Single problem name")
+    parser.add_argument(
+        "--solvers", required=True, help="Comma-separated solver display names"
+    )
+    args = parser.parse_args()
+
+    wanted = {s.strip().lower() for s in args.solvers.split(",") if s.strip()}
+    try:
+        names = [s.name for s in get_config(args.problem).solvers]
+    except Exception:
+        names = []
+    matched = [n for n in names if n.lower() in wanted]
+    print(",".join(matched))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/benchmark-run.yml
+++ b/.github/workflows/benchmark-run.yml
@@ -116,9 +116,23 @@ jobs:
       - name: Run ${{ matrix.suite }} | ${{ matrix.problem }} | ${{ matrix.hardware }}
         run: |
           SOLVERS="${{ inputs.solvers }}"
+          PROBLEM="${{ matrix.problem }}"
+          # A flat --solvers list may name solvers that only exist in some
+          # problems of the matrix (e.g. torch-fem is thermal-only, TopOpt.jl is
+          # structural-only). mosaic run rejects a name absent from the problem
+          # it runs against, so intersect the request with THIS problem's solver
+          # set first; an empty intersection means this leg has nothing to run.
+          if [[ -n "$SOLVERS" ]]; then
+            SOLVERS=$(uv run python .github/scripts/intersect-solvers.py \
+              --problem "$PROBLEM" --solvers "$SOLVERS")
+            if [[ -z "$SOLVERS" ]]; then
+              echo "::notice::None of the requested solvers exist for $PROBLEM — skipping."
+              exit 0
+            fi
+          fi
           uv run mosaic run \
             --suites ${{ matrix.suite }} \
-            --problems ${{ matrix.problem }} \
+            --problems "$PROBLEM" \
             --hardware ${{ matrix.hardware }} \
             --no-build \
             ${SOLVERS:+--solvers "$SOLVERS"}


### PR DESCRIPTION
## Problem

`benchmark-run.yml` runs a matrix over problems and applied the same flat `inputs.solvers` list to **every** leg's `mosaic run` (`--problems "${{ matrix.problem }}" --solvers "$SOLVERS"`). A cross-domain list breaks the legs whose problem lacks some of those solvers:

```
Run SOLVERS="deal.II,FEniCS,Firedrake,JAX-FEM,torch-fem"
Unknown solver 'torch-fem'.
Available solvers: FEniCS, Firedrake, JAX-FEM, TopOpt.jl, deal.II
Error: Process completed with exit code 1.
```

`torch-fem` is thermal-only (structural-mesh has `TopOpt.jl` instead), and `mosaic run` ([`_helpers.py:471`](mosaic/benchmarks/cli/_helpers.py#L471)) rejects a name absent from the problem it runs against. One bad leg fails the whole dispatch — which is exactly what blocks verifying a thermal-only change (e.g. #85) whenever the matrix also includes structural-mesh.

## Fix

- Add [`​.github/scripts/intersect-solvers.py`](.github/scripts/intersect-solvers.py) — prints the intersection of a flat solver list with one problem's own solver set (case-insensitive, canonical casing preserved), mirroring the existing `filter-problems-by-solver.py`.
- In the **Run** step, intersect `SOLVERS` with `matrix.problem` before calling `mosaic run`; skip the leg when the intersection is empty.

Each leg now runs exactly the requested solvers it actually has:

| leg | requested | runs |
|-----|-----------|------|
| thermal-mesh | `deal.II,FEniCS,Firedrake,JAX-FEM,torch-fem` | all five |
| structural-mesh | same | `FEniCS,Firedrake,JAX-FEM,deal.II` (torch-fem dropped) |
| (no overlap) | same | leg skipped with a `::notice::` |

The `pull-solver-images.py` step already skips out-of-problem solvers ([`pull-solver-images.py:96`](.github/scripts/pull-solver-images.py#L96)), so only the run step needed this.

## Verification

- `intersect-solvers.py` compiles; YAML validates; the intersection logic is unit-tested (cases above).
- Full end-to-end needs a benchmark dispatch (Docker + GHCR images), which I can't run here — the matrix legs are otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)