### PR TITLE
fix: external contributor friendly doc builds

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -220,10 +220,15 @@ jobs:
     needs: [plan, benchmarks]
     # Runs on every PR (and every dispatch where benchmarks ran), even for
     # benchmark:none PRs that ran no benchmarks. The benchmark-result steps
-    # below are guarded on should_run; the docs render / upload / RTD-trigger
-    # steps run regardless so doc-only PRs still get a Read the Docs preview.
-    # A benchmark:none PR still fetches the published baseline, so its preview
+    # below are guarded on should_run; the docs render + upload steps run
+    # regardless so doc-only PRs still get a Read the Docs preview. A
+    # benchmark:none PR still fetches the published baseline, so its preview
     # shows the full site populated with the last released results.
+    #
+    # This job runs in the PR head's context and uses NO repo secrets, so it
+    # works identically for fork PRs. The secret-requiring follow-up (trigger
+    # the RTD rebuild, resolve the preview URL, post the PR comment) lives in
+    # docs-publish.yml, which fires on workflow_run in the base-repo context.
     if: >-
       always() && !cancelled()
       && needs.plan.result == 'success'
@@ -350,6 +355,28 @@ jobs:
         # populated from the merged PR+baseline result tree above.
         run: uv run quarto render --output-dir _site
 
+      # ── Metadata for the downstream publish workflow ───────────────────
+      # The RTD trigger, preview-URL lookup, and PR comment all need repo
+      # secrets, which GitHub withholds from pull_request runs on fork PRs.
+      # So this job (which runs in the *fork's* context) does the secret-free
+      # work — render + upload — and hands off to docs-publish.yml, which runs
+      # on workflow_run in the *base* repo's context (trusted main code, full
+      # secret access). The handoff carries everything that workflow needs but
+      # can't otherwise recover: the PR number and whether benchmarks ran.
+      - name: Write publish metadata
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            echo "pr_number=${{ github.event.pull_request.number }}"
+            echo "should_run=${{ needs.plan.outputs.should_run }}"
+          } > publish-meta.txt
+          # Ship the status report alongside the site so the downstream comment
+          # can include it. Absent (benchmark:none) → downstream posts only the
+          # preview banner.
+          if [[ "${{ needs.plan.outputs.should_run }}" == "true" ]]; then
+            cp status-report.md _site-status-report.md
+          fi
+
       - name: Upload rendered docs site
         uses: actions/upload-artifact@v7
         with:
@@ -360,52 +387,20 @@ jobs:
           overwrite: true
           retention-days: 90
 
-      # ── Trigger RTD PR preview rebuild ─────────────────────────────────
-      # RTD's webhook fires on PR push, but that build starts before
-      # benchmark results exist.  After uploading the results artifact,
-      # trigger a fresh RTD build so it can pick up the results.
-      - name: Trigger RTD PR preview rebuild
+      - name: Upload publish handoff
+        # Consumed by docs-publish.yml (workflow_run). Kept separate from the
+        # _site artifact so the downstream can grab just the small metadata +
+        # report without unpacking the whole site.
         if: github.event_name == 'pull_request'
-        env:
-          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
-          RTD_PROJECT: ${{ vars.RTD_PROJECT }}
-        run: |
-          PR_NUM="${{ github.event.pull_request.number }}"
-          bash .github/scripts/rtd-trigger.sh "${PR_NUM}"
-
-      # ── Resolve RTD preview URL ────────────────────────────────────────
-      # The external version already exists (RTD's webhook created it on PR
-      # push), so its public docs URL can be looked up immediately — no need to
-      # wait for the rebuild below. Resolving it here (a fast API GET) lets the
-      # PR comment link the preview prominently without being held up by the
-      # build poll. Non-fatal: an empty output just omits the banner.
-      - name: Resolve RTD preview URL
-        id: rtd_url
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        env:
-          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
-          RTD_PROJECT: ${{ vars.RTD_PROJECT }}
-        run: |
-          PR_NUM="${{ github.event.pull_request.number }}"
-          bash .github/scripts/rtd-preview-url.sh "${PR_NUM}"
-
-      # ── Post PR comment ────────────────────────────────────────────────
-      # When benchmarks ran, pass the status report; otherwise pass nothing and
-      # the comment is just the docs-preview banner (no all-zero status table).
-      - name: Post status comment on PR
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.PL_PASTEURBOT_PAT_PUBLIC }}
-          DOCS_PREVIEW_URL: ${{ steps.rtd_url.outputs.preview_url }}
-        run: |
-          REPORT=""
-          if [[ "${{ needs.plan.outputs.should_run }}" == "true" ]]; then
-            REPORT="status-report.md"
-          fi
-          .github/scripts/post-status-comment.sh \
-            "${{ github.event.pull_request.number }}" \
-            "$REPORT"
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-publish-meta-${{ github.event.pull_request.number }}
+          path: |
+            publish-meta.txt
+            _site-status-report.md
+          if-no-files-found: ignore
+          overwrite: true
+          retention-days: 7
 
   # ── Merge gate ─────────────────────────────────────────────────────────
   bench-ok:
