### PR TITLE
chore: sync tooling config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# global owners will be requested for
+# review when someone opens a pull request.
+#
+# Add code owners here. For example:
+# *       @user1 @user2 @user3

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        informational: true
+        informational: false
         only_pulls: false
     patch: off
 comment:

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ mosaic-results/
 .env
 .claude/
 uv.lock
+.ruff_cache/
 
 /.quarto/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         additional_dependencies: [--isolated]
         args: ["--maxkb=2000"]
         # Add exceptions here, as a regex
-        exclude: ""
+        # exclude: ""
 
       - id: check-json
         additional_dependencies: [--isolated]
@@ -65,7 +65,7 @@ repos:
             mv uv.lock.bak uv.lock; \
             exit $rc;
           '
-        additional_dependencies: [uv==0.6.11, --isolated]
+        additional_dependencies: [uv==0.11.21, --isolated]
 
       # Update requirements.txt after production.uv.lock changes
       - id: update-requirements
@@ -83,7 +83,7 @@ repos:
             mv uv.lock.bak uv.lock; \
             exit $rc;
           '
-        additional_dependencies: [uv==0.6.11, --isolated]
+        additional_dependencies: [uv==0.11.21, --isolated]
 
   - repo: https://github.com/pasteurlabs/mirrors-prettier
     rev: v3.7.4 # Use the latest version


### PR DESCRIPTION
Routine maintenance bump to development tooling:

- Enable the `check-added-large-files` pre-commit hook (an empty `exclude` was silently disabling it).
- Bump the pinned `uv` version used by the lockfile hooks to `0.11.21`.
- Add `.ruff_cache/` to `.gitignore`.
- Add a `CODEOWNERS` stub — **maintainers: please fill in the owners line before merging** (currently comments only, so it has no effect yet).

No functional/library changes.

- Make the Codecov coverage check a blocking CI status (was informational).