@@ -442,8 +437,8 @@ jobs:
 
           # benchmark:none → no benchmarks to check, but the report job still
           # runs to render the docs preview. A failed render (e.g. a broken
-          # .qmd) should block merge; RTD-side steps are best-effort
-          # (continue-on-error) and don't fail the job.
+          # .qmd) should block merge. RTD publishing / PR-commenting happen in
+          # docs-publish.yml (workflow_run) and never gate the merge.
           if [[ "${{ needs.plan.outputs.label }}" == "none" ]]; then
             if [[ "${{ github.event_name }}" == "pull_request" \
                && "${{ needs.report.result }}" != "success" \

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,116 @@
+name: Publish docs preview
+
+# Second half of the fork-safe docs-preview flow. The Benchmark workflow's
+# `report` job runs in the PR head's context (fork PRs included) and does the
+# secret-free work: render the site and upload it as an artifact. It cannot
+# trigger the RTD rebuild, resolve the preview URL, or post the PR comment,
+# because GitHub withholds repo secrets from pull_request runs on fork PRs.
+#
+# This workflow fills that gap. `workflow_run` always runs in the BASE repo's
+# context using the workflow definition from the default branch — trusted code
+# with full secret access — regardless of whether the triggering run came from
+# a fork. It downloads the artifacts the report job produced and performs the
+# privileged steps. Because it never checks out or executes PR-authored code,
+# exposing secrets here is safe.
+
+on:
+  workflow_run:
+    workflows: ["Benchmark"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # download artifacts from the triggering run
+  pull-requests: write # post the status comment
+
+jobs:
+  publish:
+    name: Publish RTD preview & comment
+    runs-on: ubuntu-latest
+    # Only for PR-triggered Benchmark runs that succeeded. A failed report job
+    # means there's nothing worth publishing (and the merge gate already
+    # surfaces that failure on the PR).
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v6
+
+      # ── Recover the handoff from the triggering run ────────────────────
+      # download-artifact with an explicit run-id reaches into the upstream
+      # run (a different workflow), which the default same-run lookup can't do.
+      - name: Download publish handoff
+        id: dl_meta
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: docs-publish-meta-*
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: handoff/
+          merge-multiple: true
+
+      # No handoff artifact → the report job didn't reach the upload (e.g. a
+      # non-PR dispatch, or a render failure). Nothing to publish; exit clean.
+      - name: Parse handoff
+        id: meta
+        run: |
+          META="handoff/publish-meta.txt"
+          if [[ ! -f "$META" ]]; then
+            echo "No handoff metadata — nothing to publish."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_NUMBER=$(grep -oP '^pr_number=\K.*' "$META" || true)
+          SHOULD_RUN=$(grep -oP '^should_run=\K.*' "$META" || true)
+          # Guard: the PR number originates from fork-controlled workflow
+          # output, so validate it's purely numeric before using it in API
+          # calls / URLs. Anything else → bail rather than act on it.
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Handoff PR number '${PR_NUMBER}' is not numeric — skipping."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "should_run=${SHOULD_RUN}" >> "$GITHUB_OUTPUT"
+          echo "Publishing for PR #${PR_NUMBER} (should_run=${SHOULD_RUN})"
+
+      # ── Trigger RTD PR preview rebuild ─────────────────────────────────
+      # RTD's webhook already built a preview on PR push, but that build ran
+      # before this run rendered the results pages. Trigger a fresh build so
+      # the preview reflects the merged PR+baseline result tree.
+      - name: Trigger RTD PR preview rebuild
+        if: steps.meta.outputs.found == 'true'
+        continue-on-error: true
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+          RTD_PROJECT: ${{ vars.RTD_PROJECT }}
+        run: bash .github/scripts/rtd-trigger.sh "${{ steps.meta.outputs.pr_number }}"
+
+      # ── Resolve RTD preview URL ────────────────────────────────────────
+      - name: Resolve RTD preview URL
+        id: rtd_url
+        if: steps.meta.outputs.found == 'true'
+        continue-on-error: true
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+          RTD_PROJECT: ${{ vars.RTD_PROJECT }}
+        run: bash .github/scripts/rtd-preview-url.sh "${{ steps.meta.outputs.pr_number }}"
+
+      # ── Post PR comment ────────────────────────────────────────────────
+      # Include the status report if the report job shipped one (benchmarks
+      # ran); otherwise the comment is just the preview banner.
+      - name: Post status comment on PR
+        if: steps.meta.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PL_PASTEURBOT_PAT_PUBLIC }}
+          DOCS_PREVIEW_URL: ${{ steps.rtd_url.outputs.preview_url }}
+        run: |
+          REPORT=""
+          if [[ -f handoff/_site-status-report.md ]]; then
+            REPORT="handoff/_site-status-report.md"
+          fi
+          .github/scripts/post-status-comment.sh \
+            "${{ steps.meta.outputs.pr_number }}" \
+            "$REPORT"


### PR DESCRIPTION
This splits *building* docs (e.g. in forks) from *publishing* them. Workflows with `pull_request` trigger don't have access to secrets on forks, so we use PR triggers only for builds, and `workflow_run` to publish.