### PR TITLE
feat(solver): add autoregressive surrogate and solver-loop studies

### DIFF
--- a/mosaic/benchmarks/core/utils.py
+++ b/mosaic/benchmarks/core/utils.py
@@ -142,6 +142,25 @@ def _debug_run(run: dict) -> None:
             training[key] = min(training[key], cap)
     if training:
         training["check_grad"] = False
+    if "curriculum" in training:
+        debug_curriculum = []
+        for stage in list(training["curriculum"])[:2]:
+            debug_curriculum.append(
+                {
+                    **stage,
+                    "unroll": min(int(stage["unroll"]), 2),
+                    "updates": 1,
+                }
+            )
+        training["curriculum"] = debug_curriculum
+        training["unroll"] = max(int(stage["unroll"]) for stage in debug_curriculum)
+        training["max_updates"] = sum(
+            int(stage["updates"]) for stage in debug_curriculum
+        )
+        if "one_step_updates" in training:
+            training["one_step_updates"] = training["max_updates"]
+    if "residual_blocks" in training:
+        training["residual_blocks"] = min(int(training["residual_blocks"]), 1)
     if "model_seeds" in training:
         training["model_seeds"] = list(training["model_seeds"])[:1]
     dataset = run.get("dataset", {})
@@ -199,11 +218,9 @@ def exclusion_lookup(
     # Full path: "<suite>", "<suite>/<exp>", "<suite>/<exp>/<sub>".
     parts: list[str] = [suite]
     if experiment:
-        for p in experiment.split("/"):
-            parts.append(p)
+        parts.extend(experiment.split("/"))
     if sub:
-        for p in sub.split("/"):
-            parts.append(p)
+        parts.extend(sub.split("/"))
     # Try longest prefix first.
     for n in range(len(parts), 0, -1):
         key = "/".join(parts[:n])

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/config.py
@@ -384,6 +384,28 @@ problem.add_experiment(
 )
 
 problem.add_experiment(
+    "optimization/recovery_constant_ic_bfgs",
+    recovery,
+    optimizer="bfgs",
+    _exp_key="recovery_constant_ic_bfgs",
+    plot_description=(
+        "Final IC recovery error per solver from zero-initialised unconstrained"
+        " L-BFGS optimisation."
+    ),
+    ic={"name": "rand_div_free", "seed": 0},
+    physics={"N": 16, "nu": 0.01, "dt": 0.02, "steps": [100]},
+    optim={
+        "ic_init_type": "zeros",
+        "max_iters": 100,
+        "patience": 20,
+        "failure_threshold": 2.0,
+        "snap_interval": 5,
+        "ic_seeds": [0, 1, 2],
+        "record_diagnostics": True,
+    },
+    plot=plot_recovery,
+)
+problem.add_experiment(
     "optimization/recovery_constant_ic_bfgs_proj",
     recovery,
     optimizer="bfgs_proj",

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/exclusions.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/exclusions.py
@@ -30,6 +30,16 @@ OPENFOAM_NON_DIFFERENTIABLE_OPT = Exclusion(
     ExclusionCategory.CATEGORICAL,
     "standard icoFoam is non-differentiable forward-only solver",
 )
+XLB_2D_SURROGATE_FIXED_TASK = Exclusion(
+    ExclusionCategory.CATEGORICAL,
+    "trained only for the fixed N=32, Re=20 2D cylinder-flow drag-optimization "
+    "task; every 3D benchmark cell is out of contract",
+)
+XLB_3D_SURROGATE_FIXED_TASK = Exclusion(
+    ExclusionCategory.CATEGORICAL,
+    "trained only for the fixed N=16, nu=0.01, dt=0.02, 100-step periodic "
+    "3D initial-condition recovery task",
+)
 
 
 def register(problem: Problem) -> None:
@@ -37,3 +47,21 @@ def register(problem: Problem) -> None:
     problem.exclude("cost/vjp_cost", {"openfoam": OPENFOAM_NO_VJP})
     problem.exclude("gradient", {"openfoam": OPENFOAM_NON_DIFFERENTIABLE_GRAD})
     problem.exclude("optimization", {"openfoam": OPENFOAM_NON_DIFFERENTIABLE_OPT})
+
+    # The 2D cylinder surrogate shares this tesseract family but has no valid
+    # 3D benchmark cell.
+    _surrogate_2d_only = {"xlb_surrogate": XLB_2D_SURROGATE_FIXED_TASK}
+    problem.exclude("forward", _surrogate_2d_only)
+    problem.exclude("cost", _surrogate_2d_only)
+    problem.exclude("gradient", _surrogate_2d_only)
+    problem.exclude("optimization", _surrogate_2d_only)
+
+    # The 3D surrogate is admitted only to the exact recovery cell registered
+    # in this suite.  All general forward, cost, and gradient sweeps vary its
+    # fixed resolution, horizon, or physical parameters.
+    _surrogate_3d_only = {
+        "xlb_3d_surrogate": XLB_3D_SURROGATE_FIXED_TASK,
+    }
+    problem.exclude("forward", _surrogate_3d_only)
+    problem.exclude("cost", _surrogate_3d_only)
+    problem.exclude("gradient", _surrogate_3d_only)

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -634,7 +634,11 @@ problem.add_experiment(
                 "checkpoint_rollout_frames": 64,
                 "stable_error_threshold": 1.0,
                 "correlation_threshold": 0.95,
-                "first_interval_error_tolerance": 0.05,
+                # This regime deliberately creates a substantial coarse-grid
+                # mismatch; reference convergence is audited separately at
+                # 128²→256², so a 15% first-interval ceiling remains selective
+                # without rejecting the signal the corrector is meant to learn.
+                "first_interval_error_tolerance": 0.15,
                 "native_long_error_tolerance": 1.0,
             },
         }

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -590,7 +590,7 @@ problem.add_experiment(
                 "amplitude": 0.5,
             },
             "training": {
-                "max_updates": 12000,
+                "max_updates": 11000,
                 "unroll": 32,
                 "curriculum": [
                     {"unroll": 1, "updates": 1000, "lr": 1e-4},
@@ -598,10 +598,10 @@ problem.add_experiment(
                     {"unroll": 4, "updates": 1500, "lr": 1e-4},
                     {"unroll": 8, "updates": 2000, "lr": 1e-4},
                     {"unroll": 16, "updates": 2500, "lr": 5e-5},
-                    {"unroll": 32, "updates": 4000, "lr": 2.5e-5},
+                    {"unroll": 32, "updates": 3000, "lr": 2.5e-5},
                 ],
                 "include_one_step_baseline": True,
-                "one_step_updates": 12000,
+                "one_step_updates": 11000,
                 # The original SOL_n objective supervises every corrected
                 # state; omit the solver-terminal diagnostic used by the
                 # compact VJP audit.

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -552,12 +552,12 @@ problem.add_experiment(
     "optimization/solver_in_loop_curriculum",
     solver_in_loop,
     description=(
-        "Sparse-intervention, delayed-credit correction study separating one-step "
-        "supervision (ONE), recurrent exposure without temporal solver gradients "
-        "(NOG), and full recurrent solver differentiation (WIG). The dominant loss "
-        "is measured only after a learned correction has passed through four native "
-        "solver steps. Two stopped-gradient warm-up intervals precede a "
-        "1→2→4→8→16 look-ahead curriculum."
+        "Sparse-intervention, terminal-credit correction study separating one-step "
+        "supervision (ONE), a zero-gradient recurrent control (NOG), and full "
+        "recurrent solver differentiation (WIG). The training loss is measured only "
+        "after the corrected trajectory reaches the terminal numerical-solver state. "
+        "Two stopped-gradient warm-up intervals precede a 2→4→8→16 look-ahead "
+        "curriculum."
     ),
     plot_description=(
         "Delayed-credit curriculum checkpoints, ONE/NOG/WIG held-out errors, "
@@ -597,20 +597,20 @@ problem.add_experiment(
                 "max_updates": 4000,
                 "unroll": 16,
                 "curriculum": [
-                    {"unroll": 1, "updates": 250, "lr": 1e-4},
                     {"unroll": 2, "updates": 500, "lr": 1e-4},
                     {"unroll": 4, "updates": 750, "lr": 1e-4},
                     {"unroll": 8, "updates": 1000, "lr": 5e-5},
-                    {"unroll": 16, "updates": 1500, "lr": 2.5e-5},
+                    {"unroll": 16, "updates": 1750, "lr": 2.5e-5},
                 ],
                 "include_one_step_baseline": True,
                 "one_step_updates": 4000,
-                # WIG's dominant signal is the error before the next correction,
-                # after the previous action has traversed the solver. A small
-                # local term keeps the identical NOG forward rollout trainable.
-                "loss_mode": "solver_mediated",
+                # The observable objective is defined only after the recurrent
+                # corrected state traverses the terminal solver interval. WIG
+                # receives this credit through the solver; NOG is the exact
+                # zero-initialized native-solver control.
+                "loss_mode": "solver_terminal_mediated",
                 "solver_loss_weight": 1.0,
-                "local_loss_weight": 0.05,
+                "local_loss_weight": 0.0,
                 # Sample states from the learned rollout distribution without
                 # extending an already long differentiated chain.
                 "warmup_intervals": 2,
@@ -625,6 +625,7 @@ problem.add_experiment(
                 "seed": 2026,
                 "model_seeds": [0, 1, 2],
                 "check_grad": True,
+                "check_grad_stages": True,
                 "fd_epsilon": 1e-2,
             },
             "evaluation": {

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -594,16 +594,16 @@ problem.add_experiment(
                 "amplitude": 0.5,
             },
             "training": {
-                "max_updates": 4000,
+                "max_updates": 1000,
                 "unroll": 16,
                 "curriculum": [
-                    {"unroll": 2, "updates": 500, "lr": 1e-4},
-                    {"unroll": 4, "updates": 750, "lr": 1e-4},
-                    {"unroll": 8, "updates": 1000, "lr": 5e-5},
-                    {"unroll": 16, "updates": 1750, "lr": 2.5e-5},
+                    {"unroll": 2, "updates": 100, "lr": 1e-4},
+                    {"unroll": 4, "updates": 180, "lr": 1e-4},
+                    {"unroll": 8, "updates": 270, "lr": 5e-5},
+                    {"unroll": 16, "updates": 450, "lr": 2.5e-5},
                 ],
                 "include_one_step_baseline": True,
-                "one_step_updates": 4000,
+                "one_step_updates": 1000,
                 # The observable objective is defined only after the recurrent
                 # corrected state traverses the terminal solver interval. WIG
                 # receives this credit through the solver; NOG is the exact

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -71,6 +71,7 @@ from .physics import DIAGNOSTICS, make_inputs
 from .plots import (
     plot_drag_opt,
     plot_solver_in_loop,
+    plot_solver_in_loop_curriculum,
     plot_solver_in_loop_reference_sensitivity,
     plot_solver_in_loop_self_reference,
     plot_solver_in_loop_tgv,
@@ -544,6 +545,94 @@ problem.add_experiment(
         }
     ],
     plot=plot_solver_in_loop,
+)
+
+
+problem.add_experiment(
+    "optimization/solver_in_loop_curriculum",
+    solver_in_loop,
+    description=(
+        "Paper-aligned autoregressive correction study separating one-step "
+        "supervision (ONE), recurrent exposure without temporal solver gradients "
+        "(NOG), and full recurrent solver differentiation (WIG). The corrector is "
+        "trained with a 1→2→4→8→16→32 look-ahead curriculum and evaluated in a "
+        "300-interval free rollout."
+    ),
+    plot_description=(
+        "Curriculum checkpoints, ONE/NOG/WIG held-out errors, long-horizon "
+        "correlation and physics, final full fields, and autoregressive GIFs."
+    ),
+    runs=[
+        {
+            "ic": {"name": "multimode", "seed": 0},
+            "physics": {
+                "N": 32,
+                "nu": 0.001,
+                "dt": 0.02,
+                # Match the paper's hybrid-step semantics: the neural
+                # corrector intervenes after every native solver step.
+                "steps": 1,
+            },
+            "dataset": {
+                "reference_kind": "pseudo_spectral_multimode",
+                "reference_factor": 4,
+                "reference_substeps": 4,
+                "reference_audit_factor": 8,
+                "reference_audit_substeps": 8,
+                "reference_audit_seeds": [0, 100],
+                "reference_audit_frames": [1, 32, 96, 300],
+                "reference_convergence_tolerance": 0.005,
+                "train_seeds": list(range(32)),
+                "test_seeds": list(range(100, 108)),
+                "train_frames": 96,
+                "k0": 2.0,
+                "sigma_k": 0.5,
+                "amplitude": 0.5,
+            },
+            "training": {
+                "max_updates": 12000,
+                "unroll": 32,
+                "curriculum": [
+                    {"unroll": 1, "updates": 1000, "lr": 1e-4},
+                    {"unroll": 2, "updates": 1000, "lr": 1e-4},
+                    {"unroll": 4, "updates": 1500, "lr": 1e-4},
+                    {"unroll": 8, "updates": 2000, "lr": 1e-4},
+                    {"unroll": 16, "updates": 2500, "lr": 5e-5},
+                    {"unroll": 32, "updates": 4000, "lr": 2.5e-5},
+                ],
+                "include_one_step_baseline": True,
+                "one_step_updates": 12000,
+                # The original SOL_n objective supervises every corrected
+                # state; omit the solver-terminal diagnostic used by the
+                # compact VJP audit.
+                "loss_mode": "mean",
+                "solver_loss_weight": 0.0,
+                "loss_normalization": "solver_baseline",
+                "loss_scale_floor": 1e-6,
+                "lr": 1e-4,
+                "clip_norm": 5.0,
+                "architecture": "periodic_resnet",
+                "hidden_channels": 32,
+                "kernel_size": 5,
+                "residual_blocks": 5,
+                "seed": 2026,
+                "model_seeds": [0, 1, 2],
+                "check_grad": True,
+                "fd_epsilon": 1e-2,
+            },
+            "evaluation": {
+                "rollout_frames": 300,
+                "seen_ic_trajectories": 8,
+                "checkpoint_ic_trajectories": 2,
+                "checkpoint_rollout_frames": 100,
+                "stable_error_threshold": 1.0,
+                "correlation_threshold": 0.95,
+                "first_interval_error_tolerance": 0.05,
+                "native_long_error_tolerance": 1.0,
+            },
+        }
+    ],
+    plot=plot_solver_in_loop_curriculum,
 )
 
 

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -552,15 +552,17 @@ problem.add_experiment(
     "optimization/solver_in_loop_curriculum",
     solver_in_loop,
     description=(
-        "Paper-aligned autoregressive correction study separating one-step "
+        "Sparse-intervention, delayed-credit correction study separating one-step "
         "supervision (ONE), recurrent exposure without temporal solver gradients "
-        "(NOG), and full recurrent solver differentiation (WIG). The corrector is "
-        "trained with a 1→2→4→8→16→32 look-ahead curriculum and evaluated in a "
-        "300-interval free rollout."
+        "(NOG), and full recurrent solver differentiation (WIG). The dominant loss "
+        "is measured only after a learned correction has passed through four native "
+        "solver steps. Two stopped-gradient warm-up intervals precede a "
+        "1→2→4→8→16 look-ahead curriculum."
     ),
     plot_description=(
-        "Curriculum checkpoints, ONE/NOG/WIG held-out errors, long-horizon "
-        "correlation and physics, final full fields, and autoregressive GIFs."
+        "Delayed-credit curriculum checkpoints, ONE/NOG/WIG held-out errors, "
+        "long-horizon correlation and physics, final full fields, and "
+        "autoregressive GIFs."
     ),
     runs=[
         {
@@ -569,9 +571,9 @@ problem.add_experiment(
                 "N": 32,
                 "nu": 0.001,
                 "dt": 0.02,
-                # Match the paper's hybrid-step semantics: the neural
-                # corrector intervenes after every native solver step.
-                "steps": 1,
+                # Sparse intervention forces each learned correction to survive
+                # several native updates before the next corrective action.
+                "steps": 4,
             },
             "dataset": {
                 "reference_kind": "pseudo_spectral_multimode",
@@ -580,33 +582,38 @@ problem.add_experiment(
                 "reference_audit_factor": 8,
                 "reference_audit_substeps": 8,
                 "reference_audit_seeds": [0, 100],
-                "reference_audit_frames": [1, 32, 96, 300],
+                "reference_audit_frames": [1, 16, 64, 120],
                 "reference_convergence_tolerance": 0.005,
                 "train_seeds": list(range(32)),
                 "test_seeds": list(range(100, 108)),
-                "train_frames": 96,
-                "k0": 2.0,
-                "sigma_k": 0.5,
+                "train_frames": 64,
+                # Put appreciable energy near the coarse grid's under-resolved
+                # range so the numerical prior and its downstream response matter.
+                "k0": 4.0,
+                "sigma_k": 0.75,
                 "amplitude": 0.5,
             },
             "training": {
-                "max_updates": 11000,
-                "unroll": 32,
+                "max_updates": 4000,
+                "unroll": 16,
                 "curriculum": [
-                    {"unroll": 1, "updates": 1000, "lr": 1e-4},
-                    {"unroll": 2, "updates": 1000, "lr": 1e-4},
-                    {"unroll": 4, "updates": 1500, "lr": 1e-4},
-                    {"unroll": 8, "updates": 2000, "lr": 1e-4},
-                    {"unroll": 16, "updates": 2500, "lr": 5e-5},
-                    {"unroll": 32, "updates": 3000, "lr": 2.5e-5},
+                    {"unroll": 1, "updates": 250, "lr": 1e-4},
+                    {"unroll": 2, "updates": 500, "lr": 1e-4},
+                    {"unroll": 4, "updates": 750, "lr": 1e-4},
+                    {"unroll": 8, "updates": 1000, "lr": 5e-5},
+                    {"unroll": 16, "updates": 1500, "lr": 2.5e-5},
                 ],
                 "include_one_step_baseline": True,
-                "one_step_updates": 11000,
-                # The original SOL_n objective supervises every corrected
-                # state; omit the solver-terminal diagnostic used by the
-                # compact VJP audit.
-                "loss_mode": "mean",
-                "solver_loss_weight": 0.0,
+                "one_step_updates": 4000,
+                # WIG's dominant signal is the error before the next correction,
+                # after the previous action has traversed the solver. A small
+                # local term keeps the identical NOG forward rollout trainable.
+                "loss_mode": "solver_mediated",
+                "solver_loss_weight": 1.0,
+                "local_loss_weight": 0.05,
+                # Sample states from the learned rollout distribution without
+                # extending an already long differentiated chain.
+                "warmup_intervals": 2,
                 "loss_normalization": "solver_baseline",
                 "loss_scale_floor": 1e-6,
                 "lr": 1e-4,
@@ -621,10 +628,10 @@ problem.add_experiment(
                 "fd_epsilon": 1e-2,
             },
             "evaluation": {
-                "rollout_frames": 300,
+                "rollout_frames": 120,
                 "seen_ic_trajectories": 8,
                 "checkpoint_ic_trajectories": 2,
-                "checkpoint_rollout_frames": 100,
+                "checkpoint_rollout_frames": 64,
                 "stable_error_threshold": 1.0,
                 "correlation_threshold": 0.95,
                 "first_interval_error_tolerance": 0.05,

--- a/mosaic/benchmarks/problems/navier_stokes_grid/corrector.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/corrector.py
@@ -83,30 +83,120 @@ class PeriodicResidualCNN(eqx.Module):
         return self.layers[-1](x)
 
 
+class PeriodicResNetCorrector(eqx.Module):
+    """Paper-scale periodic residual corrector with two convolutions per block."""
+
+    stem: eqx.nn.Conv2d
+    blocks: tuple[tuple[eqx.nn.Conv2d, eqx.nn.Conv2d], ...]
+    head: eqx.nn.Conv2d
+    architecture: str = eqx.field(static=True)
+    hidden_channels: int = eqx.field(static=True)
+    kernel_size: int = eqx.field(static=True)
+    residual_blocks: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        key: jax.Array,
+        *,
+        hidden_channels: int,
+        kernel_size: int,
+        residual_blocks: int,
+    ) -> None:
+        if kernel_size % 2 != 1:
+            raise ValueError("kernel_size must be odd")
+        if residual_blocks < 1:
+            raise ValueError("residual_blocks must be positive")
+        keys = iter(jax.random.split(key, 2 * residual_blocks + 2))
+
+        def conv(cin: int, cout: int, layer_key: jax.Array) -> eqx.nn.Conv2d:
+            layer = eqx.nn.Conv2d(
+                cin,
+                cout,
+                kernel_size,
+                padding=kernel_size // 2,
+                padding_mode="CIRCULAR",
+                key=layer_key,
+            )
+            fan_in = kernel_size * kernel_size * cin
+            weight = jax.random.normal(
+                layer_key, layer.weight.shape, dtype=jnp.float32
+            ) * np.sqrt(2.0 / fan_in)
+            return eqx.tree_at(
+                lambda value: (value.weight, value.bias),
+                layer,
+                (weight, jnp.zeros((cout, 1, 1), dtype=jnp.float32)),
+            )
+
+        self.stem = conv(2, hidden_channels, next(keys))
+        self.blocks = tuple(
+            (
+                conv(hidden_channels, hidden_channels, next(keys)),
+                conv(hidden_channels, hidden_channels, next(keys)),
+            )
+            for _ in range(residual_blocks)
+        )
+        head_key = next(keys)
+        head = eqx.nn.Conv2d(
+            hidden_channels,
+            2,
+            kernel_size,
+            padding=kernel_size // 2,
+            padding_mode="CIRCULAR",
+            key=head_key,
+        )
+        self.head = eqx.tree_at(
+            lambda value: (value.weight, value.bias),
+            head,
+            (
+                jnp.zeros_like(head.weight),
+                jnp.zeros((2, 1, 1), dtype=jnp.float32),
+            ),
+        )
+        self.architecture = "periodic_resnet"
+        self.hidden_channels = hidden_channels
+        self.kernel_size = kernel_size
+        self.residual_blocks = residual_blocks
+
+    def __call__(self, velocity: jax.Array) -> jax.Array:
+        """Map a channel-first velocity field to an additive correction."""
+        x = jax.nn.gelu(self.stem(velocity))
+        for first, second in self.blocks:
+            x = jax.nn.gelu(x + second(jax.nn.gelu(first(x))))
+        return self.head(x)
+
+
 def init_corrector(
     key: jax.Array,
     *,
     hidden_channels: int = 32,
     kernel_size: int = 5,
     architecture: str = "periodic_residual_cnn",
-) -> PeriodicResidualCNN:
+    residual_blocks: int = 5,
+) -> PeriodicResidualCNN | PeriodicResNetCorrector:
     """Initialise the benchmark-owned Equinox corrector.
 
     The final layer starts at zero, so the initial corrected rollout is exactly
     the underlying solver. The first update trains the readout; subsequent
     updates propagate through the feature layers.
     """
-    if architecture != "periodic_residual_cnn":
-        raise ValueError(f"unknown corrector architecture: {architecture!r}")
-    return PeriodicResidualCNN(
-        key,
-        hidden_channels=hidden_channels,
-        kernel_size=kernel_size,
-    )
+    if architecture == "periodic_residual_cnn":
+        return PeriodicResidualCNN(
+            key,
+            hidden_channels=hidden_channels,
+            kernel_size=kernel_size,
+        )
+    if architecture == "periodic_resnet":
+        return PeriodicResNetCorrector(
+            key,
+            hidden_channels=hidden_channels,
+            kernel_size=kernel_size,
+            residual_blocks=residual_blocks,
+        )
+    raise ValueError(f"unknown corrector architecture: {architecture!r}")
 
 
 def apply_corrector(
-    model: PeriodicResidualCNN,
+    model: PeriodicResidualCNN | PeriodicResNetCorrector,
     velocity: jax.Array,
     *,
     velocity_scale: float | jax.Array,
@@ -156,7 +246,7 @@ def project_periodic_correction(delta: jax.Array, domain_extent: float) -> jax.A
 
 
 def corrected_velocity(
-    model: PeriodicResidualCNN,
+    model: PeriodicResidualCNN | PeriodicResNetCorrector,
     provisional: jax.Array,
     *,
     velocity_scale: float | jax.Array,
@@ -557,6 +647,7 @@ def finite_volume_reference_trajectory(
 
 
 __all__ = [
+    "PeriodicResNetCorrector",
     "PeriodicResidualCNN",
     "apply_corrector",
     "centered_divergence_rms",

--- a/mosaic/benchmarks/problems/navier_stokes_grid/exclusions.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/exclusions.py
@@ -82,6 +82,12 @@ XLB_TGV_LBM_FLOOR = Exclusion(
     "remaining floor is O(dx²) LBM spatial discretization at N=64, not reducible "
     "by further sub-stepping (tested k=9..27); valid=True",
 )
+XLB_3D_SURROGATE_FIXED_TASK = Exclusion(
+    ExclusionCategory.CATEGORICAL,
+    "trained only for the fixed N=16, nu=0.01, dt=0.02, 100-step periodic "
+    "3D initial-condition recovery task; this 2D benchmark is out of contract",
+)
+
 _OBSTACLE_GATE = {
     "jax_cfd": JAX_CFD_NO_OBSTACLE,
     "ins_jl": INS_JL_NO_OBSTACLE,
@@ -117,3 +123,12 @@ def register(problem: Problem) -> None:
     problem.exclude("optimization", {"openfoam": OPENFOAM_NON_DIFFERENTIABLE_OPT})
     problem.exclude("optimization/drag_opt", _OBSTACLE_GATE)
     problem.exclude("optimization/drag_opt_bfgs", _OBSTACLE_GATE)
+    # The 3D recovery surrogate shares this tesseract family but has no valid
+    # 2D benchmark cell.
+    _surrogate_3d_only = {
+        "xlb_3d_surrogate": XLB_3D_SURROGATE_FIXED_TASK,
+    }
+    problem.exclude("forward", _surrogate_3d_only)
+    problem.exclude("cost", _surrogate_3d_only)
+    problem.exclude("gradient", _surrogate_3d_only)
+    problem.exclude("optimization", _surrogate_3d_only)

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -2059,36 +2059,36 @@ def _plot_solver_in_loop_curriculum_summary(
         full = np.asarray(
             arrays.get(f"curriculum_checkpoint_error_full_{index}", np.array([]))
         )
-        native = np.asarray(
-            arrays.get(f"curriculum_checkpoint_error_native_{index}", np.array([]))
+        stopped = np.asarray(
+            arrays.get(f"curriculum_checkpoint_error_nog_{index}", np.array([]))
         )
-        if not unrolls.size or full.ndim != 2 or native.size < 2:
+        if (
+            not unrolls.size
+            or full.ndim != 2
+            or stopped.shape != full.shape
+            or full.shape[1] < 2
+        ):
             continue
-        reductions = [
+        vjp_lifts = [
             np.exp(
-                np.mean(
-                    np.log(
-                        (native[1 : stage_error.size] + 1e-12)
-                        / (stage_error[1:] + 1e-12)
-                    )
-                )
+                np.mean(np.log((stopped_stage[1:] + 1e-12) / (full_stage[1:] + 1e-12)))
             )
-            for stage_error in full
+            for full_stage, stopped_stage in zip(full, stopped, strict=True)
         ]
         _label, color, _linestyle, marker = solver_props(name)
         ax_horizon.plot(
             unrolls,
-            reductions,
+            vjp_lifts,
             color=color,
             marker=marker,
             label=_label,
         )
     ax_horizon.axhline(1.0, color="0.45", linestyle=":", linewidth=1.0)
     ax_horizon.set_xscale("log", base=2)
-    ax_horizon.set_xticks([1, 2, 4, 8, 16, 32], [1, 2, 4, 8, 16, 32])
-    ax_horizon.set_xlabel("Curriculum look-ahead")
-    ax_horizon.set_ylabel("WIG error reduction [×]")
-    ax_horizon.set_title("Checkpoint quality versus horizon")
+    ax_horizon.set_xticks([1, 2, 4, 8, 16], [1, 2, 4, 8, 16])
+    ax_horizon.set_xlabel("Differentiated correction intervals")
+    ax_horizon.set_ylabel("WIG / NOG rollout lift [×]")
+    ax_horizon.set_title("Solver-mediated credit versus horizon")
 
     one_cost = [metric(name, "one_step_training_wall_time_s") for _index, name in rows]
     nog_cost = [
@@ -2124,7 +2124,7 @@ def _plot_solver_in_loop_curriculum_summary(
     ax_cost.legend(fontsize=6.5)
 
     _solver_loop_legend(fig, [name for _index, name in rows])
-    fig.suptitle("ONE/NOG/WIG decomposition and curriculum")
+    fig.suptitle("Sparse delayed-credit solver-in-loop curriculum")
     if save:
         save_fig(fig, "solver_in_loop_curriculum_summary", out_dir)
     return fig

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -1700,6 +1700,662 @@ def _save_solver_in_loop_animation(
     _save_animation(animation, "solver_in_loop_trajectory", out_dir, fps=6)
 
 
+def plot_solver_in_loop_curriculum(
+    cfg: Problem,
+    *,
+    save: bool = True,
+    suffix: str = "",
+    **kwargs: Any,
+) -> list:
+    """Plot the paper-aligned ONE/NOG/WIG curriculum and long rollout."""
+    figs = plot_solver_in_loop(
+        cfg,
+        save=save,
+        suffix=suffix,
+        exp_key="solver_in_loop_curriculum",
+        title="Autoregressive corrector curriculum",
+        **kwargs,
+    )
+    out_dir = experiment_dir(
+        results_dir(),
+        cfg.name,
+        "optimization",
+        f"solver_in_loop_curriculum{suffix}",
+    )
+    result_path = out_dir / "result.json"
+    fields_path = out_dir / "corrector_fields.npz"
+    if not result_path.exists() or not fields_path.exists():
+        return figs
+    data = v1_to_legacy(load_json(result_path))
+    arrays = try_load_npz(fields_path)
+    names = [str(value) for value in arrays.get("solver_names", np.array([])).tolist()]
+    if not names:
+        return figs
+
+    for figure in (
+        _plot_solver_in_loop_curriculum_rollouts(arrays, names, out_dir, save=save),
+        _plot_solver_in_loop_curriculum_correlations(
+            arrays,
+            names,
+            out_dir,
+            save=save,
+        ),
+        _plot_solver_in_loop_curriculum_summary(
+            data,
+            arrays,
+            names,
+            out_dir,
+            save=save,
+        ),
+        _plot_solver_in_loop_curriculum_fields(arrays, names, out_dir, save=save),
+        _plot_solver_in_loop_curriculum_spectra(arrays, names, out_dir, save=save),
+    ):
+        if figure is not None:
+            figs.append(figure)
+    if save:
+        _save_solver_in_loop_curriculum_animation(arrays, names, out_dir)
+    return figs
+
+
+def _curriculum_rows(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+) -> list[tuple[int, str]]:
+    """Return curriculum-capable cells in canonical solver order."""
+    rows = [
+        (index, name)
+        for index, name in enumerate(names)
+        if np.asarray(arrays.get(f"error_one_step_{index}", np.array([]))).size
+    ]
+    solver_order = {alias: index for index, alias in enumerate(NS_ORDER)}
+    rows.sort(
+        key=lambda row: solver_order.get(
+            resolve_solver_alias(row[1]) or row[1],
+            len(solver_order),
+        )
+    )
+    return rows
+
+
+def _plot_solver_in_loop_curriculum_rollouts(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Show long free-rollout error for ONE, NOG, WIG, and solver only."""
+    rows = _curriculum_rows(arrays, names)
+    if not rows:
+        return None
+    plt.rcParams.update(RCPARAMS)
+    ncols = 3
+    nrows = int(np.ceil(len(rows) / ncols))
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, 1.85 * nrows),
+        squeeze=False,
+        layout="constrained",
+    )
+    times = np.asarray(arrays.get("evaluation_times", np.array([])))
+    semantics = (
+        ("error_uncorrected", "Solver only", ":", "0.45"),
+        ("error_one_step", "ONE", "-.", "#D95F02"),
+        ("error_stop_gradient", "NOG", "--", "#7570B3"),
+        ("error_corrected", "WIG", "-", "#1B9E77"),
+    )
+    for axis, (index, name) in zip(axes.ravel(), rows, strict=False):
+        for prefix, label, linestyle, color in semantics:
+            values = np.asarray(arrays.get(f"{prefix}_{index}", np.array([])))
+            if values.size < 2:
+                continue
+            x = times[: values.size] if times.size else np.arange(values.size)
+            axis.plot(
+                x[1:],
+                np.maximum(values[1:], 1e-12),
+                label=label,
+                linestyle=linestyle,
+                color=color,
+            )
+        axis.set_yscale("log")
+        axis.set_xlabel("Physical time")
+        axis.set_ylabel("Relative $L^2$ error")
+        axis.set_title(solver_props(name)[0])
+    for axis in axes.ravel()[len(rows) :]:
+        axis.axis("off")
+    axes.ravel()[0].legend(loc="best", fontsize=6.5)
+    fig.suptitle("Fully autoregressive held-out rollouts")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_rollouts", out_dir)
+    return fig
+
+
+def _plot_solver_in_loop_curriculum_correlations(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Show long-horizon field correlation for all training protocols."""
+    rows = _curriculum_rows(arrays, names)
+    if not rows:
+        return None
+    plt.rcParams.update(RCPARAMS)
+    ncols = 3
+    nrows = int(np.ceil(len(rows) / ncols))
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, 1.85 * nrows),
+        squeeze=False,
+        layout="constrained",
+    )
+    times = np.asarray(arrays.get("evaluation_times", np.array([])))
+    semantics = (
+        ("correlation_uncorrected", "Solver only", ":", "0.45"),
+        ("correlation_one_step", "ONE", "-.", "#D95F02"),
+        ("correlation_stop_gradient", "NOG", "--", "#7570B3"),
+        ("correlation_corrected", "WIG", "-", "#1B9E77"),
+    )
+    for axis, (index, name) in zip(axes.ravel(), rows, strict=False):
+        for prefix, label, linestyle, color in semantics:
+            values = np.asarray(arrays.get(f"{prefix}_{index}", np.array([])))
+            if values.size < 2:
+                continue
+            x = times[: values.size] if times.size else np.arange(values.size)
+            axis.plot(
+                x,
+                values,
+                label=label,
+                linestyle=linestyle,
+                color=color,
+            )
+        axis.axhline(0.95, color="0.6", linestyle=":", linewidth=0.8)
+        axis.set_ylim(-0.05, 1.02)
+        axis.set_xlabel("Physical time")
+        axis.set_ylabel("Field correlation")
+        axis.set_title(solver_props(name)[0])
+    for axis in axes.ravel()[len(rows) :]:
+        axis.axis("off")
+    axes.ravel()[0].legend(loc="best", fontsize=6.5)
+    fig.suptitle("Held-out correlation decay (threshold 0.95)")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_correlations", out_dir)
+    return fig
+
+
+def _plot_solver_in_loop_curriculum_summary(
+    data: dict[str, Any],
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Decompose recurrent exposure, temporal gradients, horizon, and cost."""
+    rows = _curriculum_rows(arrays, names)
+    if not rows:
+        return None
+    by_solver = data.get("by_solver", {})
+    labels = [solver_props(name)[0] for _index, name in rows]
+    colors = [solver_props(name)[1] for _index, name in rows]
+    positions = np.arange(len(rows), dtype=float)
+    width = 0.24
+
+    def metric(name: str, key: str) -> float:
+        value = by_solver.get(name, {}).get(key)
+        return float(value) if value is not None else np.nan
+
+    one_gain = [
+        metric(name, "one_step_geometric_error_reduction") for _index, name in rows
+    ]
+    nog_gain = [
+        metric(name, "stop_gradient_geometric_error_reduction") for _index, name in rows
+    ]
+    wig_gain = [metric(name, "geometric_error_reduction") for _index, name in rows]
+    unrolling_lift = [
+        100.0 * (metric(name, "unrolling_geometric_lift_nog_over_one") - 1.0)
+        for _index, name in rows
+    ]
+    vjp_lift = [
+        100.0 * (metric(name, "solver_vjp_geometric_lift") - 1.0)
+        for _index, name in rows
+    ]
+
+    plt.rcParams.update(RCPARAMS)
+    fig, axes = plt.subplots(
+        2,
+        2,
+        figsize=(TEXTWIDTH, 4.6),
+        squeeze=False,
+        layout="constrained",
+    )
+    ax_gain, ax_decomposition, ax_horizon, ax_cost = axes.ravel()
+    for offset, values, label, alpha in (
+        (-width, one_gain, "ONE", 0.35),
+        (0.0, nog_gain, "NOG", 0.65),
+        (width, wig_gain, "WIG", 0.95),
+    ):
+        ax_gain.bar(
+            positions + offset,
+            values,
+            width,
+            color=colors,
+            alpha=alpha,
+            label=label,
+        )
+    ax_gain.axhline(1.0, color="0.45", linestyle=":", linewidth=1.0)
+    ax_gain.set_xticks(positions, labels, rotation=35, ha="right")
+    ax_gain.set_ylabel("Geometric error reduction [×]")
+    ax_gain.set_title("Absolute correctability")
+    ax_gain.legend(fontsize=6.5)
+
+    ax_decomposition.bar(
+        positions - width / 2,
+        unrolling_lift,
+        width,
+        color=colors,
+        alpha=0.45,
+        label="NOG / ONE",
+    )
+    ax_decomposition.bar(
+        positions + width / 2,
+        vjp_lift,
+        width,
+        color=colors,
+        alpha=0.95,
+        label="WIG / NOG",
+    )
+    ax_decomposition.axhline(0.0, color="0.45", linestyle=":", linewidth=1.0)
+    ax_decomposition.set_xticks(positions, labels, rotation=35, ha="right")
+    ax_decomposition.set_ylabel("Incremental rollout lift [%]")
+    ax_decomposition.set_title("Exposure versus temporal credit")
+    ax_decomposition.legend(fontsize=6.5)
+
+    for index, name in rows:
+        unrolls = np.asarray(
+            arrays.get(f"curriculum_stage_unrolls_{index}", np.array([]))
+        )
+        full = np.asarray(
+            arrays.get(f"curriculum_checkpoint_error_full_{index}", np.array([]))
+        )
+        native = np.asarray(
+            arrays.get(f"curriculum_checkpoint_error_native_{index}", np.array([]))
+        )
+        if not unrolls.size or full.ndim != 2 or native.size < 2:
+            continue
+        reductions = [
+            np.exp(
+                np.mean(
+                    np.log(
+                        (native[1 : stage_error.size] + 1e-12)
+                        / (stage_error[1:] + 1e-12)
+                    )
+                )
+            )
+            for stage_error in full
+        ]
+        _label, color, _linestyle, marker = solver_props(name)
+        ax_horizon.plot(
+            unrolls,
+            reductions,
+            color=color,
+            marker=marker,
+            label=_label,
+        )
+    ax_horizon.axhline(1.0, color="0.45", linestyle=":", linewidth=1.0)
+    ax_horizon.set_xscale("log", base=2)
+    ax_horizon.set_xticks([1, 2, 4, 8, 16, 32], [1, 2, 4, 8, 16, 32])
+    ax_horizon.set_xlabel("Curriculum look-ahead")
+    ax_horizon.set_ylabel("WIG error reduction [×]")
+    ax_horizon.set_title("Checkpoint quality versus horizon")
+
+    one_cost = [metric(name, "one_step_training_wall_time_s") for _index, name in rows]
+    nog_cost = [
+        metric(name, "stop_gradient_training_wall_time_s") for _index, name in rows
+    ]
+    wig_cost = [metric(name, "training_wall_time_s") for _index, name in rows]
+    ax_cost.bar(
+        positions,
+        one_cost,
+        color=colors,
+        alpha=0.35,
+        label="ONE",
+    )
+    ax_cost.bar(
+        positions,
+        nog_cost,
+        bottom=one_cost,
+        color=colors,
+        alpha=0.65,
+        label="NOG",
+    )
+    ax_cost.bar(
+        positions,
+        wig_cost,
+        bottom=np.asarray(one_cost) + np.asarray(nog_cost),
+        color=colors,
+        alpha=0.95,
+        label="WIG",
+    )
+    ax_cost.set_xticks(positions, labels, rotation=35, ha="right")
+    ax_cost.set_ylabel("Training wall time [s]")
+    ax_cost.set_title("Measured training cost")
+    ax_cost.legend(fontsize=6.5)
+
+    _solver_loop_legend(fig, [name for _index, name in rows])
+    fig.suptitle("ONE/NOG/WIG decomposition and curriculum")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_summary", out_dir)
+    return fig
+
+
+def _curriculum_rollouts(
+    arrays: dict[str, np.ndarray],
+    solver_index: int,
+) -> tuple[np.ndarray, ...] | None:
+    """Return reference, native, ONE, NOG, and WIG rollouts for one cell."""
+    values = (
+        _solver_reference_rollout(arrays, solver_index),
+        np.asarray(arrays.get(f"rollout_uncorrected_{solver_index}", np.array([]))),
+        np.asarray(arrays.get(f"rollout_one_step_{solver_index}", np.array([]))),
+        np.asarray(arrays.get(f"rollout_stop_gradient_{solver_index}", np.array([]))),
+        np.asarray(arrays.get(f"rollout_corrected_{solver_index}", np.array([]))),
+    )
+    return values if all(value.size for value in values) else None
+
+
+def _plot_solver_in_loop_curriculum_fields(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Render final reference, solver, ONE, NOG, and WIG vorticity fields."""
+    rows = [
+        (index, name, rollouts)
+        for index, name in _curriculum_rows(arrays, names)
+        if (rollouts := _curriculum_rollouts(arrays, index)) is not None
+    ]
+    if not rows:
+        return None
+    fields = [
+        [_periodic_vorticity_2d(trajectory[-1]) for trajectory in rollouts]
+        for _index, _name, rollouts in rows
+    ]
+    vmax = (
+        float(
+            np.percentile(
+                np.abs(
+                    np.concatenate([field.ravel() for row in fields for field in row])
+                ),
+                99.0,
+            )
+        )
+        or 1.0
+    )
+    plt.rcParams.update(RCPARAMS)
+    fig, axes = plt.subplots(
+        len(rows),
+        5,
+        figsize=(TEXTWIDTH, max(2.0, 0.8 * len(rows))),
+        squeeze=False,
+        layout="constrained",
+    )
+    image = None
+    for row_index, ((_solver_index, name, _rollouts), row_fields) in enumerate(
+        zip(rows, fields, strict=True)
+    ):
+        for column, field in enumerate(row_fields):
+            image = axes[row_index, column].imshow(
+                field.T,
+                origin="lower",
+                cmap="RdBu_r",
+                vmin=-vmax,
+                vmax=vmax,
+                interpolation="nearest",
+            )
+            axes[row_index, column].set_xticks([])
+            axes[row_index, column].set_yticks([])
+        axes[row_index, 0].set_ylabel(
+            solver_props(name)[0],
+            rotation=0,
+            ha="right",
+            va="center",
+            labelpad=8,
+        )
+    for axis, title in zip(
+        axes[0],
+        ("Reference", "Solver", "ONE", "NOG", "WIG"),
+        strict=True,
+    ):
+        axis.set_title(title)
+    if image is not None:
+        colorbar = fig.colorbar(
+            image,
+            ax=axes.ravel().tolist(),
+            location="right",
+            shrink=0.82,
+            pad=0.02,
+        )
+        colorbar.set_label(r"Vorticity $\omega$")
+    fig.suptitle("Final fully autoregressive held-out fields")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_fields", out_dir)
+    return fig
+
+
+def _isotropic_energy_spectrum(velocity: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return shell-summed kinetic-energy spectrum on a periodic square."""
+    ux, uy = _vel_components_2d(np.asarray(velocity))
+    n = ux.shape[0]
+    ux_hat = np.fft.fft2(ux) / (n * n)
+    uy_hat = np.fft.fft2(uy) / (n * n)
+    energy = 0.5 * (np.abs(ux_hat) ** 2 + np.abs(uy_hat) ** 2)
+    wave = np.fft.fftfreq(n) * n
+    kx, ky = np.meshgrid(wave, wave, indexing="ij")
+    shells = np.rint(np.sqrt(kx**2 + ky**2)).astype(int)
+    shell_energy = np.bincount(
+        shells.ravel(),
+        weights=energy.ravel(),
+        minlength=n // 2 + 1,
+    )[: n // 2 + 1]
+    wavenumbers = np.arange(shell_energy.size)
+    return wavenumbers[1:], shell_energy[1:]
+
+
+def _plot_solver_in_loop_curriculum_spectra(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Compare final energy spectra for every autoregressive training mode."""
+    rows = [
+        (index, name, rollouts)
+        for index, name in _curriculum_rows(arrays, names)
+        if (rollouts := _curriculum_rollouts(arrays, index)) is not None
+    ]
+    if not rows:
+        return None
+    plt.rcParams.update(RCPARAMS)
+    ncols = 3
+    nrows = int(np.ceil(len(rows) / ncols))
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, 1.85 * nrows),
+        squeeze=False,
+        layout="constrained",
+    )
+    semantics = (
+        ("Reference", "--", "0.2"),
+        ("Solver", ":", "0.45"),
+        ("ONE", "-.", "#D95F02"),
+        ("NOG", "--", "#7570B3"),
+        ("WIG", "-", "#1B9E77"),
+    )
+    for axis, (_index, name, rollouts) in zip(
+        axes.ravel(),
+        rows,
+        strict=False,
+    ):
+        for trajectory, (label, linestyle, color) in zip(
+            rollouts,
+            semantics,
+            strict=True,
+        ):
+            wavenumber, spectrum = _isotropic_energy_spectrum(trajectory[-1])
+            axis.loglog(
+                wavenumber,
+                np.maximum(spectrum, 1e-16),
+                label=label,
+                linestyle=linestyle,
+                color=color,
+            )
+        axis.set_xlabel("Wavenumber $k$")
+        axis.set_ylabel("$E(k)$")
+        axis.set_title(solver_props(name)[0])
+    for axis in axes.ravel()[len(rows) :]:
+        axis.axis("off")
+    axes.ravel()[0].legend(loc="best", fontsize=6.0)
+    fig.suptitle("Final held-out kinetic-energy spectra")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_spectra", out_dir)
+    return fig
+
+
+def _save_solver_in_loop_curriculum_animation(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+) -> None:
+    """Animate reference, native, ONE, NOG, and WIG held-out trajectories."""
+    rows = [
+        (index, name, rollouts)
+        for index, name in _curriculum_rows(arrays, names)
+        if (rollouts := _curriculum_rollouts(arrays, index)) is not None
+    ]
+    if not rows:
+        return
+    available_frames = min(
+        trajectory.shape[0]
+        for _index, _name, rollouts in rows
+        for trajectory in rollouts
+    )
+    frame_indices = np.unique(
+        np.linspace(
+            0,
+            available_frames - 1,
+            num=min(available_frames, 24),
+            dtype=int,
+        )
+    )
+    vorticity = [
+        [
+            [_periodic_vorticity_2d(trajectory[frame]) for frame in frame_indices]
+            for trajectory in rollouts
+        ]
+        for _index, _name, rollouts in rows
+    ]
+    vmax = (
+        float(
+            np.percentile(
+                np.abs(
+                    np.concatenate(
+                        [
+                            field.ravel()
+                            for row in vorticity
+                            for mode in row
+                            for field in mode
+                        ]
+                    )
+                ),
+                99.0,
+            )
+        )
+        or 1.0
+    )
+    plt.rcParams.update(RCPARAMS)
+    fig, axes = plt.subplots(
+        len(rows),
+        5,
+        figsize=(TEXTWIDTH, max(2.0, 0.8 * len(rows))),
+        dpi=100,
+        squeeze=False,
+        layout="constrained",
+    )
+    images: list[tuple[Any, int, int]] = []
+    for row_index, (_solver_index, name, _rollouts) in enumerate(rows):
+        for column in range(5):
+            image = axes[row_index, column].imshow(
+                vorticity[row_index][column][0].T,
+                origin="lower",
+                cmap="RdBu_r",
+                vmin=-vmax,
+                vmax=vmax,
+                interpolation="nearest",
+                animated=True,
+            )
+            images.append((image, row_index, column))
+            axes[row_index, column].set_xticks([])
+            axes[row_index, column].set_yticks([])
+        axes[row_index, 0].set_ylabel(
+            solver_props(name)[0],
+            rotation=0,
+            ha="right",
+            va="center",
+            labelpad=8,
+        )
+    for axis, title_text in zip(
+        axes[0],
+        ("Reference", "Solver", "ONE", "NOG", "WIG"),
+        strict=True,
+    ):
+        axis.set_title(title_text)
+    colorbar = fig.colorbar(
+        images[-1][0],
+        ax=axes.ravel().tolist(),
+        location="right",
+        shrink=0.82,
+        pad=0.02,
+    )
+    colorbar.set_label(r"Vorticity $\omega$")
+    all_times = np.asarray(arrays.get("evaluation_times", np.array([])))
+    times = (
+        all_times[frame_indices]
+        if all_times.size >= available_frames
+        else np.arange(frame_indices.size)
+    )
+    title = fig.suptitle("Autoregressive curriculum rollout at $t=0$")
+
+    def _update(frame: int) -> tuple[Any, ...]:
+        for image, row_index, column in images:
+            image.set_data(vorticity[row_index][column][frame].T)
+        title.set_text(
+            f"Autoregressive curriculum rollout at $t={float(times[frame]):g}$"
+        )
+        return tuple([image for image, _row, _column in images] + [title])
+
+    animation = manimation.FuncAnimation(
+        fig,
+        _update,
+        frames=len(frame_indices),
+        interval=180,
+        blit=False,
+    )
+    _save_animation(
+        animation,
+        "solver_in_loop_curriculum_trajectory",
+        out_dir,
+        fps=6,
+    )
+
+
 def plot_drag_opt(
     cfg: Problem,
     *,

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -1740,6 +1740,12 @@ def plot_solver_in_loop_curriculum(
             out_dir,
             save=save,
         ),
+        _plot_solver_in_loop_curriculum_fd(
+            arrays,
+            names,
+            out_dir,
+            save=save,
+        ),
         _plot_solver_in_loop_curriculum_summary(
             data,
             arrays,
@@ -1883,6 +1889,78 @@ def _plot_solver_in_loop_curriculum_correlations(
     fig.suptitle("Held-out correlation decay (threshold 0.95)")
     if save:
         save_fig(fig, "solver_in_loop_curriculum_correlations", out_dir)
+    return fig
+
+
+def _plot_solver_in_loop_curriculum_fd(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Show directional finite-difference agreement across epsilon and seeds."""
+    rows = [
+        (index, name)
+        for index, name in _curriculum_rows(arrays, names)
+        if np.asarray(arrays.get(f"fd_rel_error_samples_{index}", np.array([]))).size
+    ]
+    if not rows:
+        return None
+    plt.rcParams.update(RCPARAMS)
+    ncols = 3
+    nrows = int(np.ceil(len(rows) / ncols))
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, 1.85 * nrows),
+        squeeze=False,
+        layout="constrained",
+    )
+    for axis, (index, name) in zip(axes.ravel(), rows, strict=False):
+        epsilons = np.asarray(arrays.get(f"fd_epsilon_{index}", np.array([])))
+        errors = np.asarray(arrays.get(f"fd_rel_error_samples_{index}", np.array([])))
+        if epsilons.size == 0 or errors.ndim != 2:
+            axis.axis("off")
+            continue
+        _label, color, _linestyle, marker = solver_props(name)
+        for seed_errors in errors:
+            axis.plot(
+                epsilons,
+                np.maximum(seed_errors, 1e-12),
+                color=color,
+                alpha=0.22,
+                linewidth=0.8,
+            )
+        median = np.median(errors, axis=0)
+        axis.plot(
+            epsilons,
+            np.maximum(median, 1e-12),
+            color=color,
+            marker=marker,
+            linewidth=1.4,
+            label="median; faint = seed",
+        )
+        best_index = int(np.argmin(median))
+        axis.scatter(
+            [epsilons[best_index]],
+            [max(float(median[best_index]), 1e-12)],
+            color=color,
+            edgecolor="black",
+            linewidth=0.4,
+            zorder=3,
+        )
+        axis.set_xscale("log")
+        axis.set_yscale("log")
+        axis.set_xlabel("FD perturbation $\\epsilon$")
+        axis.set_ylabel("Relative FD/AD error")
+        axis.set_title(_label)
+        axis.legend(fontsize=6)
+    for axis in axes.ravel()[len(rows) :]:
+        axis.axis("off")
+    fig.suptitle("End-to-end solver-VJP finite-difference sweep")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_fd", out_dir)
     return fig
 
 

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -67,6 +67,8 @@ class _TrainingResult(NamedTuple):
     grad_norms: list[float]
     update_times: list[float]
     fd_error: float | None
+    fd_epsilons: tuple[float, ...]
+    fd_errors: tuple[float, ...]
     completed: bool
     stage_models: tuple[Any, ...]
     stage_unrolls: tuple[int, ...]
@@ -882,6 +884,19 @@ def _train_corrector(
     loss_mode = str(training.get("loss_mode", "mean"))
     solver_loss_weight = float(training.get("solver_loss_weight", 0.1))
     fd_epsilon = float(training.get("fd_epsilon", 1e-2))
+    configured_fd_epsilons = training.get("fd_epsilons")
+    if configured_fd_epsilons is None:
+        fd_epsilons = (
+            10.0 * fd_epsilon,
+            3.0 * fd_epsilon,
+            fd_epsilon,
+            0.3 * fd_epsilon,
+            0.1 * fd_epsilon,
+        )
+    else:
+        fd_epsilons = tuple(float(value) for value in configured_fd_epsilons)
+    if not fd_epsilons or any(value <= 0 for value in fd_epsilons):
+        raise ValueError("training.fd_epsilons must contain positive values")
     maximum_unroll = max(stage.unroll for stage in stages)
     if train.shape[1] < maximum_unroll + 1:
         raise ValueError(
@@ -909,6 +924,7 @@ def _train_corrector(
     grad_norms: list[float] = []
     update_times: list[float] = []
     fd_error: float | None = None
+    fd_error_curve: tuple[float, ...] = ()
     completed = True
     stage_models: list[Any] = []
     stage_boundaries: list[int] = []
@@ -952,13 +968,17 @@ def _train_corrector(
                 and differentiate_solver
                 and bool(training.get("check_grad", True))
             ):
-                fd_error = _directional_fd(
-                    loss_fn,
-                    model,
-                    grads,
-                    jax.random.PRNGKey(model_seed + 1),
-                    epsilon=fd_epsilon,
+                fd_error_curve = tuple(
+                    _directional_fd(
+                        loss_fn,
+                        model,
+                        grads,
+                        jax.random.PRNGKey(model_seed + 1),
+                        epsilon=epsilon,
+                    )
+                    for epsilon in fd_epsilons
                 )
+                fd_error = min(fd_error_curve)
             updates, opt_state = optimiser.update(
                 grads,
                 opt_state,
@@ -978,6 +998,8 @@ def _train_corrector(
         grad_norms=grad_norms,
         update_times=update_times,
         fd_error=fd_error,
+        fd_epsilons=fd_epsilons if fd_error_curve else (),
+        fd_errors=fd_error_curve,
         completed=completed,
         stage_models=tuple(stage_models),
         stage_unrolls=tuple(stage.unroll for stage in stages[: len(stage_models)]),
@@ -1204,6 +1226,8 @@ def _std(values: list[float]) -> float:
         "update_time_stop_gradient_samples",
         "update_time_one_step",
         "update_time_one_step_samples",
+        "fd_epsilon",
+        "fd_rel_error_samples",
         "error_corrected",
         "error_corrected_samples",
         "error_corrected_seed_std",
@@ -1467,6 +1491,9 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     grad_norms_by_seed: list[list[float]] = []
     update_times_by_seed: list[list[float]] = []
     fd_errors: list[float | None] = []
+    fd_model_seeds: list[int] = []
+    fd_epsilons_by_seed: list[tuple[float, ...]] = []
+    fd_error_curves_by_seed: list[tuple[float, ...]] = []
     completed_by_seed: list[bool] = []
     training_walls: list[float] = []
     stop_gradient_losses_by_seed: list[list[float]] = []
@@ -1497,10 +1524,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     for seed_idx, model_seed in enumerate(model_seeds):
         seed_training = {
             **training,
-            # One end-to-end FD check is enough for a shared architecture and
-            # solver VJP; repeating it for initialisation replicates adds cost
-            # without strengthening the paired training comparison.
-            "check_grad": bool(training.get("check_grad", True)) and seed_idx == 0,
+            "check_grad": bool(training.get("check_grad", True)),
         }
         started = time.perf_counter()
         full_training = _train_corrector(
@@ -1519,6 +1543,8 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         grad_norms = full_training.grad_norms
         update_times = full_training.update_times
         fd_error = full_training.fd_error
+        fd_epsilons = full_training.fd_epsilons
+        fd_error_curve = full_training.fd_errors
         completed = full_training.completed
         training_walls.append(time.perf_counter() - started)
 
@@ -1696,6 +1722,10 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         grad_norms_by_seed.append(grad_norms)
         update_times_by_seed.append(update_times)
         fd_errors.append(fd_error)
+        if fd_error_curve:
+            fd_model_seeds.append(model_seed)
+            fd_epsilons_by_seed.append(fd_epsilons)
+            fd_error_curves_by_seed.append(fd_error_curve)
         completed_by_seed.append(completed)
         stop_gradient_losses_by_seed.append(stop_gradient_losses)
         stop_gradient_grad_norms_by_seed.append(stop_gradient_grad_norms)
@@ -1908,6 +1938,27 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             ],
             axis=0,
         )
+    fd_epsilon_array = np.asarray([], dtype=np.float32)
+    fd_error_samples = np.empty((0, 0), dtype=np.float32)
+    fd_check_summary: list[dict[str, Any]] = []
+    if fd_error_curves_by_seed:
+        if len(set(fd_epsilons_by_seed)) != 1:
+            raise RuntimeError("FD epsilon grids differ across model seeds")
+        fd_epsilon_array = np.asarray(fd_epsilons_by_seed[0], dtype=np.float32)
+        fd_error_samples = np.asarray(fd_error_curves_by_seed, dtype=np.float32)
+        fd_check_summary = [
+            {
+                "model_seed": model_seed,
+                "best_epsilon": float(fd_epsilon_array[int(np.argmin(curve))]),
+                "best_relative_error": float(np.min(curve)),
+                "max_relative_error": float(np.max(curve)),
+            }
+            for model_seed, curve in zip(
+                fd_model_seeds,
+                fd_error_samples,
+                strict=True,
+            )
+        ]
 
     metrics = {
         **reference_audit,
@@ -2074,6 +2125,11 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         if stop_gradient_grad_norms.size
         else None,
         "end_to_end_fd_rel_error": _mean_optional(fd_errors),
+        "end_to_end_fd_rel_error_max": max(
+            (value for value in fd_errors if value is not None),
+            default=None,
+        ),
+        "fd_check_summary": fd_check_summary,
         "final_divergence_rms": divergence_rms(first_corrected[-1], ctx.domain_extent)
         if first_corrected is not None
         else None,
@@ -2331,6 +2387,8 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         "update_time_stop_gradient_samples": _stack_curves(
             stop_gradient_update_times_by_seed
         ),
+        "fd_epsilon": fd_epsilon_array,
+        "fd_rel_error_samples": fd_error_samples,
         "error_corrected": np.asarray(corrected_error, dtype=np.float32),
         "error_corrected_samples": corrected_errors_array.astype(np.float32),
         "error_corrected_seed_std": np.asarray(

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -776,10 +776,12 @@ def _window_loss(
     loss_scale: float,
     local_loss_weight: float = 1.0,
     warmup_intervals: int = 0,
+    initial_state: jax.Array | None = None,
+    initial_native_state: Any | None = None,
 ) -> jax.Array:
     """Normalized recurrent loss with configurable temporal credit assignment."""
-    state = targets[0]
-    native_state = None
+    state = targets[0] if initial_state is None else initial_state
+    native_state = initial_native_state
     losses: list[jax.Array] = []
     solver_mediated_losses: list[jax.Array] = []
     solver_terminal_loss: jax.Array | None = None
@@ -846,6 +848,36 @@ def _window_loss(
     else:
         raise ValueError(f"unknown training.loss_mode: {loss_mode!r}")
     return loss / jnp.asarray(loss_scale, dtype=loss.dtype)
+
+
+def _frozen_warmup_state(
+    model: Any,
+    targets: jax.Array,
+    *,
+    t: Any,
+    ctx: KernelContext,
+    frame_steps: int,
+    velocity_scale: float,
+    warmup_intervals: int,
+) -> tuple[jax.Array, Any | None]:
+    """Run pushforward warm-up once and freeze its recurrent suffix state."""
+    state = targets[0]
+    native_state = None
+    for _ in range(warmup_intervals):
+        state, native_state = _solver_advance(
+            t,
+            ctx,
+            state,
+            frame_steps=frame_steps,
+            native_state=native_state,
+        )
+        state = corrected_velocity(
+            model,
+            state,
+            velocity_scale=velocity_scale,
+            domain_extent=ctx.domain_extent,
+        )
+    return _stop_recurrent_gradient(state, native_state)
 
 
 def _directional_fd(
@@ -1043,9 +1075,39 @@ def _train_corrector(
                 and differentiate_solver
                 and bool(training.get("check_grad", True))
             ):
+                fd_loss_fn = loss_fn
+                if warmup_intervals:
+                    frozen_state, frozen_native_state = _frozen_warmup_state(
+                        model,
+                        targets,
+                        t=t,
+                        ctx=ctx,
+                        frame_steps=frame_steps,
+                        velocity_scale=velocity_scale,
+                        warmup_intervals=warmup_intervals,
+                    )
+                    # Stop-gradient warm-up defines a truncated derivative, not
+                    # the derivative of a fully perturbed forward rollout.
+                    # Freeze its base-model state for a like-for-like FD check.
+                    fd_loss_fn = partial(
+                        _window_loss,
+                        targets=targets[warmup_intervals:],
+                        t=t,
+                        ctx=ctx,
+                        frame_steps=frame_steps,
+                        velocity_scale=velocity_scale,
+                        differentiate_solver=differentiate_solver,
+                        loss_mode=loss_mode,
+                        solver_loss_weight=solver_loss_weight,
+                        loss_scale=loss_scale,
+                        local_loss_weight=local_loss_weight,
+                        warmup_intervals=0,
+                        initial_state=frozen_state,
+                        initial_native_state=frozen_native_state,
+                    )
                 checks = tuple(
                     _directional_fd(
-                        loss_fn,
+                        fd_loss_fn,
                         model,
                         grads,
                         jax.random.PRNGKey(model_seed + 1),
@@ -2327,6 +2389,11 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         ),
         "fd_check_summary": fd_check_summary,
         "fd_horizon_summary": fd_horizon_summary,
+        "fd_check_scope": (
+            "differentiated_suffix_with_frozen_warmup"
+            if warmup_intervals
+            else "full_training_window"
+        ),
         "final_divergence_rms": divergence_rms(first_corrected[-1], ctx.domain_extent)
         if first_corrected is not None
         else None,

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -814,6 +814,13 @@ def _window_loss(
         if solver_terminal_loss is None:
             raise RuntimeError("solver-terminal loss requires a non-empty rollout")
         loss = solver_loss_weight * solver_terminal_loss + jnp.mean(jnp.stack(losses))
+    elif loss_mode == "solver_terminal_mediated":
+        if solver_terminal_loss is None:
+            raise RuntimeError("solver-terminal loss requires a non-empty rollout")
+        local_loss = jnp.mean(jnp.stack(losses))
+        loss = (
+            local_loss_weight * local_loss + solver_loss_weight * solver_terminal_loss
+        )
     elif loss_mode == "solver_mediated":
         local_loss = jnp.mean(jnp.stack(losses))
         mediated_loss = (
@@ -924,7 +931,13 @@ def _train_corrector(
         raise ValueError(
             "the warm-up plus largest look-ahead must fit inside dataset.train_frames"
         )
-    if loss_mode not in {"mean", "terminal", "solver_terminal", "solver_mediated"}:
+    if loss_mode not in {
+        "mean",
+        "terminal",
+        "solver_terminal",
+        "solver_terminal_mediated",
+        "solver_mediated",
+    }:
         raise ValueError(f"unknown training.loss_mode: {loss_mode!r}")
     if solver_loss_weight < 0:
         raise ValueError("training.solver_loss_weight must be non-negative")
@@ -933,7 +946,7 @@ def _train_corrector(
     if warmup_intervals < 0:
         raise ValueError("training.warmup_intervals must be non-negative")
     if (
-        loss_mode == "solver_mediated"
+        loss_mode in {"solver_mediated", "solver_terminal_mediated"}
         and solver_loss_weight == 0
         and local_loss_weight == 0
     ):

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -760,11 +760,14 @@ def _window_loss(
     loss_mode: str,
     solver_loss_weight: float,
     loss_scale: float,
+    local_loss_weight: float = 1.0,
+    warmup_intervals: int = 0,
 ) -> jax.Array:
     """Normalized recurrent loss with configurable temporal credit assignment."""
     state = targets[0]
     native_state = None
     losses: list[jax.Array] = []
+    solver_mediated_losses: list[jax.Array] = []
     solver_terminal_loss: jax.Array | None = None
     for step, target in enumerate(targets[1:]):
         provisional, native_state = _solver_advance(
@@ -774,26 +777,35 @@ def _window_loss(
             frame_steps=frame_steps,
             native_state=native_state,
         )
-        if not differentiate_solver:
+        if not differentiate_solver or step < warmup_intervals:
             # Keep the identical recurrent forward trajectory but cut the
             # backward graph through both canonical and solver-native recurrent
-            # state. This counterfactual measures what the same corrector can
-            # learn without the solver VJP.
+            # state. Warm-up intervals expose inference-like states without
+            # extending the differentiated chain.
             provisional, native_state = _stop_recurrent_gradient(
                 provisional,
                 native_state,
             )
+        provisional_loss = jnp.sum((provisional - target) ** 2) / (
+            jnp.sum(target**2) + 1e-12
+        )
         if step == targets.shape[0] - 2:
-            solver_terminal_loss = jnp.sum((provisional - target) ** 2) / (
-                jnp.sum(target**2) + 1e-12
-            )
+            solver_terminal_loss = provisional_loss
         state = corrected_velocity(
             model,
             provisional,
             velocity_scale=velocity_scale,
             domain_extent=ctx.domain_extent,
         )
+        if step < warmup_intervals:
+            state, native_state = _stop_recurrent_gradient(state, native_state)
+            continue
         losses.append(jnp.sum((state - target) ** 2) / (jnp.sum(target**2) + 1e-12))
+        # The first provisional state after warm-up precedes any differentiated
+        # correction. Later provisional states measure how earlier corrections
+        # survive the intervening numerical solver and therefore require its VJP.
+        if step > warmup_intervals:
+            solver_mediated_losses.append(provisional_loss)
     if loss_mode == "mean":
         loss = jnp.mean(jnp.stack(losses))
     elif loss_mode == "terminal":
@@ -802,6 +814,14 @@ def _window_loss(
         if solver_terminal_loss is None:
             raise RuntimeError("solver-terminal loss requires a non-empty rollout")
         loss = solver_loss_weight * solver_terminal_loss + jnp.mean(jnp.stack(losses))
+    elif loss_mode == "solver_mediated":
+        local_loss = jnp.mean(jnp.stack(losses))
+        mediated_loss = (
+            jnp.mean(jnp.stack(solver_mediated_losses))
+            if solver_mediated_losses
+            else jnp.zeros_like(local_loss)
+        )
+        loss = local_loss_weight * local_loss + solver_loss_weight * mediated_loss
     else:
         raise ValueError(f"unknown training.loss_mode: {loss_mode!r}")
     return loss / jnp.asarray(loss_scale, dtype=loss.dtype)
@@ -883,6 +903,8 @@ def _train_corrector(
     residual_blocks = int(training.get("residual_blocks", 5))
     loss_mode = str(training.get("loss_mode", "mean"))
     solver_loss_weight = float(training.get("solver_loss_weight", 0.1))
+    local_loss_weight = float(training.get("local_loss_weight", 1.0))
+    warmup_intervals = int(training.get("warmup_intervals", 0))
     fd_epsilon = float(training.get("fd_epsilon", 1e-2))
     configured_fd_epsilons = training.get("fd_epsilons")
     if configured_fd_epsilons is None:
@@ -898,14 +920,24 @@ def _train_corrector(
     if not fd_epsilons or any(value <= 0 for value in fd_epsilons):
         raise ValueError("training.fd_epsilons must contain positive values")
     maximum_unroll = max(stage.unroll for stage in stages)
-    if train.shape[1] < maximum_unroll + 1:
+    if train.shape[1] < warmup_intervals + maximum_unroll + 1:
         raise ValueError(
-            "the largest training look-ahead must fit inside dataset.train_frames"
+            "the warm-up plus largest look-ahead must fit inside dataset.train_frames"
         )
-    if loss_mode not in {"mean", "terminal", "solver_terminal"}:
+    if loss_mode not in {"mean", "terminal", "solver_terminal", "solver_mediated"}:
         raise ValueError(f"unknown training.loss_mode: {loss_mode!r}")
     if solver_loss_weight < 0:
         raise ValueError("training.solver_loss_weight must be non-negative")
+    if local_loss_weight < 0:
+        raise ValueError("training.local_loss_weight must be non-negative")
+    if warmup_intervals < 0:
+        raise ValueError("training.warmup_intervals must be non-negative")
+    if (
+        loss_mode == "solver_mediated"
+        and solver_loss_weight == 0
+        and local_loss_weight == 0
+    ):
+        raise ValueError("solver-mediated training needs a non-zero loss weight")
 
     model = init_corrector(
         jax.random.PRNGKey(model_seed),
@@ -937,10 +969,11 @@ def _train_corrector(
         for stage_update in range(stage.updates):
             update_started = time.perf_counter()
             trajectory_idx = int(rng.randint(train.shape[0]))
-            max_start = train.shape[1] - stage.unroll - 1
+            window_intervals = warmup_intervals + stage.unroll
+            max_start = train.shape[1] - window_intervals - 1
             start = int(rng.randint(max_start + 1)) if max_start > 0 else 0
             targets = jnp.asarray(
-                train[trajectory_idx, start : start + stage.unroll + 1]
+                train[trajectory_idx, start : start + window_intervals + 1]
             )
 
             loss_fn = partial(
@@ -954,6 +987,8 @@ def _train_corrector(
                 loss_mode=loss_mode,
                 solver_loss_weight=solver_loss_weight,
                 loss_scale=loss_scale,
+                local_loss_weight=local_loss_weight,
+                warmup_intervals=warmup_intervals,
             )
 
             loss, grads = eqx.filter_value_and_grad(loss_fn)(model)
@@ -1589,6 +1624,8 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
                 ],
                 "loss_mode": "mean",
                 "solver_loss_weight": 0.0,
+                "local_loss_weight": 1.0,
+                "warmup_intervals": 0,
                 "check_grad": False,
             }
             one_step_started = time.perf_counter()
@@ -1917,8 +1954,15 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         [stage.updates for stage in curriculum_stages],
         dtype=np.int64,
     )
+    warmup_intervals = int(training.get("warmup_intervals", 0))
+    warmup_solver_intervals_per_seed = warmup_intervals * sum(
+        stage.updates for stage in curriculum_stages
+    )
     recurrent_solver_intervals_per_seed = int(
-        sum(stage.unroll * stage.updates for stage in curriculum_stages)
+        sum(
+            (warmup_intervals + stage.unroll) * stage.updates
+            for stage in curriculum_stages
+        )
     )
     checkpoint_full_error: np.ndarray | None = None
     checkpoint_stop_error: np.ndarray | None = None
@@ -2207,8 +2251,24 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         "training_solver_intervals_per_seed": recurrent_solver_intervals_per_seed,
         "training_solver_intervals_total": recurrent_solver_intervals_per_seed
         * len(model_seeds),
+        "training_native_steps_per_seed": (
+            recurrent_solver_intervals_per_seed * frame_steps
+        ),
+        "training_native_steps_total": (
+            recurrent_solver_intervals_per_seed * frame_steps * len(model_seeds)
+        ),
+        "training_warmup_solver_intervals_per_seed": (warmup_solver_intervals_per_seed),
+        "training_warmup_solver_intervals_total": (
+            warmup_solver_intervals_per_seed * len(model_seeds)
+        ),
         "training_loss_mode": str(training.get("loss_mode", "mean")),
         "training_solver_loss_weight": float(training.get("solver_loss_weight", 0.1)),
+        "training_local_loss_weight": float(training.get("local_loss_weight", 1.0)),
+        "training_warmup_intervals": int(training.get("warmup_intervals", 0)),
+        "training_warmup_native_steps": warmup_intervals * frame_steps,
+        "training_differentiated_native_horizon": (
+            max(stage.unroll for stage in curriculum_stages) * frame_steps
+        ),
         "training_loss_normalization": loss_normalization,
         "training_loss_scale": training_loss_scale,
         "matched_horizon_time": matched_horizon_frame * interval_time,
@@ -2309,6 +2369,12 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
                 else None,
                 "one_step_training_solver_intervals_per_seed": len(one_step_losses),
                 "one_step_training_solver_intervals_total": one_step_total_updates,
+                "one_step_training_native_steps_per_seed": (
+                    len(one_step_losses) * frame_steps
+                ),
+                "one_step_training_native_steps_total": (
+                    one_step_total_updates * frame_steps
+                ),
                 "one_step_final_divergence_rms": divergence_rms(
                     first_one_step[-1],
                     ctx.domain_extent,

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -1157,6 +1157,17 @@ def _mean_curve(curves: list[list[float]]) -> np.ndarray:
     ).astype(np.float32)
 
 
+def _stack_curves(curves: list[list[float]]) -> np.ndarray:
+    """Stack the common completed prefix of repeated optimization curves."""
+    if not curves:
+        return np.empty((0, 0), dtype=np.float32)
+    common_length = min(len(curve) for curve in curves)
+    return np.stack(
+        [np.asarray(curve[:common_length]) for curve in curves],
+        axis=0,
+    ).astype(np.float32)
+
+
 def _mean_optional(values: list[float | None]) -> float | None:
     """Average present scalar measurements from repeated model seeds."""
     present = [float(value) for value in values if value is not None]
@@ -1174,35 +1185,55 @@ def _std(values: list[float]) -> float:
     snapshot_filename="corrector_fields.npz",
     snapshot_prefixes=(
         "loss",
+        "loss_samples",
         "loss_seed_std",
         "loss_stop_gradient",
+        "loss_stop_gradient_samples",
         "loss_stop_gradient_seed_std",
         "loss_one_step",
+        "loss_one_step_samples",
         "grad_norm",
+        "grad_norm_samples",
         "grad_norm_stop_gradient",
+        "grad_norm_stop_gradient_samples",
         "grad_norm_one_step",
+        "grad_norm_one_step_samples",
         "update_time",
+        "update_time_samples",
         "update_time_stop_gradient",
+        "update_time_stop_gradient_samples",
         "update_time_one_step",
+        "update_time_one_step_samples",
         "error_corrected",
+        "error_corrected_samples",
         "error_corrected_seed_std",
         "error_corrected_ic_std",
         "error_stop_gradient",
+        "error_stop_gradient_samples",
         "error_stop_gradient_seed_std",
         "error_stop_gradient_ic_std",
         "error_uncorrected",
+        "error_uncorrected_samples",
         "error_uncorrected_ic_std",
         "error_seen_corrected",
+        "error_seen_corrected_samples",
         "error_seen_stop_gradient",
+        "error_seen_stop_gradient_samples",
         "error_seen_uncorrected",
         "error_one_step",
+        "error_one_step_samples",
         "error_one_step_seed_std",
         "error_one_step_ic_std",
         "error_seen_one_step",
+        "error_seen_one_step_samples",
         "correlation_corrected",
+        "correlation_corrected_samples",
         "correlation_stop_gradient",
+        "correlation_stop_gradient_samples",
         "correlation_one_step",
+        "correlation_one_step_samples",
         "correlation_uncorrected",
+        "correlation_uncorrected_samples",
         "rollout_log_gain_samples",
         "stop_gradient_log_gain_samples",
         "solver_vjp_log_lift_samples",
@@ -1212,8 +1243,10 @@ def _std(values: list[float]) -> float:
         "curriculum_stage_unrolls",
         "curriculum_stage_boundaries",
         "curriculum_checkpoint_error_full",
+        "curriculum_checkpoint_error_full_samples",
         "curriculum_checkpoint_error_full_seed_std",
         "curriculum_checkpoint_error_nog",
+        "curriculum_checkpoint_error_nog_samples",
         "curriculum_checkpoint_error_nog_seed_std",
         "curriculum_checkpoint_error_native",
         "rollout_corrected",
@@ -2272,23 +2305,34 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         ]
     snapshots = {
         "loss": losses,
+        "loss_samples": _stack_curves(losses_by_seed),
         "loss_seed_std": np.asarray(loss_seed_std, dtype=np.float32),
         "loss_stop_gradient": stop_gradient_losses,
+        "loss_stop_gradient_samples": _stack_curves(stop_gradient_losses_by_seed),
         "loss_stop_gradient_seed_std": np.asarray(
             stop_gradient_loss_seed_std,
             dtype=np.float32,
         ),
         "grad_norm": grad_norms,
+        "grad_norm_samples": _stack_curves(grad_norms_by_seed),
         "grad_norm_stop_gradient": np.asarray(
             stop_gradient_grad_norms,
             dtype=np.float32,
         ),
+        "grad_norm_stop_gradient_samples": _stack_curves(
+            stop_gradient_grad_norms_by_seed
+        ),
         "update_time": update_times,
+        "update_time_samples": _stack_curves(update_times_by_seed),
         "update_time_stop_gradient": np.asarray(
             stop_gradient_update_times,
             dtype=np.float32,
         ),
+        "update_time_stop_gradient_samples": _stack_curves(
+            stop_gradient_update_times_by_seed
+        ),
         "error_corrected": np.asarray(corrected_error, dtype=np.float32),
+        "error_corrected_samples": corrected_errors_array.astype(np.float32),
         "error_corrected_seed_std": np.asarray(
             corrected_error_seed_std,
             dtype=np.float32,
@@ -2301,6 +2345,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             stop_gradient_error,
             dtype=np.float32,
         ),
+        "error_stop_gradient_samples": stop_gradient_errors_array.astype(np.float32),
         "error_stop_gradient_seed_std": np.asarray(
             stop_gradient_error_seed_std,
             dtype=np.float32,
@@ -2310,6 +2355,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             dtype=np.float32,
         ),
         "error_uncorrected": np.asarray(uncorrected_error, dtype=np.float32),
+        "error_uncorrected_samples": uncorrected_errors_array.astype(np.float32),
         "error_uncorrected_ic_std": np.asarray(
             uncorrected_error_ic_std,
             dtype=np.float32,
@@ -2318,9 +2364,13 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             seen_corrected_error,
             dtype=np.float32,
         ),
+        "error_seen_corrected_samples": seen_corrected_errors_array.astype(np.float32),
         "error_seen_stop_gradient": np.asarray(
             seen_stop_gradient_error,
             dtype=np.float32,
+        ),
+        "error_seen_stop_gradient_samples": (
+            seen_stop_gradient_errors_array.astype(np.float32)
         ),
         "error_seen_uncorrected": np.asarray(
             seen_uncorrected_error,
@@ -2330,13 +2380,22 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             corrected_correlation,
             dtype=np.float32,
         ),
+        "correlation_corrected_samples": np.stack(
+            corrected_correlations_by_seed
+        ).astype(np.float32),
         "correlation_stop_gradient": np.asarray(
             stop_gradient_correlation,
             dtype=np.float32,
         ),
+        "correlation_stop_gradient_samples": np.stack(
+            stop_gradient_correlations_by_seed
+        ).astype(np.float32),
         "correlation_uncorrected": np.asarray(
             uncorrected_correlation,
             dtype=np.float32,
+        ),
+        "correlation_uncorrected_samples": (
+            uncorrected_correlations_array.astype(np.float32)
         ),
         "rollout_log_gain_samples": rollout_log_gain_samples.astype(np.float32),
         "stop_gradient_log_gain_samples": stop_gradient_log_gain_samples.astype(
@@ -2356,9 +2415,17 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         snapshots.update(
             {
                 "loss_one_step": one_step_losses,
+                "loss_one_step_samples": _stack_curves(one_step_losses_by_seed),
                 "grad_norm_one_step": one_step_grad_norms,
+                "grad_norm_one_step_samples": _stack_curves(
+                    one_step_grad_norms_by_seed
+                ),
                 "update_time_one_step": one_step_update_times,
+                "update_time_one_step_samples": _stack_curves(
+                    one_step_update_times_by_seed
+                ),
                 "error_one_step": np.asarray(one_step_error, dtype=np.float32),
+                "error_one_step_samples": one_step_errors_array.astype(np.float32),
                 "error_one_step_seed_std": np.asarray(
                     one_step_error_seed_std,
                     dtype=np.float32,
@@ -2371,12 +2438,18 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
                     seen_one_step_error,
                     dtype=np.float32,
                 ),
+                "error_seen_one_step_samples": np.stack(
+                    seen_one_step_errors_by_seed
+                ).astype(np.float32),
                 "correlation_one_step": np.asarray(
                     one_step_correlation,
                     dtype=np.float32,
                 )
                 if one_step_correlation is not None
                 else np.asarray([], dtype=np.float32),
+                "correlation_one_step_samples": np.stack(
+                    one_step_correlations_by_seed
+                ).astype(np.float32),
                 "one_step_rollout_log_gain_samples": (
                     one_step_rollout_log_gain_samples.astype(np.float32)
                 ),
@@ -2405,12 +2478,18 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
                 "curriculum_checkpoint_error_full": checkpoint_full_error.astype(
                     np.float32
                 ),
+                "curriculum_checkpoint_error_full_samples": np.stack(
+                    checkpoint_full_errors_by_seed
+                ).astype(np.float32),
                 "curriculum_checkpoint_error_full_seed_std": (
                     checkpoint_full_seed_std.astype(np.float32)
                 ),
                 "curriculum_checkpoint_error_nog": checkpoint_stop_error.astype(
                     np.float32
                 ),
+                "curriculum_checkpoint_error_nog_samples": np.stack(
+                    checkpoint_stop_errors_by_seed
+                ).astype(np.float32),
                 "curriculum_checkpoint_error_nog_seed_std": (
                     checkpoint_stop_seed_std.astype(np.float32)
                 ),

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -59,6 +59,14 @@ class _TrainingStage(NamedTuple):
     lr: float
 
 
+class _DirectionalFD(NamedTuple):
+    """One directional finite-difference comparison."""
+
+    relative_error: float
+    finite_difference: float
+    autodiff: float
+
+
 class _TrainingResult(NamedTuple):
     """A trained corrector plus its curriculum checkpoints and traces."""
 
@@ -69,6 +77,12 @@ class _TrainingResult(NamedTuple):
     fd_error: float | None
     fd_epsilons: tuple[float, ...]
     fd_errors: tuple[float, ...]
+    fd_finite_differences: tuple[float, ...]
+    fd_autodiff: tuple[float, ...]
+    fd_stage_unrolls: tuple[int, ...]
+    fd_stage_errors: tuple[tuple[float, ...], ...]
+    fd_stage_finite_differences: tuple[tuple[float, ...], ...]
+    fd_stage_autodiff: tuple[tuple[float, ...], ...]
     completed: bool
     stage_models: tuple[Any, ...]
     stage_unrolls: tuple[int, ...]
@@ -841,8 +855,8 @@ def _directional_fd(
     key: jax.Array,
     *,
     epsilon: float,
-) -> float:
-    """Relative error of one end-to-end directional finite difference."""
+) -> _DirectionalFD:
+    """Compare AD and finite differences along one normalized direction."""
     dynamic, static = eqx.partition(model, eqx.is_inexact_array)
     leaves, structure = jax.tree_util.tree_flatten(dynamic)
     direction = jax.tree_util.tree_unflatten(
@@ -885,7 +899,11 @@ def _directional_fd(
             strict=True,
         )
     )
-    return float(jnp.abs(fd - ad) / (jnp.abs(fd) + jnp.abs(ad) + 1e-12))
+    return _DirectionalFD(
+        relative_error=float(jnp.abs(fd - ad) / (jnp.abs(fd) + jnp.abs(ad) + 1e-12)),
+        finite_difference=float(fd),
+        autodiff=float(ad),
+    )
 
 
 def _train_corrector(
@@ -970,6 +988,12 @@ def _train_corrector(
     update_times: list[float] = []
     fd_error: float | None = None
     fd_error_curve: tuple[float, ...] = ()
+    fd_finite_difference_curve: tuple[float, ...] = ()
+    fd_autodiff_curve: tuple[float, ...] = ()
+    fd_stage_unrolls: list[int] = []
+    fd_stage_error_curves: list[tuple[float, ...]] = []
+    fd_stage_finite_difference_curves: list[tuple[float, ...]] = []
+    fd_stage_autodiff_curves: list[tuple[float, ...]] = []
     completed = True
     stage_models: list[Any] = []
     stage_boundaries: list[int] = []
@@ -1010,13 +1034,16 @@ def _train_corrector(
             if not np.isfinite(loss_value) or not np.isfinite(grad_norm):
                 completed = False
                 break
-            if (
+            check_this_stage = bool(training.get("check_grad_stages", False)) or (
                 stage_index == len(stages) - 1
+            )
+            if (
+                check_this_stage
                 and stage_update == 0
                 and differentiate_solver
                 and bool(training.get("check_grad", True))
             ):
-                fd_error_curve = tuple(
+                checks = tuple(
                     _directional_fd(
                         loss_fn,
                         model,
@@ -1026,7 +1053,20 @@ def _train_corrector(
                     )
                     for epsilon in fd_epsilons
                 )
-                fd_error = min(fd_error_curve)
+                stage_error_curve = tuple(check.relative_error for check in checks)
+                stage_finite_difference_curve = tuple(
+                    check.finite_difference for check in checks
+                )
+                stage_autodiff_curve = tuple(check.autodiff for check in checks)
+                fd_stage_unrolls.append(stage.unroll)
+                fd_stage_error_curves.append(stage_error_curve)
+                fd_stage_finite_difference_curves.append(stage_finite_difference_curve)
+                fd_stage_autodiff_curves.append(stage_autodiff_curve)
+                if stage_index == len(stages) - 1:
+                    fd_error_curve = stage_error_curve
+                    fd_finite_difference_curve = stage_finite_difference_curve
+                    fd_autodiff_curve = stage_autodiff_curve
+                    fd_error = min(fd_error_curve)
             updates, opt_state = optimiser.update(
                 grads,
                 opt_state,
@@ -1048,6 +1088,12 @@ def _train_corrector(
         fd_error=fd_error,
         fd_epsilons=fd_epsilons if fd_error_curve else (),
         fd_errors=fd_error_curve,
+        fd_finite_differences=fd_finite_difference_curve,
+        fd_autodiff=fd_autodiff_curve,
+        fd_stage_unrolls=tuple(fd_stage_unrolls),
+        fd_stage_errors=tuple(fd_stage_error_curves),
+        fd_stage_finite_differences=tuple(fd_stage_finite_difference_curves),
+        fd_stage_autodiff=tuple(fd_stage_autodiff_curves),
         completed=completed,
         stage_models=tuple(stage_models),
         stage_unrolls=tuple(stage.unroll for stage in stages[: len(stage_models)]),
@@ -1542,6 +1588,12 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     fd_model_seeds: list[int] = []
     fd_epsilons_by_seed: list[tuple[float, ...]] = []
     fd_error_curves_by_seed: list[tuple[float, ...]] = []
+    fd_finite_difference_curves_by_seed: list[tuple[float, ...]] = []
+    fd_autodiff_curves_by_seed: list[tuple[float, ...]] = []
+    fd_stage_unrolls_by_seed: list[tuple[int, ...]] = []
+    fd_stage_error_curves_by_seed: list[tuple[tuple[float, ...], ...]] = []
+    fd_stage_finite_difference_curves_by_seed: list[tuple[tuple[float, ...], ...]] = []
+    fd_stage_autodiff_curves_by_seed: list[tuple[tuple[float, ...], ...]] = []
     completed_by_seed: list[bool] = []
     training_walls: list[float] = []
     stop_gradient_losses_by_seed: list[list[float]] = []
@@ -1593,6 +1645,8 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         fd_error = full_training.fd_error
         fd_epsilons = full_training.fd_epsilons
         fd_error_curve = full_training.fd_errors
+        fd_finite_difference_curve = full_training.fd_finite_differences
+        fd_autodiff_curve = full_training.fd_autodiff
         completed = full_training.completed
         training_walls.append(time.perf_counter() - started)
 
@@ -1776,6 +1830,14 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             fd_model_seeds.append(model_seed)
             fd_epsilons_by_seed.append(fd_epsilons)
             fd_error_curves_by_seed.append(fd_error_curve)
+            fd_finite_difference_curves_by_seed.append(fd_finite_difference_curve)
+            fd_autodiff_curves_by_seed.append(fd_autodiff_curve)
+            fd_stage_unrolls_by_seed.append(full_training.fd_stage_unrolls)
+            fd_stage_error_curves_by_seed.append(full_training.fd_stage_errors)
+            fd_stage_finite_difference_curves_by_seed.append(
+                full_training.fd_stage_finite_differences
+            )
+            fd_stage_autodiff_curves_by_seed.append(full_training.fd_stage_autodiff)
         completed_by_seed.append(completed)
         stop_gradient_losses_by_seed.append(stop_gradient_losses)
         stop_gradient_grad_norms_by_seed.append(stop_gradient_grad_norms)
@@ -1997,22 +2059,99 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         )
     fd_epsilon_array = np.asarray([], dtype=np.float32)
     fd_error_samples = np.empty((0, 0), dtype=np.float32)
+    fd_finite_difference_samples = np.empty((0, 0), dtype=np.float32)
+    fd_autodiff_samples = np.empty((0, 0), dtype=np.float32)
+    fd_stage_unroll_array = np.asarray([], dtype=np.int32)
+    fd_stage_error_samples = np.empty((0, 0, 0), dtype=np.float32)
+    fd_stage_finite_difference_samples = np.empty((0, 0, 0), dtype=np.float32)
+    fd_stage_autodiff_samples = np.empty((0, 0, 0), dtype=np.float32)
     fd_check_summary: list[dict[str, Any]] = []
+    fd_horizon_summary: list[dict[str, Any]] = []
     if fd_error_curves_by_seed:
         if len(set(fd_epsilons_by_seed)) != 1:
             raise RuntimeError("FD epsilon grids differ across model seeds")
+        if len(set(fd_stage_unrolls_by_seed)) != 1:
+            raise RuntimeError("FD horizon grids differ across model seeds")
         fd_epsilon_array = np.asarray(fd_epsilons_by_seed[0], dtype=np.float32)
         fd_error_samples = np.asarray(fd_error_curves_by_seed, dtype=np.float32)
+        fd_finite_difference_samples = np.asarray(
+            fd_finite_difference_curves_by_seed,
+            dtype=np.float32,
+        )
+        fd_autodiff_samples = np.asarray(
+            fd_autodiff_curves_by_seed,
+            dtype=np.float32,
+        )
+        fd_stage_unroll_array = np.asarray(
+            fd_stage_unrolls_by_seed[0],
+            dtype=np.int32,
+        )
+        fd_stage_error_samples = np.asarray(
+            fd_stage_error_curves_by_seed,
+            dtype=np.float32,
+        )
+        fd_stage_finite_difference_samples = np.asarray(
+            fd_stage_finite_difference_curves_by_seed,
+            dtype=np.float32,
+        )
+        fd_stage_autodiff_samples = np.asarray(
+            fd_stage_autodiff_curves_by_seed,
+            dtype=np.float32,
+        )
         fd_check_summary = [
             {
                 "model_seed": model_seed,
-                "best_epsilon": float(fd_epsilon_array[int(np.argmin(curve))]),
-                "best_relative_error": float(np.min(curve)),
+                "best_epsilon": float(
+                    fd_epsilon_array[best_index := int(np.argmin(curve))]
+                ),
+                "best_relative_error": float(curve[best_index]),
                 "max_relative_error": float(np.max(curve)),
+                "finite_difference_at_best_epsilon": float(
+                    finite_differences[best_index]
+                ),
+                "autodiff_directional_derivative": float(autodiff_values[best_index]),
+                "absolute_directional_error": float(
+                    abs(finite_differences[best_index] - autodiff_values[best_index])
+                ),
             }
-            for model_seed, curve in zip(
+            for model_seed, curve, finite_differences, autodiff_values in zip(
                 fd_model_seeds,
                 fd_error_samples,
+                fd_finite_difference_samples,
+                fd_autodiff_samples,
+                strict=True,
+            )
+        ]
+        fd_horizon_summary = [
+            {
+                "model_seed": model_seed,
+                "unroll": int(unroll),
+                "best_epsilon": float(
+                    fd_epsilon_array[best_index := int(np.argmin(curve))]
+                ),
+                "best_relative_error": float(curve[best_index]),
+                "finite_difference_at_best_epsilon": float(
+                    finite_differences[best_index]
+                ),
+                "autodiff_directional_derivative": float(autodiff_values[best_index]),
+            }
+            for (
+                model_seed,
+                seed_curves,
+                seed_finite_differences,
+                seed_autodiff_values,
+            ) in zip(
+                fd_model_seeds,
+                fd_stage_error_samples,
+                fd_stage_finite_difference_samples,
+                fd_stage_autodiff_samples,
+                strict=True,
+            )
+            for unroll, curve, finite_differences, autodiff_values in zip(
+                fd_stage_unroll_array,
+                seed_curves,
+                seed_finite_differences,
+                seed_autodiff_values,
                 strict=True,
             )
         ]
@@ -2187,6 +2326,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             default=None,
         ),
         "fd_check_summary": fd_check_summary,
+        "fd_horizon_summary": fd_horizon_summary,
         "final_divergence_rms": divergence_rms(first_corrected[-1], ctx.domain_extent)
         if first_corrected is not None
         else None,
@@ -2468,6 +2608,12 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         ),
         "fd_epsilon": fd_epsilon_array,
         "fd_rel_error_samples": fd_error_samples,
+        "fd_directional_finite_difference_samples": fd_finite_difference_samples,
+        "fd_directional_autodiff_samples": fd_autodiff_samples,
+        "fd_stage_unroll": fd_stage_unroll_array,
+        "fd_stage_rel_error_samples": fd_stage_error_samples,
+        "fd_stage_finite_difference_samples": (fd_stage_finite_difference_samples),
+        "fd_stage_autodiff_samples": fd_stage_autodiff_samples,
         "error_corrected": np.asarray(corrected_error, dtype=np.float32),
         "error_corrected_samples": corrected_errors_array.astype(np.float32),
         "error_corrected_seed_std": np.asarray(

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -51,6 +51,68 @@ _NATIVE_STATE_SUPPORT: weakref.WeakKeyDictionary[Any, bool] = (
 )
 
 
+class _TrainingStage(NamedTuple):
+    """One recurrent-lookahead stage in a corrector curriculum."""
+
+    unroll: int
+    updates: int
+    lr: float
+
+
+class _TrainingResult(NamedTuple):
+    """A trained corrector plus its curriculum checkpoints and traces."""
+
+    model: Any
+    losses: list[float]
+    grad_norms: list[float]
+    update_times: list[float]
+    fd_error: float | None
+    completed: bool
+    stage_models: tuple[Any, ...]
+    stage_unrolls: tuple[int, ...]
+    stage_boundaries: tuple[int, ...]
+    stage_learning_rates: tuple[float, ...]
+
+
+def _training_stages(training: dict[str, Any]) -> tuple[_TrainingStage, ...]:
+    """Normalize a fixed-horizon run or explicit curriculum into stages."""
+    default_lr = float(training.get("lr", 1e-4))
+    configured = training.get("curriculum")
+    if configured is None:
+        configured = [
+            {
+                "unroll": int(training.get("unroll", 4)),
+                "updates": int(training.get("max_updates", 100)),
+                "lr": default_lr,
+            }
+        ]
+    if not isinstance(configured, (list, tuple)) or not configured:
+        raise ValueError("training.curriculum must be a non-empty list")
+
+    stages: list[_TrainingStage] = []
+    for index, stage in enumerate(configured):
+        if not isinstance(stage, dict):
+            raise TypeError(f"training.curriculum[{index}] must be a mapping")
+        normalized = _TrainingStage(
+            unroll=int(stage["unroll"]),
+            updates=int(stage["updates"]),
+            lr=float(stage.get("lr", default_lr)),
+        )
+        if normalized.unroll < 1:
+            raise ValueError(f"training.curriculum[{index}].unroll must be positive")
+        if normalized.updates < 1:
+            raise ValueError(f"training.curriculum[{index}].updates must be positive")
+        if normalized.lr <= 0:
+            raise ValueError(f"training.curriculum[{index}].lr must be positive")
+        stages.append(normalized)
+    return tuple(stages)
+
+
+def _maximum_training_unroll(training: dict[str, Any]) -> int:
+    """Return the largest look-ahead required by a training configuration."""
+    return max(stage.unroll for stage in _training_stages(training))
+
+
 def _dataset_digest(config: dict[str, Any]) -> str:
     """Stable short identifier for generated reference data."""
     payload = json.dumps(config, sort_keys=True, separators=(",", ":")).encode()
@@ -270,7 +332,7 @@ def _make_reference_datasets(
     test_seeds = tuple(int(v) for v in dataset.get("test_seeds", [100, 101]))
     train_frames = int(dataset.get("train_frames", 16))
     eval_frames = int(evaluation.get("rollout_frames", 32))
-    unroll = int(training.get("unroll", 4))
+    unroll = _maximum_training_unroll(training)
     n_frames = max(train_frames, eval_frames, unroll)
     config = {
         "reference_kind": str(
@@ -464,7 +526,7 @@ def _make_solver_self_reference_datasets(
     all_seeds = train_seeds + test_seeds
     train_frames = int(dataset.get("train_frames", 16))
     eval_frames = int(evaluation.get("rollout_frames", 32))
-    unroll = int(training.get("unroll", 4))
+    unroll = _maximum_training_unroll(training)
     n_frames = max(train_frames, eval_frames, unroll)
 
     fine_n = n * reference_factor
@@ -808,22 +870,22 @@ def _train_corrector(
     loss_scale: float,
     differentiate_solver: bool,
     model_seed: int,
-) -> tuple[Any, list[float], list[float], list[float], float | None, bool]:
-    """Train one solver-specific corrector with a fixed stochastic schedule."""
-    max_updates = int(training.get("max_updates", 100))
-    unroll = int(training.get("unroll", 4))
-    lr = float(training.get("lr", 1e-4))
+) -> _TrainingResult:
+    """Train one solver-specific corrector through a fixed or staged look-ahead."""
+    stages = _training_stages(training)
     clip_norm = float(training.get("clip_norm", 1.0))
     seed = int(training.get("seed", 2026))
     hidden_channels = int(training.get("hidden_channels", 32))
     kernel_size = int(training.get("kernel_size", 5))
     architecture = str(training.get("architecture", "periodic_residual_cnn"))
+    residual_blocks = int(training.get("residual_blocks", 5))
     loss_mode = str(training.get("loss_mode", "mean"))
     solver_loss_weight = float(training.get("solver_loss_weight", 0.1))
     fd_epsilon = float(training.get("fd_epsilon", 1e-2))
-    if unroll < 1 or train.shape[1] < unroll + 1:
+    maximum_unroll = max(stage.unroll for stage in stages)
+    if train.shape[1] < maximum_unroll + 1:
         raise ValueError(
-            "training.unroll must be positive and fit inside dataset.train_frames"
+            "the largest training look-ahead must fit inside dataset.train_frames"
         )
     if loss_mode not in {"mean", "terminal", "solver_terminal"}:
         raise ValueError(f"unknown training.loss_mode: {loss_mode!r}")
@@ -835,10 +897,11 @@ def _train_corrector(
         hidden_channels=hidden_channels,
         kernel_size=kernel_size,
         architecture=architecture,
+        residual_blocks=residual_blocks,
     )
     optimiser = optax.chain(
         optax.clip_by_global_norm(clip_norm),
-        optax.adam(lr),
+        optax.adam(stages[0].lr),
     )
     opt_state = optimiser.init(eqx.filter(model, eqx.is_inexact_array))
     rng = np.random.RandomState(seed)
@@ -847,55 +910,80 @@ def _train_corrector(
     update_times: list[float] = []
     fd_error: float | None = None
     completed = True
+    stage_models: list[Any] = []
+    stage_boundaries: list[int] = []
 
-    for update in range(max_updates):
-        update_started = time.perf_counter()
-        trajectory_idx = int(rng.randint(train.shape[0]))
-        max_start = train.shape[1] - unroll - 1
-        start = int(rng.randint(max_start + 1)) if max_start > 0 else 0
-        targets = jnp.asarray(train[trajectory_idx, start : start + unroll + 1])
-
-        loss_fn = partial(
-            _window_loss,
-            targets=targets,
-            t=t,
-            ctx=ctx,
-            frame_steps=frame_steps,
-            velocity_scale=velocity_scale,
-            differentiate_solver=differentiate_solver,
-            loss_mode=loss_mode,
-            solver_loss_weight=solver_loss_weight,
-            loss_scale=loss_scale,
+    for stage_index, stage in enumerate(stages):
+        optimiser = optax.chain(
+            optax.clip_by_global_norm(clip_norm),
+            optax.adam(stage.lr),
         )
-
-        loss, grads = eqx.filter_value_and_grad(loss_fn)(model)
-        loss_value = float(loss)
-        grad_norm = float(optax.tree.norm(grads))
-        if not np.isfinite(loss_value) or not np.isfinite(grad_norm):
-            completed = False
-            break
-        if (
-            update == 0
-            and differentiate_solver
-            and bool(training.get("check_grad", True))
-        ):
-            fd_error = _directional_fd(
-                loss_fn,
-                model,
-                grads,
-                jax.random.PRNGKey(model_seed + 1),
-                epsilon=fd_epsilon,
+        for stage_update in range(stage.updates):
+            update_started = time.perf_counter()
+            trajectory_idx = int(rng.randint(train.shape[0]))
+            max_start = train.shape[1] - stage.unroll - 1
+            start = int(rng.randint(max_start + 1)) if max_start > 0 else 0
+            targets = jnp.asarray(
+                train[trajectory_idx, start : start + stage.unroll + 1]
             )
-        updates, opt_state = optimiser.update(
-            grads,
-            opt_state,
-            eqx.filter(model, eqx.is_inexact_array),
-        )
-        model = eqx.apply_updates(model, updates)
-        losses.append(loss_value)
-        grad_norms.append(grad_norm)
-        update_times.append(time.perf_counter() - update_started)
-    return model, losses, grad_norms, update_times, fd_error, completed
+
+            loss_fn = partial(
+                _window_loss,
+                targets=targets,
+                t=t,
+                ctx=ctx,
+                frame_steps=frame_steps,
+                velocity_scale=velocity_scale,
+                differentiate_solver=differentiate_solver,
+                loss_mode=loss_mode,
+                solver_loss_weight=solver_loss_weight,
+                loss_scale=loss_scale,
+            )
+
+            loss, grads = eqx.filter_value_and_grad(loss_fn)(model)
+            loss_value = float(loss)
+            grad_norm = float(optax.tree.norm(grads))
+            if not np.isfinite(loss_value) or not np.isfinite(grad_norm):
+                completed = False
+                break
+            if (
+                stage_index == len(stages) - 1
+                and stage_update == 0
+                and differentiate_solver
+                and bool(training.get("check_grad", True))
+            ):
+                fd_error = _directional_fd(
+                    loss_fn,
+                    model,
+                    grads,
+                    jax.random.PRNGKey(model_seed + 1),
+                    epsilon=fd_epsilon,
+                )
+            updates, opt_state = optimiser.update(
+                grads,
+                opt_state,
+                eqx.filter(model, eqx.is_inexact_array),
+            )
+            model = eqx.apply_updates(model, updates)
+            losses.append(loss_value)
+            grad_norms.append(grad_norm)
+            update_times.append(time.perf_counter() - update_started)
+        stage_models.append(model)
+        stage_boundaries.append(len(losses))
+        if not completed:
+            break
+    return _TrainingResult(
+        model=model,
+        losses=losses,
+        grad_norms=grad_norms,
+        update_times=update_times,
+        fd_error=fd_error,
+        completed=completed,
+        stage_models=tuple(stage_models),
+        stage_unrolls=tuple(stage.unroll for stage in stages[: len(stage_models)]),
+        stage_boundaries=tuple(stage_boundaries),
+        stage_learning_rates=tuple(stage.lr for stage in stages[: len(stage_models)]),
+    )
 
 
 def _evaluate_rollout(
@@ -937,6 +1025,7 @@ def _evaluate_rollout(
 class _ReferenceEvaluation(NamedTuple):
     first_rollout: np.ndarray | None
     errors: np.ndarray
+    correlations: np.ndarray
     final_states: np.ndarray
 
 
@@ -952,6 +1041,7 @@ def _evaluate_reference_set(
 ) -> _ReferenceEvaluation:
     """Evaluate several ICs, retaining the first rollout and every final state."""
     errors: list[list[float]] = []
+    correlations: list[list[float]] = []
     final_states: list[np.ndarray] = []
     first_rollout: np.ndarray | None = None
     for reference in references:
@@ -965,12 +1055,29 @@ def _evaluate_reference_set(
             corrected=corrected,
         )
         errors.append(reference_errors)
+        reference_correlations = []
+        for predicted, target in zip(rollout, reference, strict=True):
+            predicted_flat = np.asarray(predicted, dtype=np.float64).ravel()
+            target_flat = np.asarray(target, dtype=np.float64).ravel()
+            predicted_flat -= np.mean(predicted_flat)
+            target_flat -= np.mean(target_flat)
+            reference_correlations.append(
+                float(
+                    np.vdot(predicted_flat, target_flat).real
+                    / (
+                        np.linalg.norm(predicted_flat) * np.linalg.norm(target_flat)
+                        + 1e-12
+                    )
+                )
+            )
+        correlations.append(reference_correlations)
         final_states.append(rollout[-1])
         if first_rollout is None:
             first_rollout = rollout
     return _ReferenceEvaluation(
         first_rollout=first_rollout,
         errors=np.asarray(errors, dtype=np.float64),
+        correlations=np.asarray(correlations, dtype=np.float64),
         final_states=np.asarray(final_states),
     )
 
@@ -981,6 +1088,14 @@ def _first_unstable(errors: list[float], threshold: float) -> int:
         if not np.isfinite(error) or error > threshold:
             return idx
     return len(errors) - 1
+
+
+def _first_below(values: list[float], threshold: float) -> int:
+    """Return first frame below a quality threshold, or the completed horizon."""
+    for idx, value in enumerate(values):
+        if not np.isfinite(value) or value < threshold:
+            return idx
+    return len(values) - 1
 
 
 def _rollout_log_gain(
@@ -1062,10 +1177,13 @@ def _std(values: list[float]) -> float:
         "loss_seed_std",
         "loss_stop_gradient",
         "loss_stop_gradient_seed_std",
+        "loss_one_step",
         "grad_norm",
         "grad_norm_stop_gradient",
+        "grad_norm_one_step",
         "update_time",
         "update_time_stop_gradient",
+        "update_time_one_step",
         "error_corrected",
         "error_corrected_seed_std",
         "error_corrected_ic_std",
@@ -1077,11 +1195,30 @@ def _std(values: list[float]) -> float:
         "error_seen_corrected",
         "error_seen_stop_gradient",
         "error_seen_uncorrected",
+        "error_one_step",
+        "error_one_step_seed_std",
+        "error_one_step_ic_std",
+        "error_seen_one_step",
+        "correlation_corrected",
+        "correlation_stop_gradient",
+        "correlation_one_step",
+        "correlation_uncorrected",
         "rollout_log_gain_samples",
         "stop_gradient_log_gain_samples",
         "solver_vjp_log_lift_samples",
+        "one_step_rollout_log_gain_samples",
+        "unrolling_log_lift_samples",
+        "wig_over_one_log_lift_samples",
+        "curriculum_stage_unrolls",
+        "curriculum_stage_boundaries",
+        "curriculum_checkpoint_error_full",
+        "curriculum_checkpoint_error_full_seed_std",
+        "curriculum_checkpoint_error_nog",
+        "curriculum_checkpoint_error_nog_seed_std",
+        "curriculum_checkpoint_error_native",
         "rollout_corrected",
         "rollout_stop_gradient",
+        "rollout_one_step",
         "rollout_uncorrected",
         "reference_rollout",
     ),
@@ -1143,6 +1280,16 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             },
         }
     velocity_scale = float(np.sqrt(np.mean(train**2)) + 1e-8)
+    include_one_step = bool(training.get("include_one_step_baseline", False))
+    curriculum_stages = _training_stages(training)
+    checkpoint_trajectory_count = min(
+        int(evaluation.get("checkpoint_ic_trajectories", 2)),
+        test.shape[0],
+    )
+    checkpoint_rollout_frames = min(
+        int(evaluation.get("checkpoint_rollout_frames", test.shape[1] - 1)),
+        test.shape[1] - 1,
+    )
 
     configured_seeds = training.get("model_seeds")
     if configured_seeds is None:
@@ -1207,6 +1354,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     )
     first_uncorrected = uncorrected_eval.first_rollout
     uncorrected_errors_array = uncorrected_eval.errors
+    uncorrected_correlations_array = uncorrected_eval.correlations
     recurrent_final_states = uncorrected_eval.final_states
     seen_uncorrected_eval = _evaluate_reference_set(
         t,
@@ -1295,10 +1443,23 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     stop_gradient_training_walls: list[float] = []
     corrected_errors_by_seed: list[np.ndarray] = []
     stop_gradient_errors_by_seed: list[np.ndarray] = []
+    corrected_correlations_by_seed: list[np.ndarray] = []
+    stop_gradient_correlations_by_seed: list[np.ndarray] = []
     seen_corrected_errors_by_seed: list[np.ndarray] = []
     seen_stop_gradient_errors_by_seed: list[np.ndarray] = []
+    one_step_losses_by_seed: list[list[float]] = []
+    one_step_grad_norms_by_seed: list[list[float]] = []
+    one_step_update_times_by_seed: list[list[float]] = []
+    one_step_completed_by_seed: list[bool] = []
+    one_step_training_walls: list[float] = []
+    one_step_errors_by_seed: list[np.ndarray] = []
+    one_step_correlations_by_seed: list[np.ndarray] = []
+    seen_one_step_errors_by_seed: list[np.ndarray] = []
+    checkpoint_full_errors_by_seed: list[np.ndarray] = []
+    checkpoint_stop_errors_by_seed: list[np.ndarray] = []
     first_corrected: np.ndarray | None = None
     first_stop_gradient: np.ndarray | None = None
+    first_one_step: np.ndarray | None = None
 
     for seed_idx, model_seed in enumerate(model_seeds):
         seed_training = {
@@ -1309,14 +1470,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             "check_grad": bool(training.get("check_grad", True)) and seed_idx == 0,
         }
         started = time.perf_counter()
-        (
-            model,
-            losses,
-            grad_norms,
-            update_times,
-            fd_error,
-            completed,
-        ) = _train_corrector(
+        full_training = _train_corrector(
             t,
             ctx,
             train,
@@ -1327,17 +1481,16 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             differentiate_solver=True,
             model_seed=model_seed,
         )
+        model = full_training.model
+        losses = full_training.losses
+        grad_norms = full_training.grad_norms
+        update_times = full_training.update_times
+        fd_error = full_training.fd_error
+        completed = full_training.completed
         training_walls.append(time.perf_counter() - started)
 
         stop_gradient_started = time.perf_counter()
-        (
-            stop_gradient_model,
-            stop_gradient_losses,
-            stop_gradient_grad_norms,
-            stop_gradient_update_times,
-            _stop_gradient_fd_error,
-            stop_gradient_completed,
-        ) = _train_corrector(
+        stop_training = _train_corrector(
             t,
             ctx,
             train,
@@ -1348,7 +1501,54 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             differentiate_solver=False,
             model_seed=model_seed,
         )
+        stop_gradient_model = stop_training.model
+        stop_gradient_losses = stop_training.losses
+        stop_gradient_grad_norms = stop_training.grad_norms
+        stop_gradient_update_times = stop_training.update_times
+        stop_gradient_completed = stop_training.completed
         stop_gradient_training_walls.append(time.perf_counter() - stop_gradient_started)
+
+        one_step_model = None
+        one_step_training: _TrainingResult | None = None
+        if include_one_step:
+            one_step_updates = int(
+                training.get(
+                    "one_step_updates",
+                    sum(stage.updates for stage in curriculum_stages),
+                )
+            )
+            one_step_config = {
+                **training,
+                "unroll": 1,
+                "max_updates": one_step_updates,
+                "curriculum": [
+                    {
+                        "unroll": 1,
+                        "updates": one_step_updates,
+                        "lr": float(training.get("lr", 1e-4)),
+                    }
+                ],
+                "loss_mode": "mean",
+                "solver_loss_weight": 0.0,
+                "check_grad": False,
+            }
+            one_step_started = time.perf_counter()
+            one_step_training = _train_corrector(
+                t,
+                ctx,
+                train,
+                frame_steps=frame_steps,
+                training=one_step_config,
+                velocity_scale=velocity_scale,
+                loss_scale=training_loss_scale,
+                # With a true reference state at the beginning of every
+                # one-step sample, the solver output does not depend on model
+                # parameters. Stopping it is therefore mathematically exact.
+                differentiate_solver=False,
+                model_seed=model_seed,
+            )
+            one_step_training_walls.append(time.perf_counter() - one_step_started)
+            one_step_model = one_step_training.model
 
         corrected_eval = _evaluate_reference_set(
             t,
@@ -1392,6 +1592,68 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             corrected=True,
         )
         seen_seed_stop_gradient_errors = seen_stop_gradient_eval.errors
+        if one_step_model is not None and one_step_training is not None:
+            one_step_eval = _evaluate_reference_set(
+                t,
+                ctx,
+                one_step_model,
+                test,
+                frame_steps=frame_steps,
+                velocity_scale=velocity_scale,
+                corrected=True,
+            )
+            seen_one_step_eval = _evaluate_reference_set(
+                t,
+                ctx,
+                one_step_model,
+                seen_references,
+                frame_steps=frame_steps,
+                velocity_scale=velocity_scale,
+                corrected=True,
+            )
+            one_step_losses_by_seed.append(one_step_training.losses)
+            one_step_grad_norms_by_seed.append(one_step_training.grad_norms)
+            one_step_update_times_by_seed.append(one_step_training.update_times)
+            one_step_completed_by_seed.append(one_step_training.completed)
+            one_step_errors_by_seed.append(one_step_eval.errors)
+            one_step_correlations_by_seed.append(one_step_eval.correlations)
+            seen_one_step_errors_by_seed.append(seen_one_step_eval.errors)
+            if seed_idx == 0:
+                first_one_step = one_step_eval.first_rollout
+
+        if len(full_training.stage_models) > 1:
+            checkpoint_references = test[
+                :checkpoint_trajectory_count, : checkpoint_rollout_frames + 1
+            ]
+            full_checkpoint_errors: list[np.ndarray] = []
+            stop_checkpoint_errors: list[np.ndarray] = []
+            for full_stage_model, stop_stage_model in zip(
+                full_training.stage_models,
+                stop_training.stage_models,
+                strict=True,
+            ):
+                full_stage_eval = _evaluate_reference_set(
+                    t,
+                    ctx,
+                    full_stage_model,
+                    checkpoint_references,
+                    frame_steps=frame_steps,
+                    velocity_scale=velocity_scale,
+                    corrected=True,
+                )
+                stop_stage_eval = _evaluate_reference_set(
+                    t,
+                    ctx,
+                    stop_stage_model,
+                    checkpoint_references,
+                    frame_steps=frame_steps,
+                    velocity_scale=velocity_scale,
+                    corrected=True,
+                )
+                full_checkpoint_errors.append(np.mean(full_stage_eval.errors, axis=0))
+                stop_checkpoint_errors.append(np.mean(stop_stage_eval.errors, axis=0))
+            checkpoint_full_errors_by_seed.append(np.stack(full_checkpoint_errors))
+            checkpoint_stop_errors_by_seed.append(np.stack(stop_checkpoint_errors))
         if seed_idx == 0:
             first_corrected = corrected_rollout
             first_stop_gradient = stop_gradient_rollout
@@ -1408,11 +1670,22 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         stop_gradient_completed_by_seed.append(stop_gradient_completed)
         corrected_errors_by_seed.append(seed_corrected_errors)
         stop_gradient_errors_by_seed.append(seed_stop_gradient_errors)
+        corrected_correlations_by_seed.append(corrected_eval.correlations)
+        stop_gradient_correlations_by_seed.append(stop_gradient_eval.correlations)
         seen_corrected_errors_by_seed.append(seen_seed_corrected_errors)
         seen_stop_gradient_errors_by_seed.append(seen_seed_stop_gradient_errors)
 
     corrected_errors_array = np.stack(corrected_errors_by_seed)
     stop_gradient_errors_array = np.stack(stop_gradient_errors_by_seed)
+    corrected_correlation = np.mean(
+        np.stack(corrected_correlations_by_seed),
+        axis=(0, 1),
+    )
+    stop_gradient_correlation = np.mean(
+        np.stack(stop_gradient_correlations_by_seed),
+        axis=(0, 1),
+    )
+    uncorrected_correlation = np.mean(uncorrected_correlations_array, axis=0)
     seen_corrected_errors_array = np.stack(seen_corrected_errors_by_seed)
     seen_stop_gradient_errors_array = np.stack(seen_stop_gradient_errors_by_seed)
     corrected_error, corrected_error_seed_std, corrected_error_ic_std = (
@@ -1433,12 +1706,35 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         _seen_stop_gradient_error_seed_std,
         _seen_stop_gradient_error_ic_std,
     ) = _ensemble_curve_stats(seen_stop_gradient_errors_array)
+    one_step_error: np.ndarray | None = None
+    one_step_error_seed_std: np.ndarray | None = None
+    one_step_error_ic_std: np.ndarray | None = None
+    seen_one_step_error: np.ndarray | None = None
+    one_step_errors_array: np.ndarray | None = None
+    one_step_correlation: np.ndarray | None = None
+    if include_one_step:
+        one_step_errors_array = np.stack(one_step_errors_by_seed)
+        (
+            one_step_error,
+            one_step_error_seed_std,
+            one_step_error_ic_std,
+        ) = _ensemble_curve_stats(one_step_errors_array)
+        seen_one_step_error = _ensemble_curve_stats(
+            np.stack(seen_one_step_errors_by_seed)
+        )[0]
+        one_step_correlation = np.mean(
+            np.stack(one_step_correlations_by_seed),
+            axis=(0, 1),
+        )
     losses = _mean_curve(losses_by_seed)
     stop_gradient_losses = _mean_curve(stop_gradient_losses_by_seed)
+    one_step_losses = _mean_curve(one_step_losses_by_seed)
     grad_norms = _mean_curve(grad_norms_by_seed)
     stop_gradient_grad_norms = _mean_curve(stop_gradient_grad_norms_by_seed)
+    one_step_grad_norms = _mean_curve(one_step_grad_norms_by_seed)
     update_times = _mean_curve(update_times_by_seed)
     stop_gradient_update_times = _mean_curve(stop_gradient_update_times_by_seed)
+    one_step_update_times = _mean_curve(one_step_update_times_by_seed)
     loss_seed_std = (
         np.std(np.stack([curve[: len(losses)] for curve in losses_by_seed]), axis=0)
         if losses.size
@@ -1459,10 +1755,12 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     )
     training_wall = float(np.sum(training_walls))
     stop_gradient_training_wall = float(np.sum(stop_gradient_training_walls))
+    one_step_training_wall = float(np.sum(one_step_training_walls))
     total_updates = sum(len(curve) for curve in losses_by_seed)
     stop_gradient_total_updates = sum(
         len(curve) for curve in stop_gradient_losses_by_seed
     )
+    one_step_total_updates = sum(len(curve) for curve in one_step_losses_by_seed)
     steady_update_times = [
         value
         for seed_times in update_times_by_seed
@@ -1471,6 +1769,11 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     stop_gradient_steady_update_times = [
         value
         for seed_times in stop_gradient_update_times_by_seed
+        for value in (seed_times[1:] if len(seed_times) > 1 else seed_times)
+    ]
+    one_step_steady_update_times = [
+        value
+        for seed_times in one_step_update_times_by_seed
         for value in (seed_times[1:] if len(seed_times) > 1 else seed_times)
     ]
 
@@ -1505,7 +1808,24 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     rollout_log_gain = float(np.mean(rollout_log_gain_samples))
     stop_gradient_log_gain = float(np.mean(stop_gradient_log_gain_samples))
     solver_vjp_log_lift = float(np.mean(solver_vjp_log_lift_samples))
+    one_step_rollout_log_gain_samples: np.ndarray | None = None
+    unrolling_log_lift_samples: np.ndarray | None = None
+    wig_over_one_log_lift_samples: np.ndarray | None = None
+    if one_step_errors_array is not None:
+        one_step_rollout_log_gain_samples = _rollout_log_gain_samples(
+            uncorrected_errors_array,
+            one_step_errors_array,
+        )
+        unrolling_log_lift_samples = _rollout_log_gain_samples(
+            one_step_errors_array,
+            stop_gradient_errors_array,
+        )
+        wig_over_one_log_lift_samples = _rollout_log_gain_samples(
+            one_step_errors_array,
+            corrected_errors_array,
+        )
     threshold = float(evaluation.get("stable_error_threshold", 1.0))
+    correlation_threshold = float(evaluation.get("correlation_threshold", 0.95))
     matched_horizon_frame = min(train.shape[1] - 1, test.shape[1] - 1)
     long_horizon_frame = test.shape[1] - 1
     seen_matched_error = float(seen_corrected_error[matched_horizon_frame])
@@ -1525,6 +1845,36 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         if stop_gradient_steady_update_times
         else None
     )
+    one_step_median_update_time = (
+        float(np.median(one_step_steady_update_times))
+        if one_step_steady_update_times
+        else None
+    )
+    stage_boundaries = np.cumsum(
+        [stage.updates for stage in curriculum_stages],
+        dtype=np.int64,
+    )
+    recurrent_solver_intervals_per_seed = int(
+        sum(stage.unroll * stage.updates for stage in curriculum_stages)
+    )
+    checkpoint_full_error: np.ndarray | None = None
+    checkpoint_stop_error: np.ndarray | None = None
+    checkpoint_full_seed_std: np.ndarray | None = None
+    checkpoint_stop_seed_std: np.ndarray | None = None
+    checkpoint_native_error: np.ndarray | None = None
+    if checkpoint_full_errors_by_seed:
+        full_checkpoints = np.stack(checkpoint_full_errors_by_seed)
+        stop_checkpoints = np.stack(checkpoint_stop_errors_by_seed)
+        checkpoint_full_error = np.mean(full_checkpoints, axis=0)
+        checkpoint_stop_error = np.mean(stop_checkpoints, axis=0)
+        checkpoint_full_seed_std = np.std(full_checkpoints, axis=0)
+        checkpoint_stop_seed_std = np.std(stop_checkpoints, axis=0)
+        checkpoint_native_error = np.mean(
+            uncorrected_errors_array[
+                :checkpoint_trajectory_count, : checkpoint_rollout_frames + 1
+            ],
+            axis=0,
+        )
 
     metrics = {
         **reference_audit,
@@ -1634,6 +1984,25 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             uncorrected_error.tolist(), threshold
         )
         * interval_time,
+        "final_rollout_correlation": float(corrected_correlation[-1]),
+        "stop_gradient_final_rollout_correlation": float(stop_gradient_correlation[-1]),
+        "uncorrected_final_rollout_correlation": float(uncorrected_correlation[-1]),
+        "correlation_threshold": correlation_threshold,
+        "correlation_horizon": _first_below(
+            corrected_correlation.tolist(),
+            correlation_threshold,
+        )
+        * interval_time,
+        "stop_gradient_correlation_horizon": _first_below(
+            stop_gradient_correlation.tolist(),
+            correlation_threshold,
+        )
+        * interval_time,
+        "uncorrected_correlation_horizon": _first_below(
+            uncorrected_correlation.tolist(),
+            correlation_threshold,
+        )
+        * interval_time,
         "initial_train_loss": float(losses[0]) if losses.size else None,
         "final_train_loss": float(losses[-1]) if losses.size else None,
         "best_train_loss": float(np.min(losses)) if losses.size else None,
@@ -1736,14 +2105,28 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         "n_test_trajectories": int(test.shape[0]),
         "n_seen_ic_evaluation_trajectories": seen_trajectory_count,
         "training_frames": int(train.shape[1] - 1),
-        "training_unroll": int(training.get("unroll", 4)),
+        "training_unroll": max(stage.unroll for stage in curriculum_stages),
+        "training_curriculum": [
+            {
+                "unroll": stage.unroll,
+                "updates": stage.updates,
+                "lr": stage.lr,
+            }
+            for stage in curriculum_stages
+        ],
+        "training_stage_boundaries": stage_boundaries.tolist(),
+        "training_solver_intervals_per_seed": recurrent_solver_intervals_per_seed,
+        "training_solver_intervals_total": recurrent_solver_intervals_per_seed
+        * len(model_seeds),
         "training_loss_mode": str(training.get("loss_mode", "mean")),
         "training_solver_loss_weight": float(training.get("solver_loss_weight", 0.1)),
         "training_loss_normalization": loss_normalization,
         "training_loss_scale": training_loss_scale,
         "matched_horizon_time": matched_horizon_frame * interval_time,
         "visualization_model_seed": model_seeds[0],
-        "completed": all(completed_by_seed) and all(stop_gradient_completed_by_seed),
+        "completed": all(completed_by_seed)
+        and all(stop_gradient_completed_by_seed)
+        and (not include_one_step or all(one_step_completed_by_seed)),
         "dataset_hash": dataset_hash,
         "reference_kind": reference_kind,
         "correction_intervals": int(test.shape[1] - 1),
@@ -1751,6 +2134,142 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         "rollout_final_time": interval_time * int(test.shape[1] - 1),
         "native_state_threading": _supports_native_state(t),
     }
+    if (
+        one_step_error is not None
+        and one_step_error_seed_std is not None
+        and one_step_error_ic_std is not None
+        and one_step_rollout_log_gain_samples is not None
+        and unrolling_log_lift_samples is not None
+        and wig_over_one_log_lift_samples is not None
+    ):
+        one_step_mean_error = float(np.mean(one_step_error[1:]))
+        one_step_log_gain = float(np.mean(one_step_rollout_log_gain_samples))
+        unrolling_log_lift = float(np.mean(unrolling_log_lift_samples))
+        wig_over_one_log_lift = float(np.mean(wig_over_one_log_lift_samples))
+        metrics.update(
+            {
+                "one_step_final_rollout_error": float(one_step_error[-1]),
+                "one_step_final_rollout_error_seed_std": float(
+                    one_step_error_seed_std[-1]
+                ),
+                "one_step_final_rollout_error_ic_std": float(one_step_error_ic_std[-1]),
+                "one_step_mean_rollout_error": one_step_mean_error,
+                "one_step_geometric_error_reduction": float(np.exp(one_step_log_gain)),
+                "one_step_rollout_log_gain_seed_std": _std(
+                    np.mean(one_step_rollout_log_gain_samples, axis=1).tolist()
+                ),
+                "one_step_rollout_log_gain_ic_std": _std(
+                    np.mean(one_step_rollout_log_gain_samples, axis=0).tolist()
+                ),
+                "unrolling_geometric_lift_nog_over_one": float(
+                    np.exp(unrolling_log_lift)
+                ),
+                "unrolling_log_lift_seed_std": _std(
+                    np.mean(unrolling_log_lift_samples, axis=1).tolist()
+                ),
+                "unrolling_log_lift_ic_std": _std(
+                    np.mean(unrolling_log_lift_samples, axis=0).tolist()
+                ),
+                "wig_geometric_lift_over_one": float(np.exp(wig_over_one_log_lift)),
+                "wig_over_one_log_lift_seed_std": _std(
+                    np.mean(wig_over_one_log_lift_samples, axis=1).tolist()
+                ),
+                "wig_over_one_log_lift_ic_std": _std(
+                    np.mean(wig_over_one_log_lift_samples, axis=0).tolist()
+                ),
+                "one_step_seen_ic_matched_horizon_error": float(
+                    seen_one_step_error[matched_horizon_frame]
+                )
+                if seen_one_step_error is not None
+                else None,
+                "one_step_heldout_ic_matched_horizon_error": float(
+                    one_step_error[matched_horizon_frame]
+                ),
+                "one_step_stable_horizon": _first_unstable(
+                    one_step_error.tolist(),
+                    threshold,
+                )
+                * interval_time,
+                "one_step_final_rollout_correlation": float(one_step_correlation[-1])
+                if one_step_correlation is not None
+                else None,
+                "one_step_correlation_horizon": _first_below(
+                    one_step_correlation.tolist(),
+                    correlation_threshold,
+                )
+                * interval_time
+                if one_step_correlation is not None
+                else None,
+                "one_step_initial_train_loss": float(one_step_losses[0])
+                if one_step_losses.size
+                else None,
+                "one_step_final_train_loss": float(one_step_losses[-1])
+                if one_step_losses.size
+                else None,
+                "one_step_best_train_loss": float(np.min(one_step_losses))
+                if one_step_losses.size
+                else None,
+                "one_step_n_updates": len(one_step_losses),
+                "one_step_total_optimizer_updates": one_step_total_updates,
+                "one_step_training_wall_time_s": one_step_training_wall,
+                "one_step_seconds_per_update": one_step_training_wall
+                / max(one_step_total_updates, 1),
+                "one_step_median_update_time_s": one_step_median_update_time,
+                "one_step_final_grad_norm": float(one_step_grad_norms[-1])
+                if one_step_grad_norms.size
+                else None,
+                "one_step_training_solver_intervals_per_seed": len(one_step_losses),
+                "one_step_training_solver_intervals_total": one_step_total_updates,
+                "one_step_final_divergence_rms": divergence_rms(
+                    first_one_step[-1],
+                    ctx.domain_extent,
+                )
+                if first_one_step is not None
+                else None,
+                "one_step_final_energy_ratio_to_reference": kinetic_energy(
+                    first_one_step[-1]
+                )
+                / (kinetic_energy(test[0, -1]) + 1e-12)
+                if first_one_step is not None
+                else None,
+            }
+        )
+    if (
+        checkpoint_full_error is not None
+        and checkpoint_stop_error is not None
+        and checkpoint_native_error is not None
+    ):
+        metrics["curriculum_checkpoint_summary"] = [
+            {
+                "unroll": stage.unroll,
+                "updates_cumulative": int(stage_boundaries[index]),
+                "full_geometric_error_reduction": float(
+                    np.exp(
+                        _rollout_log_gain(
+                            checkpoint_native_error,
+                            checkpoint_full_error[index],
+                        )
+                    )
+                ),
+                "nog_geometric_error_reduction": float(
+                    np.exp(
+                        _rollout_log_gain(
+                            checkpoint_native_error,
+                            checkpoint_stop_error[index],
+                        )
+                    )
+                ),
+                "wig_geometric_lift_over_nog": float(
+                    np.exp(
+                        _rollout_log_gain(
+                            checkpoint_stop_error[index],
+                            checkpoint_full_error[index],
+                        )
+                    )
+                ),
+            }
+            for index, stage in enumerate(curriculum_stages)
+        ]
     snapshots = {
         "loss": losses,
         "loss_seed_std": np.asarray(loss_seed_std, dtype=np.float32),
@@ -1807,12 +2326,99 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             seen_uncorrected_error,
             dtype=np.float32,
         ),
+        "correlation_corrected": np.asarray(
+            corrected_correlation,
+            dtype=np.float32,
+        ),
+        "correlation_stop_gradient": np.asarray(
+            stop_gradient_correlation,
+            dtype=np.float32,
+        ),
+        "correlation_uncorrected": np.asarray(
+            uncorrected_correlation,
+            dtype=np.float32,
+        ),
         "rollout_log_gain_samples": rollout_log_gain_samples.astype(np.float32),
         "stop_gradient_log_gain_samples": stop_gradient_log_gain_samples.astype(
             np.float32
         ),
         "solver_vjp_log_lift_samples": solver_vjp_log_lift_samples.astype(np.float32),
     }
+    if (
+        one_step_error is not None
+        and one_step_error_seed_std is not None
+        and one_step_error_ic_std is not None
+        and seen_one_step_error is not None
+        and one_step_rollout_log_gain_samples is not None
+        and unrolling_log_lift_samples is not None
+        and wig_over_one_log_lift_samples is not None
+    ):
+        snapshots.update(
+            {
+                "loss_one_step": one_step_losses,
+                "grad_norm_one_step": one_step_grad_norms,
+                "update_time_one_step": one_step_update_times,
+                "error_one_step": np.asarray(one_step_error, dtype=np.float32),
+                "error_one_step_seed_std": np.asarray(
+                    one_step_error_seed_std,
+                    dtype=np.float32,
+                ),
+                "error_one_step_ic_std": np.asarray(
+                    one_step_error_ic_std,
+                    dtype=np.float32,
+                ),
+                "error_seen_one_step": np.asarray(
+                    seen_one_step_error,
+                    dtype=np.float32,
+                ),
+                "correlation_one_step": np.asarray(
+                    one_step_correlation,
+                    dtype=np.float32,
+                )
+                if one_step_correlation is not None
+                else np.asarray([], dtype=np.float32),
+                "one_step_rollout_log_gain_samples": (
+                    one_step_rollout_log_gain_samples.astype(np.float32)
+                ),
+                "unrolling_log_lift_samples": unrolling_log_lift_samples.astype(
+                    np.float32
+                ),
+                "wig_over_one_log_lift_samples": (
+                    wig_over_one_log_lift_samples.astype(np.float32)
+                ),
+            }
+        )
+    if (
+        checkpoint_full_error is not None
+        and checkpoint_stop_error is not None
+        and checkpoint_full_seed_std is not None
+        and checkpoint_stop_seed_std is not None
+        and checkpoint_native_error is not None
+    ):
+        snapshots.update(
+            {
+                "curriculum_stage_unrolls": np.asarray(
+                    [stage.unroll for stage in curriculum_stages],
+                    dtype=np.int32,
+                ),
+                "curriculum_stage_boundaries": stage_boundaries.astype(np.int32),
+                "curriculum_checkpoint_error_full": checkpoint_full_error.astype(
+                    np.float32
+                ),
+                "curriculum_checkpoint_error_full_seed_std": (
+                    checkpoint_full_seed_std.astype(np.float32)
+                ),
+                "curriculum_checkpoint_error_nog": checkpoint_stop_error.astype(
+                    np.float32
+                ),
+                "curriculum_checkpoint_error_nog_seed_std": (
+                    checkpoint_stop_seed_std.astype(np.float32)
+                ),
+                "curriculum_checkpoint_error_native": checkpoint_native_error.astype(
+                    np.float32
+                ),
+            }
+        )
     if (
         first_corrected is not None
         and first_stop_gradient is not None
@@ -1821,6 +2427,8 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         snapshots["rollout_corrected"] = first_corrected
         snapshots["rollout_stop_gradient"] = first_stop_gradient
         snapshots["rollout_uncorrected"] = first_uncorrected
+        if first_one_step is not None:
+            snapshots["rollout_one_step"] = first_one_step
     if reference_kind == "solver_self_refined":
         snapshots["reference_rollout"] = test[0]
         shared = {

--- a/mosaic/benchmarks/problems/shared/optimization.py
+++ b/mosaic/benchmarks/problems/shared/optimization.py
@@ -190,7 +190,7 @@ def _run_lbfgs(
         rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
         try:
             live = len(jax.live_arrays())
-        except Exception:  # noqa: BLE001 - optional diagnostics must never abort
+        except Exception:
             live = -1
         print(
             f"[lbfgs-diag] iter={i:3d} {label:10s} RSS={rss_kb / 1024:.1f}MiB live_arrays={live}"

--- a/mosaic/benchmarks/problems/shared/optimization.py
+++ b/mosaic/benchmarks/problems/shared/optimization.py
@@ -156,16 +156,18 @@ def _run_lbfgs(
 
     ``clip_fn`` projects ``x`` back into the feasible set after each
     update (e.g. ``jnp.clip(x, x_min, 1.0)`` for density fields).
-    ``grad_proj_fn``, when provided, is called on the gradient (numpy)
+    ``grad_proj_fn``, when provided, is called on the JAX gradient
     before the L-BFGS update — used by velocity-field optimisation to
     project onto the divergence-free subspace (Helmholtz).
 
-    The ``lr``, ``patience``, ``record_diagnostics``, and ``div_fn``
-    parameters are accepted but ignored, so call sites that pass them
-    work without modification.
+    When ``record_diagnostics`` and ``div_fn`` are provided, the divergence
+    of the gradient used by L-BFGS and of the updated iterate are recorded
+    after every step. The ``lr`` and ``patience`` parameters are accepted
+    but ignored so the call signature remains compatible with
+    :func:`_run_optim`.
 
-    Returns ``(final_x, losses, diag)`` where ``diag`` is
-    ``{"grad_norms": [...]}``. Shape matches :func:`_run_optim`.
+    Returns ``(final_x, losses, diag)`` with the same diagnostic shape as
+    :func:`_run_optim`.
     """
     if has_aux:
 
@@ -188,7 +190,7 @@ def _run_lbfgs(
         rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
         try:
             live = len(jax.live_arrays())
-        except Exception:
+        except Exception:  # noqa: BLE001 - optional diagnostics must never abort
             live = -1
         print(
             f"[lbfgs-diag] iter={i:3d} {label:10s} RSS={rss_kb / 1024:.1f}MiB live_arrays={live}"
@@ -219,7 +221,7 @@ def _run_lbfgs(
         x = optax.apply_updates(x, updates)
         if clip_fn is not None:
             x = clip_fn(x)
-        return x, opt_state, value, grad_norm, aux
+        return x, opt_state, value, grad_norm, aux, grad
 
     step = jax.jit(_step_body)
 
@@ -227,12 +229,19 @@ def _run_lbfgs(
     x = init_x
     losses: list[float] = []
     grad_norms: list[float] = []
+    diag: dict[str, Any] = {"grad_norms": grad_norms}
+    if record_diagnostics:
+        diag["grad_divs"] = [] if div_fn else None
+        diag["ic_divs"] = [] if div_fn else None
     _probe("init", -1)
     for i in range(max_iters):
-        x, opt_state, value, grad_norm, aux = step(x, opt_state)
+        x, opt_state, value, grad_norm, aux, grad = step(x, opt_state)
         if has_aux:
             _append_aux(aux_history, aux)
         grad_norms.append(float(grad_norm))
+        if record_diagnostics and div_fn is not None:
+            diag["grad_divs"].append(div_fn(np.asarray(grad)))
+            diag["ic_divs"].append(div_fn(np.asarray(x)))
         loss_val = float(value)
         losses.append(loss_val)
         _probe("after-step", i)
@@ -245,4 +254,4 @@ def _run_lbfgs(
             log_fn(i + 1, loss_val)
         if grad_norms[-1] < 1e-7:
             break
-    return x, losses, {"grad_norms": grad_norms}
+    return x, losses, diag

--- a/mosaic/benchmarks/problems/shared/plots/solver_styles.py
+++ b/mosaic/benchmarks/problems/shared/plots/solver_styles.py
@@ -29,6 +29,7 @@ SOLVER_STYLES: dict[str, dict[str, Any]] = {
     "pict": {"color": "#AA44AA", "linestyle": (0, (5, 1)), "marker": "v"},
     "warp_ns": {"color": "#EE7733", "linestyle": (0, (1, 1)), "marker": "X"},
     "xlb": {"color": "#66CCEE", "linestyle": (0, (3, 1, 1, 1)), "marker": "P"},
+    "xlb_3d_surrogate": {"color": "#CC3311", "linestyle": "--", "marker": "*"},
     "exponax": {"color": "#33AA99", "linestyle": "-", "marker": "o"},
     # ── Structural mechanics ─────────────────────────────────────────────
     "jax_fem": {"color": "#4477AA", "linestyle": "-.", "marker": "o"},

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -70,6 +70,17 @@ the shared viscous baseline it is 0.9861, while the XLB nonlinear residual has
 81.2% of the total Jacobian Frobenius norm. The restricted conditioning result
 must not be generalized to the full 12,288-dimensional input space.
 
+On the exact self-recovery benchmark, projected L-BFGS recovers the three ICs
+to 6.97%, 7.85%, and 9.54% relative L2 error (8.12% mean), compared with
+4.70%, 5.02%, and 5.94% for XLB (5.22% mean).
+
+Warm in-process RTX 5090 medians are 8.09 ms for the 20-macro-step forward
+rollout and 16.81 ms for its end-to-end VJP. XLB takes 4.81 ms and 14.37 ms on
+the same task. Unlike the replaced direct IC-to-final checkpoint, the
+autoregressive surrogate is therefore not a kernel-level speedup: repeatedly
+applying the shared operator makes it 1.68× slower for forward and 1.17×
+slower for VJP.
+
 ## Limitation: XLB-target inversion
 
 Self-recovery follows the benchmark contract: each solver produces and inverts

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -91,6 +91,12 @@ the shared viscous baseline it is 0.9941, while the XLB nonlinear residual has
 must not be generalized to the full 12,288-dimensional input space, and the
 similar scalar condition numbers do not establish Jacobian equality.
 
+Against the 4,096-trajectory checkpoint under this same restricted audit,
+increasing the dataset changes the surrogate condition number from 7.740 to
+7.142 and the Gauss–Newton condition number from 59.98 to 51.05. The
+restricted-Jacobian Frobenius relative error improves from 13.50% to 8.84%
+and cosine from 0.9914 to 0.9961.
+
 The paper's conditioning protocol instead retains the complete raw velocity
 state, constructs one Jacobian row per output degree of freedom by sequential
 VJP, and applies a dense SVD. Because this solver is fixed at `N=16`, the
@@ -106,6 +112,12 @@ and the dense matrices. This adapted fixed-task audit is distinct from the
 paper's native `N=8` TGV physics; an XLB control at those native settings is
 reported separately.
 
+The paper-style comparison is essentially unchanged by scaling the training
+set: the 4k/16k Frobenius errors are 32.98%/32.94%, while the
+float32-resolved condition numbers are `4.89e3`/`5.45e3`. Their raw condition
+numbers are `3.75e10`/`7.48e10`, so the unresolved spectral tail becomes
+worse even as the restricted Jacobian improves.
+
 The larger dataset improves excluded-seed forward error from 7.473% to 4.309%
 and full-spectrum JVP error from 38.28% to 26.00%; validation and held-out
 errors improve together, so the observed inverse-model gap is not evidence of
@@ -114,6 +126,20 @@ the amplitude gate on the learned correction: at the zero-velocity cold start,
 the correction is second-order and the full model's first derivative is fixed
 by the viscous skip. Consequently, more trajectory data cannot correct the
 measured 49.34% radial JVP error at zero, where recovery begins.
+
+End-to-end VJPs were also checked against central finite differences on the
+exact recovery physics, using three IC seeds, ten shared unit-norm random
+directions per seed, and a 12-point relative-ε sweep. For the paper's
+energy-like objective `sum(u_T²)` at the true IC, the best aggregate median
+directional error is `6.63e-3` for the float32 surrogate versus `6.77e-6` for
+XLB; the corresponding mean direction cosines are 0.999984 and effectively
+1.0. For the actual self-recovery MSE at the zero cold start, the surrogate is
+more FD-consistent: its best median error is `2.56e-4` with mean cosine
+1.000000, versus `1.32e-1` and 0.991669 for XLB. The surrogate recovery
+failure is therefore not caused by an incorrect VJP implementation: finite
+differences verify the derivative of the learned forward map, while the
+inverse-path diagnostic shows that this internally accurate derivative points
+toward the wrong learned inverse basin.
 
 Both optimizer variants from the paper were run on the exact self-recovery
 benchmark. With unconstrained L-BFGS, the surrogate recovers the three ICs to
@@ -125,14 +151,21 @@ objective, true IC error, and optimized-IC divergence histories are recorded
 for PhiFlow, XLB, Warp-NS, Exponax, and the surrogate.
 
 The 16,384-trajectory checkpoint is therefore a better forward model but a
-worse global inverse than the 4,096-trajectory checkpoint. The initial
-self-target descent direction at exactly zero has nearly unchanged mean
-cosine with the direction to the true IC (0.845 versus 0.847). Immediately
-away from zero, however, the larger model's mean alignment falls to 0.419 at
-IC amplitude 0.05 and 0.150 at amplitude 0.10, versus 0.825 and 0.807 for the
-smaller checkpoint. Forward-only rollout selection does not constrain this
-off-manifold inverse-gradient geometry; similar conditioning at the true IC
-therefore does not predict recovery from the zero cold start.
+worse global inverse than the 4,096-trajectory checkpoint. Under complete
+matched runs, the smaller checkpoint reaches 8.10% mean IC error with L-BFGS
+and 8.12% with projected L-BFGS, versus 16.70% for both variants with the
+larger checkpoint. The seed-0 final objectives are nevertheless comparable:
+`1.28e-8`/`1.33e-8` for the 4k checkpoint and `1.15e-8`/`1.18e-8` for the 16k
+checkpoint (unconstrained/projected). The 16k seed-0 final divergence is also
+slightly lower, at `1.49e-2`/`1.43e-2` versus `1.77e-2`/`1.77e-2`.
+
+The initial self-target descent direction at exactly zero has nearly
+unchanged mean cosine with the direction to the true IC (0.845 versus 0.847).
+Immediately away from zero, however, the larger model's mean alignment falls
+to 0.419 at IC amplitude 0.05 and 0.150 at amplitude 0.10, versus 0.825 and
+0.807 for the smaller checkpoint. Forward-only rollout selection does not
+constrain this off-manifold inverse-gradient geometry; similar conditioning
+at the true IC therefore does not predict recovery from the zero cold start.
 
 Warm packaged in-process RTX 5090 medians are 7.24 ms for the 20-macro-step
 forward rollout and 14.78 ms for its end-to-end VJP. XLB takes 4.81 ms and
@@ -156,5 +189,6 @@ be presented as a drop-in inverse model for XLB observations.
 
 The draft PR contains both L-BFGS recovery variants, per-iteration loss, IC
 error and divergence histories, full-field plots, animation, timing
-decomposition, restricted and paper-protocol Jacobian spectra, and external
-offline artifact provenance.
+decomposition, 4k/16k restricted and paper-protocol Jacobian spectra, the
+inverse-gradient diagnostic, finite-difference U-curves, and external offline
+artifact provenance.

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -29,15 +29,17 @@ the teacher is never restarted from equilibrium at macro-step boundaries.
 
 ## Training provenance
 
-`generate_trajectories.py`, `training_data.py`, `train.py`, and the shared
-`surrogate_model.py` are packaged with the Tesseract. The generator must run
-against the XLB teacher API; cluster submission and container orchestration
-remain external. The packaged weights were trained from 4,096 native XLB KBC
-D3Q27 trajectories, split 3,072/512/512 for training/validation/test. Each
-trajectory contains the IC plus 20 full-field snapshots, one every five XLB
-steps. The final generated snapshot matched the canonical 100-step float32
-teacher call with maximum absolute difference zero. Benchmark IC seeds 0, 1,
-and 2 were excluded.
+`generate_trajectories.py`, `training_data.py`, and `train.py` live beside the
+Tesseract source for reproducibility but are not copied into its runtime
+image. The generator must run against the XLB teacher API; cluster submission
+and container orchestration remain external. The runtime image contains only
+the inference API, shared model definition, and weights. The packaged weights
+were trained from 16,384 native XLB KBC D3Q27 trajectories, split
+12,288/2,048/2,048 for
+training/validation/test. Each trajectory contains the IC plus 20 full-field
+snapshots, one every five XLB steps. The final generated snapshot matched the
+canonical 100-step float32 teacher call with maximum absolute difference zero.
+Benchmark IC seeds 0, 1, and 2 were excluded.
 
 Training used autoregressive unroll curriculum
 `1 → 2 → 4 → 8 → 12 → 20`, followed by a full-20-step fine-tune. The
@@ -46,9 +48,9 @@ distribution contains random divergence-free fields around the benchmark's
 amplitudes from zero to 1.25.
 
 The native trajectory dataset SHA-256 is
-`f94390c512c44d893581017007720077d85f2c153d28d8841630e0adc1e60dc8`.
+`4836fba4e6a8524af7a552c5977721118e726afa21db9a9f4d0b612a879a0005`.
 The packaged checkpoint SHA-256 is
-`03178cee7457849e28ecd4f6f97bfa70b111cebedc0847f882d8362abf493835`.
+`1ea04a7333981d1bfb836461d6fd6d89ae12f31c64ea40701c2607f03fb4107f`.
 
 The reproducible program boundary is:
 
@@ -69,24 +71,25 @@ command uses the model definition that the inference API imports.
 
 All experiments were run offline through the shared Slurm and Pyxis/Enroot
 cluster path. On the three excluded recovery seeds, mean final-field relative
-L2 error is 7.473% and mean field cosine is 0.997619. Across the 491 nonzero
-held-out test trajectories, mean final-step relative L2 error is 9.905%.
+L2 error is 4.309% and mean field cosine is 0.999076. Across the 1,982 nonzero
+held-out test trajectories, mean final-step relative L2 error is 7.219%.
 
 Directional derivatives were evaluated end to end through all 20 shared
 operator applications. On low-frequency projected directions (`|k|≤4`), mean
-JVP cosine is 0.9846 and relative L2 error is 17.64%. On projected white
-full-spectrum directions, the stricter values are 0.9253 and 38.28%.
+JVP cosine is 0.9811 and relative L2 error is 18.24%. On projected white
+full-spectrum directions, the stricter values are 0.9654 and 26.00%.
 Subtracting the exact full-horizon viscous-diffusion derivative leaves
-nonlinear-residual JVP cosines of 0.9752 and 0.9757, respectively.
+nonlinear-residual JVP cosines of 0.9717 and 0.9881, respectively.
 
 The full-output Jacobian was also evaluated on the complete 512-dimensional
 real divergence-free Fourier subspace through `|k|≤4`. Across the three
-recovery ICs, mean condition number is 7.740 for the surrogate versus 6.864
-for XLB; the corresponding Gauss–Newton condition numbers are 59.98 and
-47.17. Total restricted-Jacobian Frobenius cosine is 0.9914. After subtracting
-the shared viscous baseline it is 0.9861, while the XLB nonlinear residual has
+recovery ICs, mean condition number is 7.142 for the surrogate versus 6.864
+for XLB; the corresponding Gauss–Newton condition numbers are 51.05 and
+47.17. Total restricted-Jacobian Frobenius cosine is 0.9961. After subtracting
+the shared viscous baseline it is 0.9941, while the XLB nonlinear residual has
 81.2% of the total Jacobian Frobenius norm. The restricted conditioning result
-must not be generalized to the full 12,288-dimensional input space.
+must not be generalized to the full 12,288-dimensional input space, and the
+similar scalar condition numbers do not establish Jacobian equality.
 
 The paper's conditioning protocol instead retains the complete raw velocity
 state, constructs one Jacobian row per output degree of freedom by sequential
@@ -95,40 +98,60 @@ paper-protocol audit uses an explicit orthonormal `8³` block-grid
 lift/restriction around the recovery IC, producing the same 1,536-dimensional
 raw state as the paper while retaining the fixed recovery physics. Under this
 protocol, the Jacobian Frobenius cosine falls to 0.9442 and relative error
-rises to 32.98%. Raw condition numbers are `2.79e7` for XLB and `3.75e10` for
+rises to 32.94%. Raw condition numbers are `2.79e7` for XLB and `7.48e10` for
 the surrogate. These tails fall below the float32 rank tolerance; condition
-numbers over the resolved singular values are `5.32e3` and `4.89e3`,
+numbers over the resolved singular values are `5.32e3` and `5.45e3`,
 respectively. The draft PR provides both normalized spectra, rank diagnostics,
 and the dense matrices. This adapted fixed-task audit is distinct from the
 paper's native `N=8` TGV physics; an XLB control at those native settings is
 reported separately.
 
+The larger dataset improves excluded-seed forward error from 7.473% to 4.309%
+and full-spectrum JVP error from 38.28% to 26.00%; validation and held-out
+errors improve together, so the observed inverse-model gap is not evidence of
+conventional train/test overfitting. A remaining architectural limitation is
+the amplitude gate on the learned correction: at the zero-velocity cold start,
+the correction is second-order and the full model's first derivative is fixed
+by the viscous skip. Consequently, more trajectory data cannot correct the
+measured 49.34% radial JVP error at zero, where recovery begins.
+
 Both optimizer variants from the paper were run on the exact self-recovery
 benchmark. With unconstrained L-BFGS, the surrogate recovers the three ICs to
-6.94%, 7.82%, and 9.55% relative L2 error (8.10% mean), compared with 4.96%,
-5.17%, and 6.12% for XLB (5.42% mean). With divergence-free gradient
-projection, the surrogate reaches 6.97%, 7.85%, and 9.54% (8.12% mean),
+17.31%, 15.70%, and 17.10% relative L2 error (16.70% mean), compared with
+4.96%, 5.17%, and 6.12% for XLB (5.42% mean). With divergence-free gradient
+projection, the surrogate reaches 17.32%, 15.59%, and 17.19% (16.70% mean),
 compared with 4.70%, 5.02%, and 5.94% for XLB (5.22% mean). Per-iteration
 objective, true IC error, and optimized-IC divergence histories are recorded
 for PhiFlow, XLB, Warp-NS, Exponax, and the surrogate.
 
-Warm packaged in-process RTX 5090 medians are 7.12 ms for the 20-macro-step
-forward rollout and 14.86 ms for its end-to-end VJP. XLB takes 4.81 ms and
+The 16,384-trajectory checkpoint is therefore a better forward model but a
+worse global inverse than the 4,096-trajectory checkpoint. The initial
+self-target descent direction at exactly zero has nearly unchanged mean
+cosine with the direction to the true IC (0.845 versus 0.847). Immediately
+away from zero, however, the larger model's mean alignment falls to 0.419 at
+IC amplitude 0.05 and 0.150 at amplitude 0.10, versus 0.825 and 0.807 for the
+smaller checkpoint. Forward-only rollout selection does not constrain this
+off-manifold inverse-gradient geometry; similar conditioning at the true IC
+therefore does not predict recovery from the zero cold start.
+
+Warm packaged in-process RTX 5090 medians are 7.24 ms for the 20-macro-step
+forward rollout and 14.78 ms for its end-to-end VJP. XLB takes 4.81 ms and
 14.37 ms on the same task. The autoregressive surrogate is therefore not a
-kernel-level speedup: repeatedly applying the shared operator makes it 1.48×
-slower for forward and 1.03× slower for VJP. The matched RTX 5090 recovery
-harness takes 33.17 s versus 30.96 s for XLB (1.07× slower); shared RPC,
-optimizer, projection, and line-search overhead narrows the kernel difference.
+kernel-level speedup: repeatedly applying the shared operator makes it 1.51×
+slower for forward and 1.03× slower for VJP. Complete three-seed recovery
+harness times remain similar (34.73 s surrogate versus 34.21 s XLB for
+L-BFGS, and 33.38 s versus 35.78 s with projection) because RPC, optimizer,
+projection, callbacks, and line search dominate these single-run wall times.
 
 ## Limitation: XLB-target inversion
 
 Self-recovery follows the benchmark contract: each solver produces and inverts
 its own final field. It does not establish that the surrogate can safely invert
 an XLB-generated observation. In a separate cross-model test, projected L-BFGS
-through this checkpoint against XLB final fields finishes at 49.2–53.4% IC
-error (51.5% mean), despite reducing the surrogate residual to 1.7–2.4%.
-The best saved IC errors are 20.4–24.6%, and XLB re-evaluation of the final
-recovered ICs leaves 11.2–16.1% final-field residual. The checkpoint must not
+through this checkpoint against XLB final fields finishes at 32.1–41.0% IC
+error (37.4% mean), despite reducing the surrogate residual to 1.6–2.0%.
+The best saved IC errors are 17.5–18.9%, and XLB re-evaluation of the final
+recovered ICs leaves 14.9–19.8% final-field residual. The checkpoint must not
 be presented as a drop-in inverse model for XLB observations.
 
 The draft PR contains both L-BFGS recovery variants, per-iteration loss, IC

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -1,0 +1,35 @@
+# XLB 3D initial-condition recovery surrogate
+
+This Tesseract is a task-specific, direct full-field surrogate for the
+`N=16`, `ν=0.01`, `dt=0.02`, 100-step periodic 3D initial-condition recovery
+benchmark. It is not a general Navier–Stokes solver and is excluded from other
+resolutions, physical parameters, horizons, geometries, and benchmark cells.
+
+## Model contract
+
+The differentiable input is the complete `16 × 16 × 16 × 3` initial velocity
+field. A periodic 3D Fourier neural operator maps that initial condition
+directly to the full final velocity field. It is not an autoregressive or
+one-step model.
+
+The network has width 32, six retained Fourier modes per axis, and six residual
+spectral blocks. An exact linear viscous-diffusion operator supplies the
+zero-state Jacobian; the neural operator learns the finite-amplitude nonlinear
+correction. Inputs and outputs are Helmholtz-projected so the model and its
+recovery gradients remain on the divergence-free periodic manifold.
+
+## Training provenance
+
+Training and dataset-generation code remain outside this repository. The
+packaged weights were trained from 8,192 XLB KBC D3Q27 trajectories, split
+6,144/1,024/1,024 for training/validation/test. Benchmark IC seeds 0, 1, and 2
+were excluded. The training distribution contains random divergence-free
+fields around the benchmark's `|k|=2` energy shell, broader off-manifold
+spectra, and amplitudes from zero to 1.25.
+
+Directional derivatives from 4,096 float64 XLB JVPs were used for gradient
+distillation. This is important for the inverse task: field accuracy alone does
+not establish that an optimizer sees the teacher's local geometry.
+
+Dataset, weight, accuracy, gradient, conditioning, and recovery metrics are
+reported in the draft PR and its external offline artifacts.

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -4,6 +4,8 @@ This Tesseract is a task-specific, direct full-field surrogate for the
 `N=16`, `ν=0.01`, `dt=0.02`, 100-step periodic 3D initial-condition recovery
 benchmark. It is not a general Navier–Stokes solver and is excluded from other
 resolutions, physical parameters, horizons, geometries, and benchmark cells.
+The canonical drag output is zero because this triply-periodic task has no
+obstacle; there is no learned drag head.
 
 ## Model contract
 
@@ -31,5 +33,42 @@ Directional derivatives from 4,096 float64 XLB JVPs were used for gradient
 distillation. This is important for the inverse task: field accuracy alone does
 not establish that an optimizer sees the teacher's local geometry.
 
-Dataset, weight, accuracy, gradient, conditioning, and recovery metrics are
-reported in the draft PR and its external offline artifacts.
+The packaged checkpoint SHA-256 is
+`8669ebaf92d920668c945b04722021fef12d5fc6fa4aa182abc63c81780ed0c9`.
+
+## Offline validation
+
+All validation was run offline through the same Slurm and Pyxis/Enroot path as
+the solver benchmarks. On benchmark seeds 0, 1, and 2, which were excluded from
+training, mean final-field relative L2 error is 7.151% and mean field cosine is
+0.997441. Mean random projected-JVP cosine is 0.849667; these white-spectrum
+directions are harsher than the low-frequency recovery manifold.
+
+On the exact self-recovery benchmark, projected L-BFGS recovers the three ICs
+to 6.20%, 6.92%, and 8.15% relative L2 error (7.09% mean), compared with 4.70%,
+5.02%, and 5.94% for XLB (5.22% mean).
+
+The full-output Jacobian was also evaluated on the complete 512-dimensional
+real divergence-free Fourier subspace through `|k| <= 4`. Across the three
+recovery ICs, the surrogate's mean condition number is 6.56 versus 6.86 for
+XLB; the corresponding Gauss–Newton condition numbers are 43.09 and 47.17.
+The restricted Jacobians have mean Frobenius cosine 0.9901.
+
+Warm in-process packaged medians are 0.920 ms for forward and 1.082 ms for VJP,
+versus 4.812 ms and 14.368 ms for XLB. The exact remote harness takes 24.48 s
+versus 30.96 s because RPC, callbacks, L-BFGS bookkeeping, projection, and line
+search dominate this small cell.
+
+## Limitation: cross-model inversion
+
+Self-recovery follows the benchmark contract: each solver produces and inverts
+its own final field. It does not imply that the surrogate can safely invert an
+XLB-generated observation. In a separate cross-model test, optimizing through
+the surrogate against XLB final fields drives surrogate residuals to 1.3–1.6%
+but finishes at 40.3–42.5% IC error (41.5% mean); the best saved snapshots are
+17.8–20.9% IC error. XLB re-evaluation of those recovered ICs leaves 6.5–9.2%
+final-field residual. This checkpoint must therefore not be presented as a
+drop-in inverse model for XLB observations.
+
+The draft PR contains the full per-seed results, plots, animation, and external
+offline artifact provenance.

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -70,18 +70,37 @@ the shared viscous baseline it is 0.9861, while the XLB nonlinear residual has
 81.2% of the total Jacobian Frobenius norm. The restricted conditioning result
 must not be generalized to the full 12,288-dimensional input space.
 
-On the exact self-recovery benchmark, projected L-BFGS recovers the three ICs
-to 6.97%, 7.85%, and 9.54% relative L2 error (8.12% mean), compared with
-4.70%, 5.02%, and 5.94% for XLB (5.22% mean).
+The paper's conditioning protocol instead retains the complete raw velocity
+state, constructs one Jacobian row per output degree of freedom by sequential
+VJP, and applies a dense SVD. Because this solver is fixed at `N=16`, the
+paper-protocol audit uses an explicit orthonormal `8³` block-grid
+lift/restriction around the recovery IC, producing the same 1,536-dimensional
+raw state as the paper while retaining the fixed recovery physics. Under this
+protocol, the Jacobian Frobenius cosine falls to 0.9442 and relative error
+rises to 32.98%. Raw condition numbers are `2.79e7` for XLB and `3.75e10` for
+the surrogate. These tails fall below the float32 rank tolerance; condition
+numbers over the resolved singular values are `5.32e3` and `4.89e3`,
+respectively. The draft PR provides both normalized spectra, rank diagnostics,
+and the dense matrices. This adapted fixed-task audit is distinct from the
+paper's native `N=8` TGV physics; an XLB control at those native settings is
+reported separately.
+
+Both optimizer variants from the paper were run on the exact self-recovery
+benchmark. With unconstrained L-BFGS, the surrogate recovers the three ICs to
+6.94%, 7.82%, and 9.55% relative L2 error (8.10% mean), compared with 4.96%,
+5.17%, and 6.12% for XLB (5.42% mean). With divergence-free gradient
+projection, the surrogate reaches 6.97%, 7.85%, and 9.54% (8.12% mean),
+compared with 4.70%, 5.02%, and 5.94% for XLB (5.22% mean). Per-iteration
+objective, true IC error, and optimized-IC divergence histories are recorded
+for PhiFlow, XLB, Warp-NS, Exponax, and the surrogate.
 
 Warm packaged in-process RTX 5090 medians are 7.12 ms for the 20-macro-step
-forward rollout and 14.86 ms for its end-to-end VJP. XLB takes 4.81 ms and 14.37 ms on
-the same task. Unlike the replaced direct IC-to-final checkpoint, the
-autoregressive surrogate is therefore not a kernel-level speedup: repeatedly
-applying the shared operator makes it 1.48× slower for forward and 1.03×
-slower for VJP. The matched RTX 5090 recovery harness takes 33.17 s versus
-30.96 s for XLB (1.07× slower); shared RPC, optimizer, projection, and
-line-search overhead narrows the kernel difference.
+forward rollout and 14.86 ms for its end-to-end VJP. XLB takes 4.81 ms and
+14.37 ms on the same task. The autoregressive surrogate is therefore not a
+kernel-level speedup: repeatedly applying the shared operator makes it 1.48×
+slower for forward and 1.03× slower for VJP. The matched RTX 5090 recovery
+harness takes 33.17 s versus 30.96 s for XLB (1.07× slower); shared RPC,
+optimizer, projection, and line-search overhead narrows the kernel difference.
 
 ## Limitation: XLB-target inversion
 
@@ -94,6 +113,7 @@ The best saved IC errors are 20.4–24.6%, and XLB re-evaluation of the final
 recovered ICs leaves 11.2–16.1% final-field residual. The checkpoint must not
 be presented as a drop-in inverse model for XLB observations.
 
-The draft PR contains the exact self-recovery results, paper-style loss and IC
-error histories, full-field plots, animation, timing decomposition, Jacobian
-spectra, and external offline artifact provenance.
+The draft PR contains both L-BFGS recovery variants, per-iteration loss, IC
+error and divergence histories, full-field plots, animation, timing
+decomposition, restricted and paper-protocol Jacobian spectra, and external
+offline artifact provenance.

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -71,8 +71,10 @@ command uses the model definition that the inference API imports.
 
 All experiments were run offline through the shared Slurm and Pyxis/Enroot
 cluster path. On the three excluded recovery seeds, mean final-field relative
-L2 error is 4.309% and mean field cosine is 0.999076. Across the 1,982 nonzero
-held-out test trajectories, mean final-step relative L2 error is 7.219%.
+L2 error is 4.309% and mean field cosine is 0.999076. Across the 1,982
+held-out trajectories with IC amplitude at least 0.05, mean final-step
+relative L2 error is 7.219%. The 66 lower-amplitude cases are reported with
+absolute RMS error because relative error is ill-conditioned near zero.
 
 Directional derivatives were evaluated end to end through all 20 shared
 operator applications. On low-frequency projected directions (`|k|≤4`), mean
@@ -97,26 +99,24 @@ increasing the dataset changes the surrogate condition number from 7.740 to
 restricted-Jacobian Frobenius relative error improves from 13.50% to 8.84%
 and cosine from 0.9914 to 0.9961.
 
-The paper's conditioning protocol instead retains the complete raw velocity
-state, constructs one Jacobian row per output degree of freedom by sequential
-VJP, and applies a dense SVD. Because this solver is fixed at `N=16`, the
-paper-protocol audit uses an explicit orthonormal `8³` block-grid
-lift/restriction around the recovery IC, producing the same 1,536-dimensional
-raw state as the paper while retaining the fixed recovery physics. Under this
-protocol, the Jacobian Frobenius cosine falls to 0.9442 and relative error
-rises to 32.94%. Raw condition numbers are `2.79e7` for XLB and `7.48e10` for
-the surrogate. These tails fall below the float32 rank tolerance; condition
-numbers over the resolved singular values are `5.32e3` and `5.45e3`,
-respectively. The draft PR provides both normalized spectra, rank diagnostics,
-and the dense matrices. This adapted fixed-task audit is distinct from the
-paper's native `N=8` TGV physics; an XLB control at those native settings is
-reported separately.
+An adapted dense audit uses an explicit orthonormal `8³` block-grid
+lift/restriction around the fixed `N=16` recovery map, producing the same
+1,536-dimensional matrix size as the paper's raw-state protocol. It covers
+every coordinate of that coarse block-grid map, but it is not the complete
+12,288-dimensional production Jacobian and is distinct from the paper's
+native `N=8` TGV physics. Under this audit, the Jacobian Frobenius cosine falls
+to 0.9442 and relative error rises to 32.94%. Raw condition numbers are
+`2.79e7` for XLB and `7.48e10` for the surrogate. These tails fall below the
+float32 rank tolerance; condition numbers over the resolved singular values
+are `5.32e3` and `5.45e3`, respectively. The draft PR provides both normalized
+spectra, rank diagnostics, the dense matrices, and a native `N=8` TGV XLB
+control.
 
-The paper-style comparison is essentially unchanged by scaling the training
-set: the 4k/16k Frobenius errors are 32.98%/32.94%, while the
+The adapted block-grid comparison is essentially unchanged by scaling the
+training set: the 4k/16k Frobenius errors are 32.98%/32.94%, while the
 float32-resolved condition numbers are `4.89e3`/`5.45e3`. Their raw condition
-numbers are `3.75e10`/`7.48e10`, so the unresolved spectral tail becomes
-worse even as the restricted Jacobian improves.
+numbers are `3.75e10`/`7.48e10`, so the unresolved spectral tail becomes worse
+even as the restricted Jacobian improves.
 
 The larger dataset improves excluded-seed forward error from 7.473% to 4.309%
 and full-spectrum JVP error from 38.28% to 26.00%; validation and held-out
@@ -167,14 +167,17 @@ to 0.419 at IC amplitude 0.05 and 0.150 at amplitude 0.10, versus 0.825 and
 constrain this off-manifold inverse-gradient geometry; similar conditioning
 at the true IC therefore does not predict recovery from the zero cold start.
 
-Warm packaged in-process RTX 5090 medians are 7.24 ms for the 20-macro-step
-forward rollout and 14.78 ms for its end-to-end VJP. XLB takes 4.81 ms and
-14.37 ms on the same task. The autoregressive surrogate is therefore not a
-kernel-level speedup: repeatedly applying the shared operator makes it 1.51×
-slower for forward and 1.03× slower for VJP. Complete three-seed recovery
-harness times remain similar (34.73 s surrogate versus 34.21 s XLB for
-L-BFGS, and 33.38 s versus 35.78 s with projection) because RPC, optimizer,
-projection, callbacks, and line search dominate these single-run wall times.
+Two matched RTX 5090 timing blocks counterbalance solver order and contribute
+40 warm trials per solver. Their combined medians are 7.35 ms for the
+20-macro-step surrogate forward and 14.77 ms for its end-to-end VJP; XLB takes
+4.79 ms and 15.20 ms on the same task. The surrogate is therefore 1.53× slower
+for forward, while VJP cost is effectively at parity (0.97× here; an earlier
+independent run measured 1.03×). Solver-scoped three-seed harness times remain
+similar: 32.81 s surrogate versus 32.09 s XLB for L-BFGS, and 31.51 s versus
+32.50 s with projection. Including result-script setup and serialization gives
+34.73 s versus 34.21 s and 33.38 s versus 35.78 s, respectively. RPC,
+optimizer, projection, callbacks, and line search dominate these single-run
+wall times.
 
 ## Limitation: XLB-target inversion
 

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -74,12 +74,14 @@ On the exact self-recovery benchmark, projected L-BFGS recovers the three ICs
 to 6.97%, 7.85%, and 9.54% relative L2 error (8.12% mean), compared with
 4.70%, 5.02%, and 5.94% for XLB (5.22% mean).
 
-Warm in-process RTX 5090 medians are 8.09 ms for the 20-macro-step forward
-rollout and 16.81 ms for its end-to-end VJP. XLB takes 4.81 ms and 14.37 ms on
+Warm packaged in-process RTX 5090 medians are 7.12 ms for the 20-macro-step
+forward rollout and 14.86 ms for its end-to-end VJP. XLB takes 4.81 ms and 14.37 ms on
 the same task. Unlike the replaced direct IC-to-final checkpoint, the
 autoregressive surrogate is therefore not a kernel-level speedup: repeatedly
-applying the shared operator makes it 1.68× slower for forward and 1.17×
-slower for VJP.
+applying the shared operator makes it 1.48× slower for forward and 1.03×
+slower for VJP. The matched RTX 5090 recovery harness takes 33.17 s versus
+30.96 s for XLB (1.07× slower); shared RPC, optimizer, projection, and
+line-search overhead narrows the kernel difference.
 
 ## Limitation: XLB-target inversion
 

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -29,12 +29,15 @@ the teacher is never restarted from equilibrium at macro-step boundaries.
 
 ## Training provenance
 
-Training and dataset-generation code remain outside this repository. The
-packaged weights were trained from 4,096 native XLB KBC D3Q27 trajectories,
-split 3,072/512/512 for training/validation/test. Each trajectory contains the
-IC plus 20 full-field snapshots, one every five XLB steps. The final generated
-snapshot matched the canonical 100-step float32 teacher call with maximum
-absolute difference zero. Benchmark IC seeds 0, 1, and 2 were excluded.
+`generate_trajectories.py`, `training_data.py`, `train.py`, and the shared
+`surrogate_model.py` are packaged with the Tesseract. The generator must run
+against the XLB teacher API; cluster submission and container orchestration
+remain external. The packaged weights were trained from 4,096 native XLB KBC
+D3Q27 trajectories, split 3,072/512/512 for training/validation/test. Each
+trajectory contains the IC plus 20 full-field snapshots, one every five XLB
+steps. The final generated snapshot matched the canonical 100-step float32
+teacher call with maximum absolute difference zero. Benchmark IC seeds 0, 1,
+and 2 were excluded.
 
 Training used autoregressive unroll curriculum
 `1 → 2 → 4 → 8 → 12 → 20`, followed by a full-20-step fine-tune. The
@@ -46,6 +49,21 @@ The native trajectory dataset SHA-256 is
 `f94390c512c44d893581017007720077d85f2c153d28d8841630e0adc1e60dc8`.
 The packaged checkpoint SHA-256 is
 `03178cee7457849e28ecd4f6f97bfa70b111cebedc0847f882d8362abf493835`.
+
+The reproducible program boundary is:
+
+```bash
+python generate_trajectories.py \
+  --teacher-api /tesseract/tesseract_api.py \
+  --output /surrogate-output/recovery_3d_xlb_trajectories.npy
+python train.py \
+  --dataset /surrogate-output/recovery_3d_xlb_trajectories.npy \
+  --weights /surrogate-output/recovery_3d_autoregressive_weights.npz
+```
+
+The first command is run in the XLB solver image so
+`/tesseract/tesseract_api.py` is the teacher implementation. The second
+command uses the model definition that the inference API imports.
 
 ## Offline validation
 

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/MODEL.md
@@ -1,6 +1,6 @@
 # XLB 3D initial-condition recovery surrogate
 
-This Tesseract is a task-specific, direct full-field surrogate for the
+This Tesseract is a task-specific autoregressive full-field surrogate for the
 `N=16`, `ν=0.01`, `dt=0.02`, 100-step periodic 3D initial-condition recovery
 benchmark. It is not a general Navier–Stokes solver and is excluded from other
 resolutions, physical parameters, horizons, geometries, and benchmark cells.
@@ -9,66 +9,78 @@ obstacle; there is no learned drag head.
 
 ## Model contract
 
-The differentiable input is the complete `16 × 16 × 16 × 3` initial velocity
-field. A periodic 3D Fourier neural operator maps that initial condition
-directly to the full final velocity field. It is not an autoregressive or
-one-step model.
+The differentiable state is the complete `16 × 16 × 16 × 3` velocity field.
+One periodic 3D Fourier neural operator advances that field by a macro-step of
+five XLB solver steps (`ΔT=0.1`). The same weights are reused autoregressively
+20 times to produce the full-horizon result. This is not an IC-to-final-state
+regressor.
 
-The network has width 32, six retained Fourier modes per axis, and six residual
-spectral blocks. An exact linear viscous-diffusion operator supplies the
-zero-state Jacobian; the neural operator learns the finite-amplitude nonlinear
-correction. Inputs and outputs are Helmholtz-projected so the model and its
-recovery gradients remain on the divergence-free periodic manifold.
+The neural operator has width 32, six retained Fourier modes per axis, and six
+residual spectral blocks. An exact one-macro-step viscous-diffusion operator
+supplies a physics skip while the neural operator learns the finite-amplitude
+nonlinear correction. Every macro-step is Helmholtz-projected so both the
+rollout and its recovery gradients remain on the divergence-free periodic
+manifold.
+
+XLB's velocity alone omits the lattice populations and is therefore not a
+closed representation of the teacher's numerical state. The training targets
+are nevertheless decoded from one continuous native XLB population rollout;
+the teacher is never restarted from equilibrium at macro-step boundaries.
 
 ## Training provenance
 
 Training and dataset-generation code remain outside this repository. The
-packaged weights were trained from 8,192 XLB KBC D3Q27 trajectories, split
-6,144/1,024/1,024 for training/validation/test. Benchmark IC seeds 0, 1, and 2
-were excluded. The training distribution contains random divergence-free
-fields around the benchmark's `|k|=2` energy shell, broader off-manifold
-spectra, and amplitudes from zero to 1.25.
+packaged weights were trained from 4,096 native XLB KBC D3Q27 trajectories,
+split 3,072/512/512 for training/validation/test. Each trajectory contains the
+IC plus 20 full-field snapshots, one every five XLB steps. The final generated
+snapshot matched the canonical 100-step float32 teacher call with maximum
+absolute difference zero. Benchmark IC seeds 0, 1, and 2 were excluded.
 
-Directional derivatives from 4,096 float64 XLB JVPs were used for gradient
-distillation. This is important for the inverse task: field accuracy alone does
-not establish that an optimizer sees the teacher's local geometry.
+Training used autoregressive unroll curriculum
+`1 → 2 → 4 → 8 → 12 → 20`, followed by a full-20-step fine-tune. The
+distribution contains random divergence-free fields around the benchmark's
+`|k|=2` energy shell, broader spectra for optimizer-path coverage, and
+amplitudes from zero to 1.25.
 
+The native trajectory dataset SHA-256 is
+`f94390c512c44d893581017007720077d85f2c153d28d8841630e0adc1e60dc8`.
 The packaged checkpoint SHA-256 is
-`8669ebaf92d920668c945b04722021fef12d5fc6fa4aa182abc63c81780ed0c9`.
+`03178cee7457849e28ecd4f6f97bfa70b111cebedc0847f882d8362abf493835`.
 
 ## Offline validation
 
-All validation was run offline through the same Slurm and Pyxis/Enroot path as
-the solver benchmarks. On benchmark seeds 0, 1, and 2, which were excluded from
-training, mean final-field relative L2 error is 7.151% and mean field cosine is
-0.997441. Mean random projected-JVP cosine is 0.849667; these white-spectrum
-directions are harsher than the low-frequency recovery manifold.
+All experiments were run offline through the shared Slurm and Pyxis/Enroot
+cluster path. On the three excluded recovery seeds, mean final-field relative
+L2 error is 7.473% and mean field cosine is 0.997619. Across the 491 nonzero
+held-out test trajectories, mean final-step relative L2 error is 9.905%.
 
-On the exact self-recovery benchmark, projected L-BFGS recovers the three ICs
-to 6.20%, 6.92%, and 8.15% relative L2 error (7.09% mean), compared with 4.70%,
-5.02%, and 5.94% for XLB (5.22% mean).
+Directional derivatives were evaluated end to end through all 20 shared
+operator applications. On low-frequency projected directions (`|k|≤4`), mean
+JVP cosine is 0.9846 and relative L2 error is 17.64%. On projected white
+full-spectrum directions, the stricter values are 0.9253 and 38.28%.
+Subtracting the exact full-horizon viscous-diffusion derivative leaves
+nonlinear-residual JVP cosines of 0.9752 and 0.9757, respectively.
 
 The full-output Jacobian was also evaluated on the complete 512-dimensional
-real divergence-free Fourier subspace through `|k| <= 4`. Across the three
-recovery ICs, the surrogate's mean condition number is 6.56 versus 6.86 for
-XLB; the corresponding Gauss–Newton condition numbers are 43.09 and 47.17.
-The restricted Jacobians have mean Frobenius cosine 0.9901.
+real divergence-free Fourier subspace through `|k|≤4`. Across the three
+recovery ICs, mean condition number is 7.740 for the surrogate versus 6.864
+for XLB; the corresponding Gauss–Newton condition numbers are 59.98 and
+47.17. Total restricted-Jacobian Frobenius cosine is 0.9914. After subtracting
+the shared viscous baseline it is 0.9861, while the XLB nonlinear residual has
+81.2% of the total Jacobian Frobenius norm. The restricted conditioning result
+must not be generalized to the full 12,288-dimensional input space.
 
-Warm in-process packaged medians are 0.920 ms for forward and 1.082 ms for VJP,
-versus 4.812 ms and 14.368 ms for XLB. The exact remote harness takes 24.48 s
-versus 30.96 s because RPC, callbacks, L-BFGS bookkeeping, projection, and line
-search dominate this small cell.
-
-## Limitation: cross-model inversion
+## Limitation: XLB-target inversion
 
 Self-recovery follows the benchmark contract: each solver produces and inverts
-its own final field. It does not imply that the surrogate can safely invert an
-XLB-generated observation. In a separate cross-model test, optimizing through
-the surrogate against XLB final fields drives surrogate residuals to 1.3–1.6%
-but finishes at 40.3–42.5% IC error (41.5% mean); the best saved snapshots are
-17.8–20.9% IC error. XLB re-evaluation of those recovered ICs leaves 6.5–9.2%
-final-field residual. This checkpoint must therefore not be presented as a
-drop-in inverse model for XLB observations.
+its own final field. It does not establish that the surrogate can safely invert
+an XLB-generated observation. In a separate cross-model test, projected L-BFGS
+through this checkpoint against XLB final fields finishes at 49.2–53.4% IC
+error (51.5% mean), despite reducing the surrogate residual to 1.7–2.4%.
+The best saved IC errors are 20.4–24.6%, and XLB re-evaluation of the final
+recovered ICs leaves 11.2–16.1% final-field residual. The checkpoint must not
+be presented as a drop-in inverse model for XLB observations.
 
-The draft PR contains the full per-seed results, plots, animation, and external
-offline artifact provenance.
+The draft PR contains the exact self-recovery results, paper-style loss and IC
+error histories, full-field plots, animation, timing decomposition, Jacobian
+spectra, and external offline artifact provenance.

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/generate_trajectories.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/generate_trajectories.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate native XLB trajectories for autoregressive full-field training.
+
+The teacher populations are evolved continuously for all 100 LBM steps.  We
+decode velocity snapshots every ``STRIDE`` steps without reinitialising the
+hidden lattice populations from equilibrium between snapshots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+import time
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from training_data import make_inputs
+
+N = 16
+VISCOSITY = 0.01
+DT = 0.02
+STEPS = 100
+STRIDE = 5
+ROLLOUT_STEPS = STEPS // STRIDE
+DOMAIN_EXTENT = 2.0 * math.pi
+
+
+def _load_api(path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location("trajectory_teacher_api", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> None:
+    """Generate and persist a deterministic train/validation/test dataset."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--samples", type=int, default=16384)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--seed", type=int, default=20260726)
+    parser.add_argument(
+        "--teacher-api",
+        type=Path,
+        default=Path("/tesseract/tesseract_api.py"),
+        help="XLB teacher API; run this script in the XLB solver image.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("/surrogate-output/recovery_3d_xlb_trajectories.npy"),
+    )
+    args = parser.parse_args()
+    if STEPS % STRIDE:
+        raise ValueError(f"steps={STEPS} must be divisible by stride={STRIDE}")
+
+    started = time.perf_counter()
+    print("jax_backend", jax.default_backend(), flush=True)
+    print("jax_devices", jax.devices(), flush=True)
+    api = _load_api(args.teacher_api)
+    inputs, amplitudes, families = make_inputs(args.samples, args.seed)
+
+    dx = DOMAIN_EXTENT / N
+    scale = DT / dx
+    nu_lb = VISCOSITY * DT / dx**2
+    omega = 1.0 / (3.0 * nu_lb + 0.5)
+    ops = api._OPS[(3, False, "kbc")]
+    xlb_eq = ops["eq"]
+    xlb_stream = ops["stream"]
+    xlb_macro = ops["macro"]
+    xlb_collide = ops["bgk"]
+
+    def one_trajectory(v0: jax.Array) -> jax.Array:
+        u0 = jnp.moveaxis(v0, -1, 0).astype(jnp.float32) * scale
+        rho0 = jnp.ones((1, N, N, N), dtype=jnp.float32)
+        f0 = xlb_eq(rho0, u0)
+
+        def lbm_step(_: int, f: jax.Array) -> jax.Array:
+            f_streamed = xlb_stream(f)
+            rho, velocity = xlb_macro(f_streamed)
+            equilibrium = xlb_eq(rho, velocity)
+            return xlb_collide(
+                f_streamed,
+                equilibrium,
+                rho,
+                velocity,
+                omega,
+            )
+
+        def macro_step(
+            f: jax.Array,
+            _: None,
+        ) -> tuple[jax.Array, jax.Array]:
+            f_next = jax.lax.fori_loop(0, STRIDE, lbm_step, f)
+            _, velocity = xlb_macro(f_next)
+            decoded = jnp.moveaxis(velocity, 0, -1) / scale
+            return f_next, decoded.astype(jnp.float32)
+
+        _, decoded = jax.lax.scan(
+            macro_step,
+            f0,
+            None,
+            length=ROLLOUT_STEPS,
+        )
+        return jnp.concatenate([v0[None], decoded], axis=0)
+
+    run_batch = jax.jit(jax.vmap(one_trajectory))
+
+    # Prove that snapshotting did not alter the exact teacher trajectory.
+    check_input = jnp.asarray(inputs[0])
+    check_trajectory = run_batch(check_input[None])[0]
+    check_final, _ = api.xlb_fwd(
+        v0=check_input,
+        viscosity=VISCOSITY,
+        dt=DT,
+        steps=STEPS,
+        domain_extent=DOMAIN_EXTENT,
+        _use_f64=False,
+        _sub_k=1,
+        _collision_kind_override="kbc",
+    )
+    check_max_abs = float(jnp.max(jnp.abs(check_trajectory[-1] - check_final)))
+    print(f"native_final_check_max_abs={check_max_abs:.9g}", flush=True)
+    if check_max_abs > 2e-5:
+        raise RuntimeError(
+            "native trajectory final snapshot does not match xlb_fwd: "
+            f"max_abs={check_max_abs}"
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    trajectories = np.lib.format.open_memmap(
+        args.output,
+        mode="w+",
+        dtype=np.float32,
+        shape=(args.samples, ROLLOUT_STEPS + 1, N, N, N, 3),
+    )
+    cursor = 0
+    while cursor < args.samples:
+        stop = min(cursor + args.batch_size, args.samples)
+        result = np.asarray(jax.device_get(run_batch(jnp.asarray(inputs[cursor:stop]))))
+        expected = trajectories[cursor:stop].shape
+        if result.shape != expected or not np.all(np.isfinite(result)):
+            raise RuntimeError(
+                f"invalid teacher batch {cursor}:{stop}: "
+                f"shape={result.shape}, expected={expected}, "
+                f"finite={np.all(np.isfinite(result))}"
+            )
+        trajectories[cursor:stop] = result
+        cursor = stop
+        elapsed = time.perf_counter() - started
+        print(
+            f"generated={cursor}/{args.samples} "
+            f"rate={cursor / max(elapsed, 1e-9):.2f}/s",
+            flush=True,
+        )
+    trajectories.flush()
+    del trajectories
+
+    permutation = np.random.default_rng(args.seed + 2).permutation(args.samples)
+    train_count = math.floor(args.samples * 0.75)
+    validation_count = math.floor(args.samples * 0.125)
+    split = np.full(args.samples, 2, dtype=np.int8)
+    split[permutation[:train_count]] = 0
+    split[permutation[train_count : train_count + validation_count]] = 1
+    split_path = args.output.with_suffix(".split.npz")
+    np.savez(
+        split_path,
+        amplitudes=amplitudes,
+        families=families,
+        split=split,
+    )
+    metadata = {
+        "teacher": "xlb",
+        "collision": "kbc",
+        "samples": args.samples,
+        "split": {
+            "train": train_count,
+            "validation": validation_count,
+            "test": args.samples - train_count - validation_count,
+        },
+        "seed": args.seed,
+        "physics": {
+            "N": N,
+            "viscosity": VISCOSITY,
+            "dt": DT,
+            "solver_steps": STEPS,
+            "domain_extent": DOMAIN_EXTENT,
+        },
+        "trajectory": {
+            "native_continuous_populations": True,
+            "snapshot_stride_solver_steps": STRIDE,
+            "macro_dt": DT * STRIDE,
+            "rollout_steps": ROLLOUT_STEPS,
+            "snapshots_including_ic": ROLLOUT_STEPS + 1,
+        },
+        "benchmark_seeds_excluded": [0, 1, 2],
+        "amplitude_min": float(np.min(amplitudes)),
+        "amplitude_max": float(np.max(amplitudes)),
+        "native_final_check_max_abs": check_max_abs,
+        "trajectory_sha256": _sha256(args.output),
+        "split_sha256": _sha256(split_path),
+        "elapsed_seconds": time.perf_counter() - started,
+    }
+    args.output.with_suffix(".json").write_text(json.dumps(metadata, indent=2))
+    print(json.dumps(metadata, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/surrogate_model.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/surrogate_model.py
@@ -1,0 +1,230 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Autoregressive 3D Fourier neural operator for the XLB recovery task.
+
+This module is shared by the packaged inference API and the reproducible
+training program. Keep architecture or checkpoint-format changes here so the
+two paths cannot drift.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+N = 16
+DOMAIN_EXTENT = 2.0 * math.pi
+VISCOSITY = 0.01
+SOLVER_DT = 0.02
+SOLVER_STEPS = 100
+STRIDE = 5
+MACRO_DT = SOLVER_DT * STRIDE
+ROLLOUT_STEPS = SOLVER_STEPS // STRIDE
+
+
+def helmholtz_project(velocity: jax.Array) -> jax.Array:
+    """Spectrally project channels-last periodic velocity to divergence-free."""
+    axes = tuple(range(velocity.ndim - 4, velocity.ndim - 1))
+    velocity_hat = jnp.fft.rfftn(velocity, axes=axes)
+    k = jnp.fft.fftfreq(N, d=1.0 / N)
+    kz = jnp.fft.rfftfreq(N, d=1.0 / N)
+    kx, ky, kz_grid = jnp.meshgrid(k, k, kz, indexing="ij")
+    wave = jnp.stack([kx, ky, kz_grid], axis=-1)
+    k2 = jnp.sum(wave**2, axis=-1)
+    safe_k2 = jnp.where(k2 == 0, 1.0, k2)
+    dot = jnp.sum(velocity_hat * wave, axis=-1)
+    projected_hat = velocity_hat - wave * (dot / safe_k2)[..., None]
+    projected_hat = projected_hat.at[..., 0, 0, 0, :].set(velocity_hat[..., 0, 0, 0, :])
+    return jnp.fft.irfftn(
+        projected_hat,
+        s=(N, N, N),
+        axes=axes,
+    ).real.astype(jnp.float32)
+
+
+def diffuse_macro(velocity: jax.Array) -> jax.Array:
+    """Exact linear viscous evolution for one five-solver-step interval."""
+    axes = tuple(range(velocity.ndim - 4, velocity.ndim - 1))
+    velocity_hat = jnp.fft.rfftn(helmholtz_project(velocity), axes=axes)
+    k = jnp.fft.fftfreq(N, d=1.0 / N)
+    kz = jnp.fft.rfftfreq(N, d=1.0 / N)
+    kx, ky, kz_grid = jnp.meshgrid(k, k, kz, indexing="ij")
+    k2 = kx**2 + ky**2 + kz_grid**2
+    decay = jnp.exp(-VISCOSITY * MACRO_DT * k2)
+    return jnp.fft.irfftn(
+        velocity_hat * decay[..., None],
+        s=(N, N, N),
+        axes=axes,
+    ).real.astype(jnp.float32)
+
+
+def _spectral_convolution(
+    x: jax.Array,
+    params: dict[str, jax.Array],
+    layer: int,
+    modes: int,
+) -> jax.Array:
+    x_hat = jnp.fft.rfftn(x, axes=(1, 2, 3))
+    output_hat = jnp.zeros_like(x_hat)
+    selections = (
+        (slice(0, modes), slice(0, modes)),
+        (slice(-modes, None), slice(0, modes)),
+        (slice(0, modes), slice(-modes, None)),
+        (slice(-modes, None), slice(-modes, None)),
+    )
+    for quadrant, (sx, sy) in enumerate(selections):
+        weight = (
+            params[f"spec_{layer}_{quadrant}_real"]
+            + 1j * params[f"spec_{layer}_{quadrant}_imag"]
+        )
+        transformed = jnp.einsum(
+            "bxyzi,xyzio->bxyzo",
+            x_hat[:, sx, sy, :modes, :],
+            weight,
+        )
+        output_hat = output_hat.at[:, sx, sy, :modes, :].set(transformed)
+    return jnp.fft.irfftn(
+        output_hat,
+        s=(N, N, N),
+        axes=(1, 2, 3),
+    ).real.astype(jnp.float32)
+
+
+def one_step(
+    params: dict[str, jax.Array],
+    velocity: jax.Array,
+    *,
+    input_scale: jax.Array,
+    correction_scale: jax.Array,
+    modes: int,
+    layers: int,
+) -> jax.Array:
+    """Apply the shared full-field neural operator for one macro time step."""
+    velocity = helmholtz_project(velocity)
+    normalized = velocity / input_scale
+    hidden = jnp.einsum("bxyzi,io->bxyzo", normalized, params["w_lift"])
+    for layer in range(layers):
+        spectral = _spectral_convolution(hidden, params, layer, modes)
+        local = jnp.einsum(
+            "bxyzi,io->bxyzo",
+            hidden,
+            params[f"w_local_{layer}"],
+        )
+        update = jax.nn.gelu(spectral + local)
+        hidden = (hidden + update) * jnp.asarray(2.0**-0.5, jnp.float32)
+    raw_correction = jnp.einsum(
+        "bxyzi,io->bxyzo",
+        hidden,
+        params["w_out"],
+    )
+    amplitude = jnp.sqrt(
+        jnp.mean(velocity**2, axis=(1, 2, 3, 4), keepdims=True) + 1e-12
+    )
+    correction = (
+        raw_correction
+        * correction_scale.reshape(1, 1, 1, 1, 3)
+        * (amplitude / input_scale)
+    )
+    return helmholtz_project(diffuse_macro(velocity) + correction)
+
+
+def rollout(
+    params: dict[str, jax.Array],
+    velocity: jax.Array,
+    *,
+    steps: int,
+    input_scale: jax.Array,
+    correction_scale: jax.Array,
+    modes: int,
+    layers: int,
+) -> jax.Array:
+    """Autoregressively return ``steps`` predicted fields after ``velocity``."""
+
+    def body(current: jax.Array, _: None) -> tuple[jax.Array, jax.Array]:
+        predicted = one_step(
+            params,
+            current,
+            input_scale=input_scale,
+            correction_scale=correction_scale,
+            modes=modes,
+            layers=layers,
+        )
+        return predicted, predicted
+
+    _, predictions = jax.lax.scan(body, velocity, None, length=steps)
+    return jnp.moveaxis(predictions, 0, 1)
+
+
+def init_params(
+    *,
+    width: int,
+    modes: int,
+    layers: int,
+    seed: int,
+) -> dict[str, jax.Array]:
+    """Initialize one FNO parameter tree deterministically."""
+    rng = np.random.default_rng(seed)
+
+    def weight(fan_in: int, fan_out: int) -> jax.Array:
+        scale = math.sqrt(2.0 / (fan_in + fan_out))
+        return jnp.asarray(
+            rng.normal(scale=scale, size=(fan_in, fan_out)),
+            dtype=jnp.float32,
+        )
+
+    params: dict[str, jax.Array] = {
+        "w_lift": weight(3, width),
+        "w_out": weight(width, 3) * 0.03,
+    }
+    spectral_scale = 0.15 / math.sqrt(width)
+    for layer in range(layers):
+        local = np.eye(width, dtype=np.float32) * 0.2
+        local += rng.normal(scale=0.015, size=(width, width)).astype(np.float32)
+        params[f"w_local_{layer}"] = jnp.asarray(local)
+        for quadrant in range(4):
+            shape = (modes, modes, modes, width, width)
+            params[f"spec_{layer}_{quadrant}_real"] = jnp.asarray(
+                rng.normal(scale=spectral_scale, size=shape),
+                dtype=jnp.float32,
+            )
+            params[f"spec_{layer}_{quadrant}_imag"] = jnp.asarray(
+                rng.normal(scale=spectral_scale, size=shape),
+                dtype=jnp.float32,
+            )
+    return params
+
+
+def tree_l2(params: dict[str, jax.Array]) -> jax.Array:
+    """Return the unnormalized squared L2 norm of a parameter tree."""
+    return sum(jnp.sum(value**2) for value in params.values())
+
+
+def serialize_params(
+    params: dict[str, Any],
+    *,
+    input_scale: float,
+    correction_scale: np.ndarray,
+    width: int,
+    modes: int,
+    layers: int,
+) -> dict[str, np.ndarray]:
+    """Serialize parameters and fixed-task architecture metadata."""
+    return {
+        **{key: np.asarray(value) for key, value in params.items()},
+        "input_scale": np.asarray(input_scale, dtype=np.float32),
+        "correction_scale": np.asarray(correction_scale, dtype=np.float32),
+        "width": np.asarray(width, dtype=np.int32),
+        "modes": np.asarray(modes, dtype=np.int32),
+        "layers": np.asarray(layers, dtype=np.int32),
+        "solver_dt": np.asarray(SOLVER_DT, dtype=np.float32),
+        "solver_steps": np.asarray(SOLVER_STEPS, dtype=np.int32),
+        "stride": np.asarray(STRIDE, dtype=np.int32),
+        "macro_dt": np.asarray(MACRO_DT, dtype=np.float32),
+        "rollout_steps": np.asarray(ROLLOUT_STEPS, dtype=np.int32),
+        "autoregressive": np.asarray(1, dtype=np.int32),
+    }

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_api.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_api.py
@@ -5,13 +5,13 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-import surrogate_model as model
 from mosaic_shared.problems.navier_stokes_grid import (
     InputSchema as _CanonicalInputSchema,
 )
@@ -19,6 +19,12 @@ from mosaic_shared.problems.navier_stokes_grid import (
     OutputSchema as _CanonicalOutputSchema,
 )
 from mosaic_shared.schema_types import make_differentiable
+
+_MODULE_DIR = Path(__file__).resolve().parent
+if str(_MODULE_DIR) not in sys.path:
+    sys.path.insert(0, str(_MODULE_DIR))
+
+import surrogate_model as model  # noqa: E402
 
 
 class InputSchema(make_differentiable(_CanonicalInputSchema, ["v0"])):

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_api.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_api.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Pasteur Labs. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Direct full-field XLB surrogate for the fixed 3D IC-recovery task."""
+"""Autoregressive full-field XLB surrogate for the fixed 3D recovery task."""
 
 from __future__ import annotations
 
@@ -33,6 +33,9 @@ _N = 16
 _VISCOSITY = 0.01
 _DT = 0.02
 _STEPS = 100
+_STRIDE = 5
+_MACRO_DT = _DT * _STRIDE
+_ROLLOUT_STEPS = _STEPS // _STRIDE
 _DOMAIN_EXTENT = 2.0 * math.pi
 _WIDTH = 32
 _MODES = 6
@@ -57,11 +60,17 @@ def _load_weights() -> dict[str, jax.Array]:
                 "width": int(data["width"]),
                 "modes": int(data["modes"]),
                 "layers": int(data["layers"]),
+                "stride": int(data["stride"]),
+                "rollout_steps": int(data["rollout_steps"]),
+                "autoregressive": int(data["autoregressive"]),
             }
             expected = {
                 "width": _WIDTH,
                 "modes": _MODES,
                 "layers": _LAYERS,
+                "stride": _STRIDE,
+                "rollout_steps": _ROLLOUT_STEPS,
+                "autoregressive": 1,
             }
             if metadata != expected:
                 raise RuntimeError(
@@ -107,7 +116,7 @@ def _helmholtz_project(velocity: jax.Array) -> jax.Array:
 
 
 def _diffuse(velocity: jax.Array) -> jax.Array:
-    """Exact linear viscous evolution over the fixed recovery horizon."""
+    """Exact linear viscous evolution over one learned macro time step."""
     velocity_hat = jnp.fft.rfftn(
         _helmholtz_project(velocity),
         axes=(1, 2, 3),
@@ -116,7 +125,7 @@ def _diffuse(velocity: jax.Array) -> jax.Array:
     kz = jnp.fft.rfftfreq(_N, d=1.0 / _N)
     kx, ky, kz_grid = jnp.meshgrid(k, k, kz, indexing="ij")
     k2 = kx**2 + ky**2 + kz_grid**2
-    decay = jnp.exp(-_VISCOSITY * (_DT * _STEPS) * k2)
+    decay = jnp.exp(-_VISCOSITY * _MACRO_DT * k2)
     return jnp.fft.irfftn(
         velocity_hat * decay[..., None],
         s=(_N, _N, _N),
@@ -155,12 +164,12 @@ def _spectral_convolution(
     ).real.astype(jnp.float32)
 
 
-def _surrogate_forward(
-    initial_velocity: jax.Array,
+def _one_step(
+    velocity: jax.Array,
     weights: dict[str, jax.Array],
 ) -> jax.Array:
-    """Map one full initial field directly to the fixed-horizon final field."""
-    velocity = _helmholtz_project(initial_velocity[None])
+    """Advance a batch of full velocity fields by five XLB solver steps."""
+    velocity = _helmholtz_project(velocity)
     normalized = velocity / weights["input_scale"]
     hidden = jnp.einsum("bxyzi,io->bxyzo", normalized, weights["w_lift"])
     for layer in range(_LAYERS):
@@ -177,13 +186,33 @@ def _surrogate_forward(
         hidden,
         weights["w_out"],
     )
-    amplitude = jnp.sqrt(jnp.mean(velocity**2, keepdims=True) + 1e-12)
+    amplitude = jnp.sqrt(
+        jnp.mean(velocity**2, axis=(1, 2, 3, 4), keepdims=True) + 1e-12
+    )
     correction = (
         raw_correction
         * weights["correction_scale"].reshape(1, 1, 1, 1, 3)
         * (amplitude / weights["input_scale"])
     )
-    return _helmholtz_project(_diffuse(velocity) + correction)[0]
+    return _helmholtz_project(_diffuse(velocity) + correction)
+
+
+def _surrogate_forward(
+    initial_velocity: jax.Array,
+    weights: dict[str, jax.Array],
+) -> jax.Array:
+    """Apply the shared macro-step neural operator autoregressively 20 times."""
+
+    def body(_: int, velocity: jax.Array) -> jax.Array:
+        return _one_step(velocity, weights)
+
+    final = jax.lax.fori_loop(
+        0,
+        _ROLLOUT_STEPS,
+        body,
+        initial_velocity[None],
+    )
+    return final[0]
 
 
 @jax.jit
@@ -239,7 +268,7 @@ def _validate_contract(inputs: InputSchema) -> None:
 
 
 def apply(inputs: InputSchema) -> dict[str, jax.Array | None]:
-    """Evaluate the direct IC-to-final-state full-field surrogate."""
+    """Evaluate the autoregressive full-field surrogate rollout."""
     _validate_contract(inputs)
     initial_velocity = jnp.asarray(inputs.v0, dtype=jnp.float32)
     return {

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_api.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_api.py
@@ -5,13 +5,13 @@
 
 from __future__ import annotations
 
-import math
 from pathlib import Path
 from typing import Any
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+import surrogate_model as model
 from mosaic_shared.problems.navier_stokes_grid import (
     InputSchema as _CanonicalInputSchema,
 )
@@ -29,14 +29,14 @@ class OutputSchema(make_differentiable(_CanonicalOutputSchema, ["result"])):
     """Fixed-horizon full 3D velocity field."""
 
 
-_N = 16
-_VISCOSITY = 0.01
-_DT = 0.02
-_STEPS = 100
-_STRIDE = 5
-_MACRO_DT = _DT * _STRIDE
-_ROLLOUT_STEPS = _STEPS // _STRIDE
-_DOMAIN_EXTENT = 2.0 * math.pi
+_N = model.N
+_VISCOSITY = model.VISCOSITY
+_DT = model.SOLVER_DT
+_STEPS = model.SOLVER_STEPS
+_STRIDE = model.STRIDE
+_MACRO_DT = model.MACRO_DT
+_ROLLOUT_STEPS = model.ROLLOUT_STEPS
+_DOMAIN_EXTENT = model.DOMAIN_EXTENT
 _WIDTH = 32
 _MODES = 6
 _LAYERS = 6
@@ -96,105 +96,19 @@ def _load_weights() -> dict[str, jax.Array]:
     return _WEIGHTS
 
 
-def _helmholtz_project(velocity: jax.Array) -> jax.Array:
-    """Project a batched periodic velocity field to the divergence-free subspace."""
-    velocity_hat = jnp.fft.rfftn(velocity, axes=(1, 2, 3))
-    k = jnp.fft.fftfreq(_N, d=1.0 / _N)
-    kz = jnp.fft.rfftfreq(_N, d=1.0 / _N)
-    kx, ky, kz_grid = jnp.meshgrid(k, k, kz, indexing="ij")
-    wave = jnp.stack([kx, ky, kz_grid], axis=-1)
-    k2 = jnp.sum(wave**2, axis=-1)
-    safe_k2 = jnp.where(k2 == 0, 1.0, k2)
-    dot = jnp.sum(velocity_hat * wave, axis=-1)
-    projected_hat = velocity_hat - wave * (dot / safe_k2)[..., None]
-    projected_hat = projected_hat.at[:, 0, 0, 0, :].set(velocity_hat[:, 0, 0, 0, :])
-    return jnp.fft.irfftn(
-        projected_hat,
-        s=(_N, _N, _N),
-        axes=(1, 2, 3),
-    ).real.astype(jnp.float32)
-
-
-def _diffuse(velocity: jax.Array) -> jax.Array:
-    """Exact linear viscous evolution over one learned macro time step."""
-    velocity_hat = jnp.fft.rfftn(
-        _helmholtz_project(velocity),
-        axes=(1, 2, 3),
-    )
-    k = jnp.fft.fftfreq(_N, d=1.0 / _N)
-    kz = jnp.fft.rfftfreq(_N, d=1.0 / _N)
-    kx, ky, kz_grid = jnp.meshgrid(k, k, kz, indexing="ij")
-    k2 = kx**2 + ky**2 + kz_grid**2
-    decay = jnp.exp(-_VISCOSITY * _MACRO_DT * k2)
-    return jnp.fft.irfftn(
-        velocity_hat * decay[..., None],
-        s=(_N, _N, _N),
-        axes=(1, 2, 3),
-    ).real.astype(jnp.float32)
-
-
-def _spectral_convolution(
-    hidden: jax.Array,
-    weights: dict[str, jax.Array],
-    layer: int,
-) -> jax.Array:
-    hidden_hat = jnp.fft.rfftn(hidden, axes=(1, 2, 3))
-    output_hat = jnp.zeros_like(hidden_hat)
-    selections = (
-        (slice(0, _MODES), slice(0, _MODES)),
-        (slice(-_MODES, None), slice(0, _MODES)),
-        (slice(0, _MODES), slice(-_MODES, None)),
-        (slice(-_MODES, None), slice(-_MODES, None)),
-    )
-    for quadrant, (sx, sy) in enumerate(selections):
-        spectral_weight = (
-            weights[f"spec_{layer}_{quadrant}_real"]
-            + 1j * weights[f"spec_{layer}_{quadrant}_imag"]
-        )
-        transformed = jnp.einsum(
-            "bxyzi,xyzio->bxyzo",
-            hidden_hat[:, sx, sy, :_MODES, :],
-            spectral_weight,
-        )
-        output_hat = output_hat.at[:, sx, sy, :_MODES, :].set(transformed)
-    return jnp.fft.irfftn(
-        output_hat,
-        s=(_N, _N, _N),
-        axes=(1, 2, 3),
-    ).real.astype(jnp.float32)
-
-
 def _one_step(
     velocity: jax.Array,
     weights: dict[str, jax.Array],
 ) -> jax.Array:
     """Advance a batch of full velocity fields by five XLB solver steps."""
-    velocity = _helmholtz_project(velocity)
-    normalized = velocity / weights["input_scale"]
-    hidden = jnp.einsum("bxyzi,io->bxyzo", normalized, weights["w_lift"])
-    for layer in range(_LAYERS):
-        spectral = _spectral_convolution(hidden, weights, layer)
-        local = jnp.einsum(
-            "bxyzi,io->bxyzo",
-            hidden,
-            weights[f"w_local_{layer}"],
-        )
-        update = jax.nn.gelu(spectral + local)
-        hidden = (hidden + update) * jnp.asarray(2.0**-0.5, jnp.float32)
-    raw_correction = jnp.einsum(
-        "bxyzi,io->bxyzo",
-        hidden,
-        weights["w_out"],
+    return model.one_step(
+        weights,
+        velocity,
+        input_scale=weights["input_scale"],
+        correction_scale=weights["correction_scale"],
+        modes=_MODES,
+        layers=_LAYERS,
     )
-    amplitude = jnp.sqrt(
-        jnp.mean(velocity**2, axis=(1, 2, 3, 4), keepdims=True) + 1e-12
-    )
-    correction = (
-        raw_correction
-        * weights["correction_scale"].reshape(1, 1, 1, 1, 3)
-        * (amplitude / weights["input_scale"])
-    )
-    return _helmholtz_project(_diffuse(velocity) + correction)
 
 
 def _surrogate_forward(
@@ -202,17 +116,19 @@ def _surrogate_forward(
     weights: dict[str, jax.Array],
 ) -> jax.Array:
     """Apply the shared macro-step neural operator autoregressively 20 times."""
-
-    def body(_: int, velocity: jax.Array) -> jax.Array:
-        return _one_step(velocity, weights)
-
-    final = jax.lax.fori_loop(
-        0,
-        _ROLLOUT_STEPS,
-        body,
+    return model.rollout(
+        weights,
         initial_velocity[None],
-    )
-    return final[0]
+        steps=_ROLLOUT_STEPS,
+        input_scale=weights["input_scale"],
+        correction_scale=weights["correction_scale"],
+        modes=_MODES,
+        layers=_LAYERS,
+    )[0, -1]
+
+
+_helmholtz_project = model.helmholtz_project
+_diffuse = model.diffuse_macro
 
 
 @jax.jit

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_api.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_api.py
@@ -1,0 +1,291 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct full-field XLB surrogate for the fixed 3D IC-recovery task."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from mosaic_shared.problems.navier_stokes_grid import (
+    InputSchema as _CanonicalInputSchema,
+)
+from mosaic_shared.problems.navier_stokes_grid import (
+    OutputSchema as _CanonicalOutputSchema,
+)
+from mosaic_shared.schema_types import make_differentiable
+
+
+class InputSchema(make_differentiable(_CanonicalInputSchema, ["v0"])):
+    """Fixed-task surrogate with differentiable full 3D initial velocity."""
+
+
+class OutputSchema(make_differentiable(_CanonicalOutputSchema, ["result"])):
+    """Fixed-horizon full 3D velocity field."""
+
+
+_N = 16
+_VISCOSITY = 0.01
+_DT = 0.02
+_STEPS = 100
+_DOMAIN_EXTENT = 2.0 * math.pi
+_WIDTH = 32
+_MODES = 6
+_LAYERS = 6
+_WEIGHTS: dict[str, jax.Array] | None = None
+
+
+def _weights_path() -> Path:
+    packaged = Path("/tesseract/weights.npz")
+    return packaged if packaged.exists() else Path(__file__).with_name("weights.npz")
+
+
+def _load_weights() -> dict[str, jax.Array]:
+    """Load and validate the packaged Fourier-neural-operator parameters."""
+    global _WEIGHTS
+    if _WEIGHTS is None:
+        path = _weights_path()
+        if not path.exists():
+            raise RuntimeError(f"XLB 3D surrogate weights are missing: {path}")
+        with np.load(path, allow_pickle=False) as data:
+            metadata = {
+                "width": int(data["width"]),
+                "modes": int(data["modes"]),
+                "layers": int(data["layers"]),
+            }
+            expected = {
+                "width": _WIDTH,
+                "modes": _MODES,
+                "layers": _LAYERS,
+            }
+            if metadata != expected:
+                raise RuntimeError(
+                    f"XLB 3D surrogate architecture mismatch: {metadata} != {expected}"
+                )
+            required = {
+                "input_scale",
+                "correction_scale",
+                "w_lift",
+                "w_out",
+            }
+            for layer in range(_LAYERS):
+                required.add(f"w_local_{layer}")
+                for quadrant in range(4):
+                    required.add(f"spec_{layer}_{quadrant}_real")
+                    required.add(f"spec_{layer}_{quadrant}_imag")
+            missing = required - set(data.files)
+            if missing:
+                raise RuntimeError(
+                    f"XLB 3D surrogate weights are incomplete: {sorted(missing)}"
+                )
+            _WEIGHTS = {key: jnp.asarray(data[key]) for key in required}
+    return _WEIGHTS
+
+
+def _helmholtz_project(velocity: jax.Array) -> jax.Array:
+    """Project a batched periodic velocity field to the divergence-free subspace."""
+    velocity_hat = jnp.fft.rfftn(velocity, axes=(1, 2, 3))
+    k = jnp.fft.fftfreq(_N, d=1.0 / _N)
+    kz = jnp.fft.rfftfreq(_N, d=1.0 / _N)
+    kx, ky, kz_grid = jnp.meshgrid(k, k, kz, indexing="ij")
+    wave = jnp.stack([kx, ky, kz_grid], axis=-1)
+    k2 = jnp.sum(wave**2, axis=-1)
+    safe_k2 = jnp.where(k2 == 0, 1.0, k2)
+    dot = jnp.sum(velocity_hat * wave, axis=-1)
+    projected_hat = velocity_hat - wave * (dot / safe_k2)[..., None]
+    projected_hat = projected_hat.at[:, 0, 0, 0, :].set(velocity_hat[:, 0, 0, 0, :])
+    return jnp.fft.irfftn(
+        projected_hat,
+        s=(_N, _N, _N),
+        axes=(1, 2, 3),
+    ).real.astype(jnp.float32)
+
+
+def _diffuse(velocity: jax.Array) -> jax.Array:
+    """Exact linear viscous evolution over the fixed recovery horizon."""
+    velocity_hat = jnp.fft.rfftn(
+        _helmholtz_project(velocity),
+        axes=(1, 2, 3),
+    )
+    k = jnp.fft.fftfreq(_N, d=1.0 / _N)
+    kz = jnp.fft.rfftfreq(_N, d=1.0 / _N)
+    kx, ky, kz_grid = jnp.meshgrid(k, k, kz, indexing="ij")
+    k2 = kx**2 + ky**2 + kz_grid**2
+    decay = jnp.exp(-_VISCOSITY * (_DT * _STEPS) * k2)
+    return jnp.fft.irfftn(
+        velocity_hat * decay[..., None],
+        s=(_N, _N, _N),
+        axes=(1, 2, 3),
+    ).real.astype(jnp.float32)
+
+
+def _spectral_convolution(
+    hidden: jax.Array,
+    weights: dict[str, jax.Array],
+    layer: int,
+) -> jax.Array:
+    hidden_hat = jnp.fft.rfftn(hidden, axes=(1, 2, 3))
+    output_hat = jnp.zeros_like(hidden_hat)
+    selections = (
+        (slice(0, _MODES), slice(0, _MODES)),
+        (slice(-_MODES, None), slice(0, _MODES)),
+        (slice(0, _MODES), slice(-_MODES, None)),
+        (slice(-_MODES, None), slice(-_MODES, None)),
+    )
+    for quadrant, (sx, sy) in enumerate(selections):
+        spectral_weight = (
+            weights[f"spec_{layer}_{quadrant}_real"]
+            + 1j * weights[f"spec_{layer}_{quadrant}_imag"]
+        )
+        transformed = jnp.einsum(
+            "bxyzi,xyzio->bxyzo",
+            hidden_hat[:, sx, sy, :_MODES, :],
+            spectral_weight,
+        )
+        output_hat = output_hat.at[:, sx, sy, :_MODES, :].set(transformed)
+    return jnp.fft.irfftn(
+        output_hat,
+        s=(_N, _N, _N),
+        axes=(1, 2, 3),
+    ).real.astype(jnp.float32)
+
+
+def _surrogate_forward(
+    initial_velocity: jax.Array,
+    weights: dict[str, jax.Array],
+) -> jax.Array:
+    """Map one full initial field directly to the fixed-horizon final field."""
+    velocity = _helmholtz_project(initial_velocity[None])
+    normalized = velocity / weights["input_scale"]
+    hidden = jnp.einsum("bxyzi,io->bxyzo", normalized, weights["w_lift"])
+    for layer in range(_LAYERS):
+        spectral = _spectral_convolution(hidden, weights, layer)
+        local = jnp.einsum(
+            "bxyzi,io->bxyzo",
+            hidden,
+            weights[f"w_local_{layer}"],
+        )
+        update = jax.nn.gelu(spectral + local)
+        hidden = (hidden + update) * jnp.asarray(2.0**-0.5, jnp.float32)
+    raw_correction = jnp.einsum(
+        "bxyzi,io->bxyzo",
+        hidden,
+        weights["w_out"],
+    )
+    amplitude = jnp.sqrt(jnp.mean(velocity**2, keepdims=True) + 1e-12)
+    correction = (
+        raw_correction
+        * weights["correction_scale"].reshape(1, 1, 1, 1, 3)
+        * (amplitude / weights["input_scale"])
+    )
+    return _helmholtz_project(_diffuse(velocity) + correction)[0]
+
+
+@jax.jit
+def _apply_jit(
+    initial_velocity: jax.Array,
+    weights: dict[str, jax.Array],
+) -> jax.Array:
+    return _surrogate_forward(initial_velocity, weights)
+
+
+@jax.jit
+def _vjp_jit(
+    initial_velocity: jax.Array,
+    result_cotangent: jax.Array,
+    weights: dict[str, jax.Array],
+) -> jax.Array:
+    _, pullback = jax.vjp(
+        lambda velocity: _surrogate_forward(velocity, weights),
+        initial_velocity,
+    )
+    return pullback(result_cotangent)[0].astype(jnp.float32)
+
+
+def _as_float(value: Any) -> float:
+    array = np.asarray(value)
+    return float(array.reshape(-1)[0])
+
+
+def _validate_contract(inputs: InputSchema) -> None:
+    data = inputs.model_dump()
+    v0 = np.asarray(data["v0"])
+    if v0.shape != (_N, _N, _N, 3):
+        raise ValueError(f"XLB 3D surrogate requires v0 shape ({_N}, {_N}, {_N}, 3)")
+    if not np.all(np.isfinite(v0)):
+        raise ValueError("XLB 3D surrogate requires finite v0 values")
+    fixed_scalars = {
+        "viscosity": (_as_float(data["viscosity"]), _VISCOSITY),
+        "dt": (_as_float(data["dt"]), _DT),
+        "steps": (float(data["steps"]), float(_STEPS)),
+        "domain_extent": (float(data["domain_extent"]), _DOMAIN_EXTENT),
+    }
+    for name, (actual, expected) in fixed_scalars.items():
+        if not np.isclose(actual, expected, rtol=0.0, atol=1e-7):
+            raise ValueError(
+                f"XLB 3D surrogate requires {name}={expected}, received {actual}"
+            )
+    if not inputs.boundary_conditions.is_fully_periodic:
+        raise ValueError("XLB 3D surrogate requires fully periodic boundaries")
+    if inputs.obstacle is not None or inputs.inflow_profile is not None:
+        raise ValueError(
+            "XLB 3D surrogate does not support obstacles or inflow profiles"
+        )
+
+
+def apply(inputs: InputSchema) -> dict[str, jax.Array | None]:
+    """Evaluate the direct IC-to-final-state full-field surrogate."""
+    _validate_contract(inputs)
+    initial_velocity = jnp.asarray(inputs.v0, dtype=jnp.float32)
+    return {
+        "result": _apply_jit(initial_velocity, _load_weights()),
+        # The canonical grid schema always exposes drag.  This task has no
+        # obstacle, so match the other periodic solvers with a zero scalar.
+        "drag": jnp.zeros((1,), dtype=jnp.float32),
+    }
+
+
+def vector_jacobian_product(
+    inputs: InputSchema,
+    vjp_inputs: set[str],
+    vjp_outputs: set[str],
+    cotangent_vector: dict[str, Any],
+) -> dict[str, jax.Array]:
+    """Differentiate the full final field with respect to the full initial field."""
+    _validate_contract(inputs)
+    unsupported = set(vjp_inputs) - {"v0"}
+    if unsupported:
+        raise ValueError(f"XLB 3D surrogate only differentiates v0, not {unsupported}")
+    initial_velocity = jnp.asarray(inputs.v0, dtype=jnp.float32)
+    result_cotangent = (
+        jnp.asarray(cotangent_vector["result"], dtype=jnp.float32)
+        if "result" in vjp_outputs
+        else jnp.zeros_like(initial_velocity)
+    )
+    return {
+        "v0": _vjp_jit(
+            initial_velocity,
+            result_cotangent,
+            _load_weights(),
+        )
+    }
+
+
+def abstract_eval(abstract_inputs: Any) -> dict[str, dict[str, Any]]:
+    """Return output metadata matching the full input velocity field."""
+    v0_info = abstract_inputs.v0
+    if isinstance(v0_info, dict):
+        shape = tuple(v0_info["shape"])
+        dtype = v0_info.get("dtype", "float32")
+    else:
+        shape = tuple(v0_info.shape)
+        dtype = "float32"
+    return {
+        "result": {"shape": shape, "dtype": dtype},
+        "drag": {"shape": (1,), "dtype": "float32"},
+    }

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_config.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_config.yaml
@@ -1,0 +1,26 @@
+name: xlb_3d_surrogate_navier_stokes_grid
+version: "0.1.0"
+description: >
+  Differentiable direct full-field surrogate of XLB for the fixed N=16 3D
+  initial-condition recovery task. A periodic Fourier neural operator maps the
+  complete initial velocity directly to the 100-step final velocity.
+build_config:
+  base_image: "nvidia/cuda:12.6.3-runtime-ubuntu24.04"
+  package_data:
+    - ["./weights.npz", "/tesseract/weights.npz"]
+env:
+  XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+
+metadata:
+  mosaic:
+    name: "XLB 3D surrogate"
+    backend: jax
+    family: surrogate
+    scheme: "direct full-field Fourier neural operator"
+    discretization: Learned
+    numerics: "3D FNO with viscous skip and Helmholtz projection"
+    ad_strategy: autodiff
+    differentiable: true
+    uses_gpu: true
+    internal_dtype: float32
+    doc_url: "https://github.com/pasteurlabs/mosaic"

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_config.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_config.yaml
@@ -9,6 +9,10 @@ build_config:
   base_image: "nvidia/cuda:12.6.3-runtime-ubuntu24.04"
   package_data:
     - ["./weights.npz", "/tesseract/weights.npz"]
+    - ["./surrogate_model.py", "/tesseract/surrogate_model.py"]
+    - ["./training_data.py", "/tesseract/training_data.py"]
+    - ["./generate_trajectories.py", "/tesseract/generate_trajectories.py"]
+    - ["./train.py", "/tesseract/train.py"]
 env:
   XLA_PYTHON_CLIENT_PREALLOCATE: "false"
 

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_config.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_config.yaml
@@ -1,9 +1,10 @@
 name: xlb_3d_surrogate_navier_stokes_grid
 version: "0.1.0"
 description: >
-  Differentiable direct full-field surrogate of XLB for the fixed N=16 3D
-  initial-condition recovery task. A periodic Fourier neural operator maps the
-  complete initial velocity directly to the 100-step final velocity.
+  Differentiable autoregressive full-field surrogate of XLB for the fixed N=16
+  3D initial-condition recovery task. One periodic Fourier neural operator
+  advances the complete velocity by five XLB steps and is reused for a
+  20-macro-step rollout.
 build_config:
   base_image: "nvidia/cuda:12.6.3-runtime-ubuntu24.04"
   package_data:
@@ -16,9 +17,9 @@ metadata:
     name: "XLB 3D surrogate"
     backend: jax
     family: surrogate
-    scheme: "direct full-field Fourier neural operator"
+    scheme: "autoregressive full-field Fourier neural operator"
     discretization: Learned
-    numerics: "3D FNO with viscous skip and Helmholtz projection"
+    numerics: "shared 5-step 3D FNO, 20-step rollout, viscous skip, Helmholtz projection"
     ad_strategy: autodiff
     differentiable: true
     uses_gpu: true

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_config.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_config.yaml
@@ -10,9 +10,6 @@ build_config:
   package_data:
     - ["./weights.npz", "/tesseract/weights.npz"]
     - ["./surrogate_model.py", "/tesseract/surrogate_model.py"]
-    - ["./training_data.py", "/tesseract/training_data.py"]
-    - ["./generate_trajectories.py", "/tesseract/generate_trajectories.py"]
-    - ["./train.py", "/tesseract/train.py"]
 env:
   XLA_PYTHON_CLIENT_PREALLOCATE: "false"
 

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_requirements.txt
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/tesseract_requirements.txt
@@ -1,0 +1,2 @@
+jax[cuda12]==0.11.0
+../../../mosaic_shared

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/train.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/train.py
@@ -374,12 +374,34 @@ def main() -> None:
 
     validation_subset = val_idx[: min(args.validation_samples, val_idx.size)]
     rng = np.random.default_rng(args.seed + 3)
+    initial_predictions = evaluate_indices(params, validation_subset)
+    initial_targets = np.asarray(
+        trajectories[validation_subset, 1:],
+        dtype=np.float32,
+    )
+    initial_validation_errors = _relative_l2(
+        initial_predictions,
+        initial_targets,
+    )
+    initial_validation_mean = float(np.mean(initial_validation_errors))
+    initial_validation_final = float(np.mean(initial_validation_errors[:, -1]))
     best_params: dict[str, Any] = jax.tree.map(
         lambda value: np.asarray(value),
         params,
     )
-    best_validation = float("inf")
+    best_validation = initial_validation_final
     best_global_step = 0
+    print(
+        " ".join(
+            (
+                "global_step=0",
+                f"validation_rollout_relative_l2_mean={initial_validation_mean}",
+                f"validation_final_relative_l2_mean={initial_validation_final}",
+                "best_global_step=0",
+            )
+        ),
+        flush=True,
+    )
     global_step = 0
     history: list[dict[str, Any]] = []
     for phase_index, (horizon, phase_updates) in enumerate(phases):
@@ -523,6 +545,8 @@ def main() -> None:
             {"unroll_horizon": horizon, "updates": updates}
             for horizon, updates in phases
         ],
+        "initial_validation_rollout_relative_l2": initial_validation_mean,
+        "initial_validation_final_relative_l2": initial_validation_final,
         "best_global_step": best_global_step,
         "best_validation_final_relative_l2": best_validation,
         "test_nonzero_samples": int(np.count_nonzero(test_nonzero)),

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/train.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/train.py
@@ -1,0 +1,553 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Curriculum-train the autoregressive full-field 3D neural operator.
+
+The input is a memory-mapped trajectory array produced by
+``generate_trajectories.py`` and its adjacent ``.split.npz`` file. Cluster
+submission and container orchestration intentionally remain outside this
+Tesseract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import surrogate_model as fno
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _parse_curriculum(value: str) -> list[tuple[int, int]]:
+    phases: list[tuple[int, int]] = []
+    for item in value.split(","):
+        horizon_text, updates_text = item.split(":", 1)
+        horizon = int(horizon_text)
+        updates = int(updates_text)
+        if horizon < 1 or horizon > fno.ROLLOUT_STEPS or updates < 1:
+            raise ValueError(f"invalid curriculum phase {item!r}")
+        phases.append((horizon, updates))
+    if not phases or phases[-1][0] != fno.ROLLOUT_STEPS:
+        raise ValueError(f"curriculum must end at full horizon {fno.ROLLOUT_STEPS}")
+    return phases
+
+
+def _relative_l2(predicted: np.ndarray, target: np.ndarray) -> np.ndarray:
+    axes = tuple(range(2, predicted.ndim))
+    return np.sqrt(
+        np.sum((predicted - target) ** 2, axis=axes)
+        / (np.sum(target**2, axis=axes) + 1e-20)
+    )
+
+
+def _estimate_scales(
+    trajectories: np.ndarray,
+    train_idx: np.ndarray,
+    *,
+    scale_samples: int,
+) -> tuple[float, np.ndarray, np.ndarray]:
+    selected = train_idx[: min(scale_samples, train_idx.size)]
+    sum_sq = 0.0
+    count = 0
+    channel_sum_sq = np.zeros(3, dtype=np.float64)
+    channel_count = 0
+    for start in range(0, selected.size, 8):
+        batch = np.asarray(
+            trajectories[selected[start : start + 8]],
+            dtype=np.float32,
+        )
+        sum_sq += float(np.sum(batch.astype(np.float64) ** 2))
+        count += batch.size
+        channel_sum_sq += np.sum(
+            batch.astype(np.float64) ** 2,
+            axis=(0, 1, 2, 3, 4),
+        )
+        channel_count += int(np.prod(batch.shape[:-1]))
+    input_scale = float(np.sqrt(sum_sq / count))
+    output_scale = np.sqrt(channel_sum_sq / channel_count)
+
+    @jax.jit
+    def diffuse(values: jax.Array) -> jax.Array:
+        return fno.diffuse_macro(values)
+
+    correction_sum_sq = np.zeros(3, dtype=np.float64)
+    correction_count = 0
+    for start in range(0, selected.size, 4):
+        batch = np.asarray(
+            trajectories[selected[start : start + 4]],
+            dtype=np.float32,
+        )
+        current = batch[:, :-1].reshape(-1, fno.N, fno.N, fno.N, 3)
+        target = batch[:, 1:].reshape(-1, fno.N, fno.N, fno.N, 3)
+        for transition_start in range(0, current.shape[0], 32):
+            transition_stop = min(transition_start + 32, current.shape[0])
+            linear = np.asarray(
+                diffuse(jnp.asarray(current[transition_start:transition_stop]))
+            )
+            correction = (target[transition_start:transition_stop] - linear).astype(
+                np.float64
+            )
+            correction_sum_sq += np.sum(
+                correction**2,
+                axis=(0, 1, 2, 3),
+            )
+            correction_count += int(np.prod(correction.shape[:-1]))
+    correction_scale = np.sqrt(correction_sum_sq / correction_count)
+    return (
+        max(input_scale, 1e-5),
+        np.maximum(correction_scale, 1e-6).astype(np.float32),
+        np.maximum(output_scale, 1e-5).astype(np.float32),
+    )
+
+
+def main() -> None:
+    """Train, select by validation rollout error, and export one checkpoint."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=Path("/surrogate-output/recovery_3d_xlb_trajectories.npy"),
+    )
+    parser.add_argument(
+        "--weights",
+        type=Path,
+        default=Path("/surrogate-output/recovery_3d_autoregressive_weights.npz"),
+    )
+    parser.add_argument("--init-weights", type=Path)
+    parser.add_argument("--width", type=int, default=32)
+    parser.add_argument("--modes", type=int, default=6)
+    parser.add_argument("--layers", type=int, default=6)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--lr", type=float, default=8e-4)
+    parser.add_argument("--min-lr", type=float, default=2e-5)
+    parser.add_argument("--seed", type=int, default=20260727)
+    parser.add_argument("--scale-samples", type=int, default=2048)
+    parser.add_argument("--validation-samples", type=int, default=256)
+    parser.add_argument("--validation-interval", type=int, default=400)
+    parser.add_argument(
+        "--curriculum",
+        default="1:7200,2:5600,4:5600,8:4800,12:4000,20:4800",
+    )
+    args = parser.parse_args()
+    phases = _parse_curriculum(args.curriculum)
+    started = time.perf_counter()
+    print("jax_backend", jax.default_backend(), flush=True)
+    print("jax_devices", jax.devices(), flush=True)
+    print(f"curriculum={phases}", flush=True)
+
+    trajectories = np.load(args.dataset, mmap_mode="r")
+    expected_tail = (
+        fno.ROLLOUT_STEPS + 1,
+        fno.N,
+        fno.N,
+        fno.N,
+        3,
+    )
+    if trajectories.shape[1:] != expected_tail:
+        raise ValueError(
+            f"trajectory shape {trajectories.shape} does not end in {expected_tail}"
+        )
+    split_path = args.dataset.with_suffix(".split.npz")
+    with np.load(split_path, allow_pickle=False) as split_data:
+        split = np.asarray(split_data["split"])
+        amplitudes = np.asarray(split_data["amplitudes"], dtype=np.float32)
+    train_idx = np.flatnonzero(split == 0)
+    val_idx = np.flatnonzero(split == 1)
+    test_idx = np.flatnonzero(split == 2)
+    input_scale, correction_scale, output_scale = _estimate_scales(
+        trajectories,
+        train_idx,
+        scale_samples=args.scale_samples,
+    )
+    print(
+        f"input_scale={input_scale:.7g} "
+        f"correction_scale={correction_scale.tolist()} "
+        f"output_scale={output_scale.tolist()}",
+        flush=True,
+    )
+
+    input_scale_jax = jnp.asarray(input_scale, dtype=jnp.float32)
+    correction_scale_jax = jnp.asarray(correction_scale)
+    output_scale_jax = jnp.asarray(output_scale).reshape(1, 1, 1, 1, 1, 3)
+    params = fno.init_params(
+        width=args.width,
+        modes=args.modes,
+        layers=args.layers,
+        seed=args.seed,
+    )
+    if args.init_weights is not None:
+        metadata_keys = {
+            "input_scale",
+            "correction_scale",
+            "width",
+            "modes",
+            "layers",
+            "solver_dt",
+            "solver_steps",
+            "stride",
+            "macro_dt",
+            "rollout_steps",
+            "autoregressive",
+        }
+        with np.load(args.init_weights, allow_pickle=False) as checkpoint:
+            if (
+                int(checkpoint["width"]) != args.width
+                or int(checkpoint["modes"]) != args.modes
+                or int(checkpoint["layers"]) != args.layers
+                or int(checkpoint["autoregressive"]) != 1
+            ):
+                raise ValueError("initial checkpoint architecture mismatch")
+            loaded = {
+                key: jnp.asarray(checkpoint[key])
+                for key in checkpoint.files
+                if key not in metadata_keys
+            }
+        if set(loaded) != set(params):
+            raise ValueError(
+                "initial checkpoint parameter mismatch: "
+                f"missing={sorted(set(params) - set(loaded))}, "
+                f"extra={sorted(set(loaded) - set(params))}"
+            )
+        params = loaded
+        print(f"initialized_from={args.init_weights}", flush=True)
+    first_moment = jax.tree.map(jnp.zeros_like, params)
+    second_moment = jax.tree.map(jnp.zeros_like, params)
+
+    def predict(
+        current: dict[str, jax.Array],
+        initial: jax.Array,
+        horizon: int,
+    ) -> jax.Array:
+        return fno.rollout(
+            current,
+            initial,
+            steps=horizon,
+            input_scale=input_scale_jax,
+            correction_scale=correction_scale_jax,
+            modes=args.modes,
+            layers=args.layers,
+        )
+
+    def make_update(horizon: int, phase_updates: int, phase_index: int):
+        def loss_fn(
+            current: dict[str, jax.Array],
+            initial: jax.Array,
+            target: jax.Array,
+        ) -> tuple[jax.Array, tuple[jax.Array, jax.Array, jax.Array]]:
+            predicted = predict(current, initial, horizon)
+            difference = (predicted - target) / output_scale_jax
+            per_time_field = jnp.mean(
+                difference**2,
+                axis=(0, 2, 3, 4, 5),
+            )
+            time_weights = jnp.linspace(
+                1.0,
+                2.0,
+                horizon,
+                dtype=jnp.float32,
+            )
+            field_loss = jnp.sum(per_time_field * time_weights) / jnp.sum(time_weights)
+            flattened = difference.reshape(-1, fno.N, fno.N, fno.N, 3)
+            error_hat = jnp.fft.rfftn(flattened, axes=(1, 2, 3))
+            k = jnp.fft.fftfreq(fno.N, d=1.0 / fno.N)
+            kz = jnp.fft.rfftfreq(fno.N, d=1.0 / fno.N)
+            kx, ky, kz_grid = jnp.meshgrid(k, k, kz, indexing="ij")
+            spectral_weight = jnp.sqrt(1.0 + kx**2 + ky**2 + kz_grid**2)
+            spectral_loss = jnp.mean(
+                jnp.abs(error_hat) ** 2 * spectral_weight[None, ..., None]
+            ) / (fno.N**3)
+            terminal_loss = jnp.mean(difference[:, -1] ** 2)
+            loss = field_loss + 0.02 * spectral_loss + 0.25 * terminal_loss
+            loss += 1e-8 * fno.tree_l2(current)
+            return loss, (field_loss, spectral_loss, terminal_loss)
+
+        @jax.jit
+        def update(
+            current: dict[str, jax.Array],
+            first: dict[str, jax.Array],
+            second: dict[str, jax.Array],
+            initial: jax.Array,
+            target: jax.Array,
+            global_step: jax.Array,
+            phase_step: jax.Array,
+        ):
+            (loss, components), gradients = jax.value_and_grad(loss_fn, has_aux=True)(
+                current, initial, target
+            )
+            gradients = jax.tree.map(
+                lambda value: jnp.nan_to_num(
+                    value,
+                    nan=0.0,
+                    posinf=1e3,
+                    neginf=-1e3,
+                ),
+                gradients,
+            )
+            grad_norm = jnp.sqrt(sum(jnp.sum(value**2) for value in gradients.values()))
+            clip_scale = jnp.minimum(1.0, 1.0 / (grad_norm + 1e-12))
+            gradients = jax.tree.map(
+                lambda value: value * clip_scale,
+                gradients,
+            )
+            beta1 = 0.9
+            beta2 = 0.999
+            first = jax.tree.map(
+                lambda old, grad: beta1 * old + (1.0 - beta1) * grad,
+                first,
+                gradients,
+            )
+            second = jax.tree.map(
+                lambda old, grad: beta2 * old + (1.0 - beta2) * grad**2,
+                second,
+                gradients,
+            )
+            global_float = global_step.astype(jnp.float32)
+            first_hat = jax.tree.map(
+                lambda value: value / (1.0 - beta1**global_float),
+                first,
+            )
+            second_hat = jax.tree.map(
+                lambda value: value / (1.0 - beta2**global_float),
+                second,
+            )
+            progress = (phase_step.astype(jnp.float32) - 1.0) / max(
+                phase_updates - 1,
+                1,
+            )
+            phase_lr = args.lr * (0.82**phase_index)
+            learning_rate = args.min_lr + 0.5 * (phase_lr - args.min_lr) * (
+                1.0 + jnp.cos(jnp.pi * progress)
+            )
+            current = jax.tree.map(
+                lambda value, mm, vv: (
+                    value - learning_rate * mm / (jnp.sqrt(vv) + 1e-8)
+                ),
+                current,
+                first_hat,
+                second_hat,
+            )
+            return (
+                current,
+                first,
+                second,
+                loss,
+                components,
+                learning_rate,
+                grad_norm,
+            )
+
+        return update
+
+    predict_full = jax.jit(
+        lambda current, initial: predict(
+            current,
+            initial,
+            fno.ROLLOUT_STEPS,
+        )
+    )
+
+    def evaluate_indices(
+        current: dict[str, jax.Array],
+        indices: np.ndarray,
+        batch_size: int = 4,
+    ) -> np.ndarray:
+        predictions: list[np.ndarray] = []
+        for start in range(0, indices.size, batch_size):
+            batch_indices = indices[start : start + batch_size]
+            initial = jnp.asarray(np.asarray(trajectories[batch_indices, 0]))
+            predictions.append(np.asarray(predict_full(current, initial)))
+        return np.concatenate(predictions)
+
+    validation_subset = val_idx[: min(args.validation_samples, val_idx.size)]
+    rng = np.random.default_rng(args.seed + 3)
+    best_params: dict[str, Any] = jax.tree.map(
+        lambda value: np.asarray(value),
+        params,
+    )
+    best_validation = float("inf")
+    best_global_step = 0
+    global_step = 0
+    history: list[dict[str, Any]] = []
+    for phase_index, (horizon, phase_updates) in enumerate(phases):
+        print(
+            f"phase={phase_index + 1}/{len(phases)} "
+            f"horizon={horizon} updates={phase_updates}",
+            flush=True,
+        )
+        update = make_update(horizon, phase_updates, phase_index)
+        max_start = fno.ROLLOUT_STEPS - horizon
+        for phase_step in range(1, phase_updates + 1):
+            global_step += 1
+            batch_indices = rng.choice(
+                train_idx,
+                size=min(args.batch_size, train_idx.size),
+                replace=False,
+            )
+            if max_start:
+                starts = rng.integers(0, max_start + 1, size=batch_indices.size)
+                starts[0] = 0
+            else:
+                starts = np.zeros(batch_indices.size, dtype=np.int64)
+            initial_np = np.stack(
+                [
+                    np.asarray(trajectories[index, start], dtype=np.float32)
+                    for index, start in zip(batch_indices, starts, strict=True)
+                ]
+            )
+            target_np = np.stack(
+                [
+                    np.asarray(
+                        trajectories[
+                            index,
+                            start + 1 : start + horizon + 1,
+                        ],
+                        dtype=np.float32,
+                    )
+                    for index, start in zip(batch_indices, starts, strict=True)
+                ]
+            )
+            (
+                params,
+                first_moment,
+                second_moment,
+                loss,
+                components,
+                learning_rate,
+                grad_norm,
+            ) = update(
+                params,
+                first_moment,
+                second_moment,
+                jnp.asarray(initial_np),
+                jnp.asarray(target_np),
+                jnp.asarray(global_step),
+                jnp.asarray(phase_step),
+            )
+            should_validate = (
+                phase_step == 1
+                or phase_step == phase_updates
+                or phase_step % args.validation_interval == 0
+            )
+            if not should_validate:
+                continue
+            predicted_val = evaluate_indices(params, validation_subset)
+            target_val = np.asarray(
+                trajectories[validation_subset, 1:],
+                dtype=np.float32,
+            )
+            validation_errors = _relative_l2(predicted_val, target_val)
+            validation_final = float(np.mean(validation_errors[:, -1]))
+            validation_mean = float(np.mean(validation_errors))
+            if validation_final < best_validation:
+                best_validation = validation_final
+                best_global_step = global_step
+                best_params = jax.tree.map(
+                    lambda value: np.asarray(value),
+                    params,
+                )
+            field_loss, spectral_loss, terminal_loss = map(float, components)
+            record = {
+                "global_step": global_step,
+                "phase": phase_index + 1,
+                "horizon": horizon,
+                "phase_step": phase_step,
+                "loss": float(loss),
+                "field_loss": field_loss,
+                "spectral_loss": spectral_loss,
+                "terminal_loss": terminal_loss,
+                "validation_rollout_relative_l2_mean": validation_mean,
+                "validation_final_relative_l2_mean": validation_final,
+                "learning_rate": float(learning_rate),
+                "gradient_norm_pre_clip": float(grad_norm),
+                "best_global_step": best_global_step,
+            }
+            history.append(record)
+            print(
+                " ".join(f"{key}={value}" for key, value in record.items()),
+                flush=True,
+            )
+
+    best_jax = jax.tree.map(jnp.asarray, best_params)
+    predicted_test = evaluate_indices(best_jax, test_idx)
+    target_test = np.asarray(trajectories[test_idx, 1:], dtype=np.float32)
+    test_error = _relative_l2(predicted_test, target_test)
+    test_nonzero = amplitudes[test_idx] >= 0.05
+    test_error_nonzero = test_error[test_nonzero]
+    args.weights.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        args.weights,
+        **fno.serialize_params(
+            best_params,
+            input_scale=input_scale,
+            correction_scale=correction_scale,
+            width=args.width,
+            modes=args.modes,
+            layers=args.layers,
+        ),
+    )
+    metrics = {
+        "architecture": "autoregressive_fourier_neural_operator",
+        "teacher": "xlb_kbc",
+        "initialized_from": (
+            str(args.init_weights) if args.init_weights is not None else None
+        ),
+        "dataset_sha256": _sha256(args.dataset),
+        "split_sha256": _sha256(split_path),
+        "weights_sha256": _sha256(args.weights),
+        "samples": int(trajectories.shape[0]),
+        "train_samples": int(train_idx.size),
+        "validation_samples": int(val_idx.size),
+        "test_samples": int(test_idx.size),
+        "width": args.width,
+        "modes": args.modes,
+        "layers": args.layers,
+        "solver_steps": fno.SOLVER_STEPS,
+        "snapshot_stride_solver_steps": fno.STRIDE,
+        "macro_dt": fno.MACRO_DT,
+        "rollout_steps": fno.ROLLOUT_STEPS,
+        "curriculum": [
+            {"unroll_horizon": horizon, "updates": updates}
+            for horizon, updates in phases
+        ],
+        "best_global_step": best_global_step,
+        "best_validation_final_relative_l2": best_validation,
+        "test_nonzero_samples": int(np.count_nonzero(test_nonzero)),
+        "test_rollout_relative_l2_mean": float(np.mean(test_error_nonzero)),
+        "test_final_relative_l2_mean": float(np.mean(test_error_nonzero[:, -1])),
+        "test_final_relative_l2_median": float(np.median(test_error_nonzero[:, -1])),
+        "test_final_relative_l2_p95": float(
+            np.quantile(test_error_nonzero[:, -1], 0.95)
+        ),
+        "test_relative_l2_by_macro_step": np.mean(
+            test_error_nonzero,
+            axis=0,
+        ).tolist(),
+        "test_rollout_relative_l2_mean_including_zero_anchors": float(
+            np.mean(test_error)
+        ),
+        "input_scale": input_scale,
+        "correction_scale": correction_scale.tolist(),
+        "output_scale": output_scale.tolist(),
+        "history": history,
+        "elapsed_seconds": time.perf_counter() - started,
+    }
+    args.weights.with_suffix(".metrics.json").write_text(json.dumps(metrics, indent=2))
+    print(json.dumps(metrics, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/training_data.py
+++ b/mosaic/tesseracts/navier-stokes-grid/xlb-3d-surrogate/training_data.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Initial-condition distribution used for XLB trajectory generation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+N = 16
+
+
+def _rand_div_free(
+    rng: np.random.Generator,
+    *,
+    k_peak: float,
+    k_width: float,
+) -> np.ndarray:
+    """Sample one smooth periodic divergence-free velocity field."""
+    kn = np.fft.fftfreq(N, d=1.0 / N)
+    kx, ky, kz = np.meshgrid(kn, kn, kn, indexing="ij")
+    k_abs = np.sqrt(kx**2 + ky**2 + kz**2)
+    envelope = np.exp(-0.5 * ((k_abs - k_peak) / k_width) ** 2)
+    potentials = [
+        (rng.standard_normal((N, N, N)) + 1j * rng.standard_normal((N, N, N)))
+        * envelope
+        for _ in range(3)
+    ]
+    ax, ay, az = potentials
+    velocity = np.stack(
+        [
+            np.fft.ifftn(1j * (ky * az - kz * ay)).real,
+            np.fft.ifftn(1j * (kz * ax - kx * az)).real,
+            np.fft.ifftn(1j * (kx * ay - ky * ax)).real,
+        ],
+        axis=-1,
+    )
+    velocity -= np.mean(velocity, axis=(0, 1, 2), keepdims=True)
+    max_speed = np.sqrt(np.sum(velocity**2, axis=-1)).max()
+    return (velocity / max(max_speed, 1e-12)).astype(np.float32)
+
+
+def make_inputs(
+    count: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Build the deterministic training IC distribution and metadata arrays."""
+    rng = np.random.default_rng(seed)
+    fields = np.empty((count, N, N, N, 3), dtype=np.float32)
+    amplitudes = np.empty((count,), dtype=np.float32)
+    families = np.empty((count,), dtype=np.int8)
+    for index in range(count):
+        family = index % 5
+        # Four fifths match the exact recovery spectrum. The last fifth
+        # broadens coverage of states visited by optimization.
+        if family < 4:
+            k_peak = 2.0
+            k_width = 1.0
+        else:
+            k_peak = rng.uniform(1.25, 4.5)
+            k_width = rng.uniform(0.5, 1.6)
+        field = _rand_div_free(rng, k_peak=k_peak, k_width=k_width)
+        bucket = index % 10
+        if bucket == 0:
+            amplitude = rng.uniform(0.0, 0.15)
+        elif bucket < 3:
+            amplitude = rng.uniform(0.15, 0.5)
+        else:
+            amplitude = rng.uniform(0.5, 1.25)
+        fields[index] = amplitude * field
+        amplitudes[index] = amplitude
+        families[index] = family
+
+    # Exact anchors make the zero-to-unit-amplitude recovery path explicit.
+    anchor_rng = np.random.default_rng(seed + 1_000_000)
+    anchor = _rand_div_free(anchor_rng, k_peak=2.0, k_width=1.0)
+    for index, amplitude in enumerate((0.0, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.25)):
+        if index >= count:
+            break
+        fields[index] = amplitude * anchor
+        amplitudes[index] = amplitude
+        families[index] = 0
+    return fields, amplitudes, families

--- a/tests/test_dummy_integration.py
+++ b/tests/test_dummy_integration.py
@@ -288,6 +288,7 @@ def _maybe_shrink(cfg, problem: str, exp_key: str) -> None:
         exp_key
         in {
             "optimization/solver_in_loop",
+            "optimization/solver_in_loop_curriculum",
             "optimization/solver_in_loop_self_reference",
             "optimization/solver_in_loop_tgv",
         }
@@ -469,7 +470,7 @@ def dummy_corpus(tmp_path_factory):
                 tags = dict.fromkeys(cfg.solver_names, tag)
                 try:
                     cfg.experiments[exp_key].fn(cfg, tags)
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001 - corpus records every failure
                     errors[(problem, exp_key)] = exc
         yield {"results_root": results_root, "errors": errors}
     finally:

--- a/tests/test_dummy_integration.py
+++ b/tests/test_dummy_integration.py
@@ -470,7 +470,7 @@ def dummy_corpus(tmp_path_factory):
                 tags = dict.fromkeys(cfg.solver_names, tag)
                 try:
                     cfg.experiments[exp_key].fn(cfg, tags)
-                except Exception as exc:  # noqa: BLE001 - corpus records every failure
+                except Exception as exc:
                     errors[(problem, exp_key)] = exc
         yield {"results_root": results_root, "errors": errors}
     finally:

--- a/tests/test_shared_optimization.py
+++ b/tests/test_shared_optimization.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for shared optimisation diagnostics."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+from mosaic.benchmarks.problems.shared.optimization import _run_lbfgs
+
+
+def test_lbfgs_records_iterate_and_projected_gradient_diagnostics():
+    init = jnp.asarray([2.0, -1.0], dtype=jnp.float32)
+
+    _, losses, diagnostics = _run_lbfgs(
+        lambda value: jnp.sum((value - 0.25) ** 2),
+        init,
+        max_iters=3,
+        record_diagnostics=True,
+        div_fn=lambda value: float(np.max(np.abs(value))),
+        grad_proj_fn=lambda gradient: gradient.at[1].set(0.0),
+    )
+
+    assert len(losses) == 3
+    assert len(diagnostics["grad_norms"]) == len(losses)
+    assert len(diagnostics["grad_divs"]) == len(losses)
+    assert len(diagnostics["ic_divs"]) == len(losses)
+    assert diagnostics["grad_divs"][0] == 3.5
+    assert all(np.isfinite(diagnostics["ic_divs"]))

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -1277,9 +1277,18 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
     out_dir = tmp_path / "ns-grid" / "optimization" / "solver_in_loop_curriculum_smoke"
     with np.load(out_dir / "corrector_fields.npz") as snapshots:
         assert snapshots["error_one_step_0"].shape == (4,)
+        assert snapshots["error_one_step_samples_0"].shape == (1, 1, 4)
+        assert snapshots["error_corrected_samples_0"].shape == (1, 1, 4)
+        assert snapshots["loss_samples_0"].shape == (1, 2)
         assert snapshots["curriculum_stage_unrolls_0"].tolist() == [1, 2]
         assert snapshots["curriculum_checkpoint_error_full_0"].shape == (2, 4)
+        assert snapshots["curriculum_checkpoint_error_full_samples_0"].shape == (
+            1,
+            2,
+            4,
+        )
         assert snapshots["correlation_corrected_0"].shape == (4,)
+        assert snapshots["correlation_corrected_samples_0"].shape == (1, 1, 4)
 
 
 def test_solver_self_reference_skips_training_below_refinement_floor(

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -201,7 +201,7 @@ def test_terminal_credit_curriculum_declares_one_nog_wig_protocol():
         8,
         16,
     ]
-    assert sum(stage["updates"] for stage in training["curriculum"]) == 4000
+    assert sum(stage["updates"] for stage in training["curriculum"]) == 1000
 
 
 def test_curriculum_normalization_preserves_stage_learning_rates():

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -1392,6 +1392,7 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
     assert metrics["training_warmup_solver_intervals_per_seed"] == 2
     assert metrics["training_loss_mode"] == "solver_mediated"
     assert metrics["training_local_loss_weight"] == 0.05
+    assert metrics["fd_check_scope"] == "differentiated_suffix_with_frozen_warmup"
     assert metrics["one_step_training_solver_intervals_per_seed"] == 2
     assert len(metrics["curriculum_checkpoint_summary"]) == 2
     assert [entry["unroll"] for entry in metrics["fd_horizon_summary"]] == [1, 2]

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -812,6 +812,46 @@ def test_solver_mediated_loss_requires_the_solver_vjp(monkeypatch):
     assert float(stopped_grad) == 0.0
 
 
+def test_solver_terminal_mediated_loss_assigns_delayed_credit(monkeypatch):
+    def _advance(_t, _ctx, velocity, *, frame_steps, native_state=None):
+        del frame_steps, native_state
+        return 2.0 * jnp.asarray(velocity), None
+
+    monkeypatch.setattr(
+        "mosaic.benchmarks.problems.navier_stokes_grid.solver_in_loop._solver_advance",
+        _advance,
+    )
+    monkeypatch.setattr(
+        "mosaic.benchmarks.problems.navier_stokes_grid.solver_in_loop."
+        "corrected_velocity",
+        lambda model, velocity, **_kwargs: velocity + model,
+    )
+    targets = jnp.ones((4, 1, 1, 1, 1))
+    ctx = SimpleNamespace(domain_extent=2.0 * np.pi)
+
+    def objective(model, differentiate_solver):
+        return _window_loss(
+            model,
+            targets,
+            t=None,
+            ctx=ctx,
+            frame_steps=1,
+            velocity_scale=1.0,
+            differentiate_solver=differentiate_solver,
+            loss_mode="solver_terminal_mediated",
+            solver_loss_weight=1.0,
+            local_loss_weight=0.0,
+            loss_scale=1.0,
+        )
+
+    full_loss, full_grad = jax.value_and_grad(objective)(jnp.asarray(0.0), True)
+    stopped_loss, stopped_grad = jax.value_and_grad(objective)(jnp.asarray(0.0), False)
+
+    assert float(full_loss) == float(stopped_loss)
+    assert abs(float(full_grad)) > 1.0
+    assert float(stopped_grad) == 0.0
+
+
 def test_stop_gradient_cuts_velocity_and_native_state():
     def stopped(value):
         velocity, native_state = _stop_recurrent_gradient(

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -18,6 +18,7 @@ import numpy as np
 from mosaic.benchmarks.core.utils import _debug_run, active_solvers
 from mosaic.benchmarks.problems.navier_stokes_grid.corrector import (
     PeriodicResidualCNN,
+    PeriodicResNetCorrector,
     apply_corrector,
     centered_divergence_rms,
     divergence_rms,
@@ -32,11 +33,17 @@ from mosaic.benchmarks.problems.navier_stokes_grid.corrector import (
 from mosaic.benchmarks.problems.navier_stokes_grid.ics import _tgv, _tgv_analytic
 from mosaic.benchmarks.problems.navier_stokes_grid.plots import (
     _periodic_vorticity_2d,
+    _plot_solver_in_loop_curriculum_correlations,
+    _plot_solver_in_loop_curriculum_fields,
+    _plot_solver_in_loop_curriculum_rollouts,
+    _plot_solver_in_loop_curriculum_spectra,
+    _plot_solver_in_loop_curriculum_summary,
     _plot_solver_in_loop_diagnostics,
     _plot_solver_in_loop_fairness,
     _plot_solver_in_loop_fields,
     _plot_solver_in_loop_physics,
     _save_solver_in_loop_animation,
+    _save_solver_in_loop_curriculum_animation,
 )
 from mosaic.benchmarks.problems.navier_stokes_grid.solver_in_loop import (
     _evaluate_rollout,
@@ -46,6 +53,7 @@ from mosaic.benchmarks.problems.navier_stokes_grid.solver_in_loop import (
     _rollout_log_gain,
     _solver_advance,
     _stop_recurrent_gradient,
+    _training_stages,
     _window_loss,
     make_reference_dataset,
     solver_in_loop,
@@ -165,6 +173,48 @@ def test_reference_sensitivity_declares_independent_converged_targets():
         assert dataset["reference_convergence_tolerance"] == 0.005
 
 
+def test_paper_aligned_curriculum_declares_one_nog_wig_protocol():
+    from mosaic.benchmarks.problems import get_config
+
+    cfg = get_config("ns-grid")
+    experiment = cfg.experiments["optimization/solver_in_loop_curriculum"]
+    run = inspect.signature(experiment.fn).parameters["_kw"].default["runs"][0]
+    training = run["training"]
+
+    assert run["physics"]["steps"] == 1
+    assert run["dataset"]["train_seeds"] == list(range(32))
+    assert run["evaluation"]["rollout_frames"] == 300
+    assert training["include_one_step_baseline"] is True
+    assert training["loss_mode"] == "mean"
+    assert training["architecture"] == "periodic_resnet"
+    assert training["residual_blocks"] == 5
+    assert [stage["unroll"] for stage in training["curriculum"]] == [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+    ]
+    assert sum(stage["updates"] for stage in training["curriculum"]) == 12000
+
+
+def test_curriculum_normalization_preserves_stage_learning_rates():
+    stages = _training_stages(
+        {
+            "lr": 1e-4,
+            "curriculum": [
+                {"unroll": 1, "updates": 2},
+                {"unroll": 4, "updates": 3, "lr": 5e-5},
+            ],
+        }
+    )
+
+    assert [stage.unroll for stage in stages] == [1, 4]
+    assert [stage.updates for stage in stages] == [2, 3]
+    np.testing.assert_allclose([stage.lr for stage in stages], [1e-4, 5e-5])
+
+
 def test_self_reference_does_not_gate_the_learnable_refinement_signal():
     assert _passes_reference_accuracy_gate(
         "solver_self_refined",
@@ -209,6 +259,28 @@ def test_corrector_starts_from_the_uncorrected_solver():
     model = init_corrector(jax.random.PRNGKey(0), hidden_channels=4, kernel_size=3)
     velocity = jax.random.normal(jax.random.PRNGKey(1), (8, 8, 1, 2))
 
+    np.testing.assert_array_equal(
+        apply_corrector(model, velocity, velocity_scale=1.0),
+        jnp.zeros_like(velocity),
+    )
+
+
+def test_paper_scale_resnet_starts_at_solver_and_has_expected_capacity():
+    model = init_corrector(
+        jax.random.PRNGKey(0),
+        architecture="periodic_resnet",
+        hidden_channels=32,
+        kernel_size=5,
+        residual_blocks=5,
+    )
+    velocity = jax.random.normal(jax.random.PRNGKey(1), (8, 8, 1, 2))
+    parameter_count = sum(
+        int(leaf.size)
+        for leaf in jax.tree_util.tree_leaves(eqx.filter(model, eqx.is_inexact_array))
+    )
+
+    assert isinstance(model, PeriodicResNetCorrector)
+    assert parameter_count == 259554
     np.testing.assert_array_equal(
         apply_corrector(model, velocity, velocity_scale=1.0),
         jnp.zeros_like(velocity),
@@ -759,6 +831,42 @@ def test_debug_run_caps_corrector_training():
     assert run["evaluation"]["rollout_frames"] == 3
 
 
+def test_debug_run_caps_curriculum_and_one_step_baseline():
+    run = {
+        "physics": {"N": 32, "steps": 1},
+        "training": {
+            "max_updates": 12000,
+            "unroll": 32,
+            "curriculum": [
+                {"unroll": 1, "updates": 1000, "lr": 1e-4},
+                {"unroll": 2, "updates": 1000, "lr": 1e-4},
+                {"unroll": 4, "updates": 1500, "lr": 1e-4},
+            ],
+            "one_step_updates": 12000,
+            "residual_blocks": 5,
+            "model_seeds": [0, 1, 2],
+        },
+        "dataset": {
+            "train_seeds": list(range(32)),
+            "test_seeds": list(range(100, 108)),
+            "train_frames": 96,
+        },
+        "evaluation": {"rollout_frames": 300},
+    }
+
+    _debug_run(run)
+
+    assert run["training"]["curriculum"] == [
+        {"unroll": 1, "updates": 1, "lr": 1e-4},
+        {"unroll": 2, "updates": 1, "lr": 1e-4},
+    ]
+    assert run["training"]["max_updates"] == 2
+    assert run["training"]["unroll"] == 2
+    assert run["training"]["one_step_updates"] == 2
+    assert run["training"]["residual_blocks"] == 1
+    assert run["training"]["model_seeds"] == [0]
+
+
 def test_solver_in_loop_fields_render_reference_raw_and_corrected(tmp_path):
     n = 16
     coordinates = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
@@ -913,6 +1021,85 @@ def test_self_reference_fairness_normalizes_solver_specific_targets(tmp_path):
     assert figure.axes[0].get_title() == "Target-normalized quality"
 
 
+def test_curriculum_plots_render_all_training_protocols(tmp_path):
+    reference = np.stack([_tgv(8) * np.exp(-0.02 * frame) for frame in range(4)])
+    native = reference * np.asarray([1.0, 0.98, 0.96, 0.94])[:, None, None, None, None]
+    one = reference * np.asarray([1.0, 0.99, 0.98, 0.97])[:, None, None, None, None]
+    nog = reference * np.asarray([1.0, 0.995, 0.99, 0.985])[:, None, None, None, None]
+    wig = reference * np.asarray([1.0, 0.998, 0.996, 0.994])[:, None, None, None, None]
+    arrays = {
+        "evaluation_times": np.arange(4, dtype=np.float32) * 0.02,
+        "reference_rollout": reference,
+        "rollout_uncorrected_0": native,
+        "rollout_one_step_0": one,
+        "rollout_stop_gradient_0": nog,
+        "rollout_corrected_0": wig,
+        "error_uncorrected_0": np.asarray([0.0, 0.02, 0.04, 0.06]),
+        "error_one_step_0": np.asarray([0.0, 0.01, 0.02, 0.03]),
+        "error_stop_gradient_0": np.asarray([0.0, 0.005, 0.01, 0.015]),
+        "error_corrected_0": np.asarray([0.0, 0.002, 0.004, 0.006]),
+        "correlation_uncorrected_0": np.asarray([1.0, 0.99, 0.97, 0.94]),
+        "correlation_one_step_0": np.asarray([1.0, 0.995, 0.985, 0.97]),
+        "correlation_stop_gradient_0": np.asarray([1.0, 0.998, 0.99, 0.98]),
+        "correlation_corrected_0": np.asarray([1.0, 0.999, 0.996, 0.99]),
+        "curriculum_stage_unrolls_0": np.asarray([1, 2]),
+        "curriculum_checkpoint_error_native_0": np.asarray([0.0, 0.02, 0.04, 0.06]),
+        "curriculum_checkpoint_error_full_0": np.asarray(
+            [[0.0, 0.015, 0.03, 0.045], [0.0, 0.005, 0.01, 0.015]]
+        ),
+    }
+    data = {
+        "by_solver": {
+            "jax-cfd": {
+                "one_step_geometric_error_reduction": 1.5,
+                "stop_gradient_geometric_error_reduction": 2.0,
+                "geometric_error_reduction": 3.0,
+                "unrolling_geometric_lift_nog_over_one": 4.0 / 3.0,
+                "solver_vjp_geometric_lift": 1.5,
+                "one_step_training_wall_time_s": 1.0,
+                "stop_gradient_training_wall_time_s": 2.0,
+                "training_wall_time_s": 3.0,
+            }
+        }
+    }
+
+    figures = [
+        _plot_solver_in_loop_curriculum_rollouts(
+            arrays, ["jax-cfd"], tmp_path, save=True
+        ),
+        _plot_solver_in_loop_curriculum_correlations(
+            arrays, ["jax-cfd"], tmp_path, save=True
+        ),
+        _plot_solver_in_loop_curriculum_summary(
+            data,
+            arrays,
+            ["jax-cfd"],
+            tmp_path,
+            save=True,
+        ),
+        _plot_solver_in_loop_curriculum_fields(
+            arrays, ["jax-cfd"], tmp_path, save=True
+        ),
+        _plot_solver_in_loop_curriculum_spectra(
+            arrays, ["jax-cfd"], tmp_path, save=True
+        ),
+    ]
+    _save_solver_in_loop_curriculum_animation(arrays, ["jax-cfd"], tmp_path)
+
+    assert all(figure is not None for figure in figures)
+    for filename in (
+        "solver_in_loop_curriculum_rollouts.png",
+        "solver_in_loop_curriculum_correlations.png",
+        "solver_in_loop_curriculum_summary.png",
+        "solver_in_loop_curriculum_fields.png",
+        "solver_in_loop_curriculum_spectra.png",
+        "solver_in_loop_curriculum_trajectory.gif",
+    ):
+        rendered = tmp_path / filename
+        assert rendered.exists()
+        assert rendered.stat().st_size > 0
+
+
 def test_solver_vjp_panels_only_show_recurrence_admitted_cells(tmp_path):
     common = {
         "uncorrected_mean_rollout_error": 0.4,
@@ -1019,6 +1206,80 @@ def test_solver_in_loop_runs_recurrently_through_dummy(tmp_path, monkeypatch):
     assert (out_dir / "result.json").exists()
     with np.load(out_dir / "corrector_fields.npz") as snapshots:
         assert snapshots["solver_vjp_log_lift_samples_0"].shape == (2, 1)
+
+
+def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
+    tmp_path,
+    monkeypatch,
+):
+    """The opt-in curriculum keeps all three paper protocols in one result."""
+    from mosaic.benchmarks.problems import get_config
+
+    monkeypatch.setenv("MOSAIC_RESULTS_DIR", str(tmp_path))
+    base = get_config("ns-grid")
+    jax_cfd = next(spec for spec in base.solvers if spec.key == "jax_cfd")
+    cfg = dataclasses.replace(base, solvers=[jax_cfd])
+    cfg.add_experiment(
+        "optimization/solver_in_loop_curriculum_smoke",
+        solver_in_loop,
+        runs=[
+            {
+                "ic": {"name": "multimode", "seed": 0},
+                "physics": {"N": 8, "nu": 0.001, "dt": 0.02, "steps": 1},
+                "dataset": {
+                    "reference_factor": 2,
+                    "reference_substeps": 1,
+                    "train_seeds": [0],
+                    "test_seeds": [100],
+                    "train_frames": 3,
+                    "k0": 2.0,
+                },
+                "training": {
+                    "max_updates": 2,
+                    "unroll": 2,
+                    "curriculum": [
+                        {"unroll": 1, "updates": 1, "lr": 1e-4},
+                        {"unroll": 2, "updates": 1, "lr": 5e-5},
+                    ],
+                    "include_one_step_baseline": True,
+                    "one_step_updates": 2,
+                    "loss_mode": "mean",
+                    "loss_normalization": "solver_baseline",
+                    "hidden_channels": 4,
+                    "kernel_size": 3,
+                    "model_seeds": [0],
+                    "check_grad": False,
+                },
+                "evaluation": {
+                    "rollout_frames": 3,
+                    "checkpoint_ic_trajectories": 1,
+                    "checkpoint_rollout_frames": 3,
+                },
+            }
+        ],
+    )
+
+    result = cfg.experiments["optimization/solver_in_loop_curriculum_smoke"].fn(
+        cfg,
+        {jax_cfd.name: f"inprocess:{_IDENTITY_DUMMY}"},
+    )
+
+    metrics = result["results"][0]["metrics"]
+    assert metrics["completed"] is True
+    assert metrics["n_updates"] == 2
+    assert metrics["one_step_n_updates"] == 2
+    assert metrics["training_solver_intervals_per_seed"] == 3
+    assert metrics["one_step_training_solver_intervals_per_seed"] == 2
+    assert len(metrics["curriculum_checkpoint_summary"]) == 2
+    assert metrics["unrolling_geometric_lift_nog_over_one"] > 0
+    assert metrics["solver_vjp_geometric_lift"] > 0
+
+    out_dir = tmp_path / "ns-grid" / "optimization" / "solver_in_loop_curriculum_smoke"
+    with np.load(out_dir / "corrector_fields.npz") as snapshots:
+        assert snapshots["error_one_step_0"].shape == (4,)
+        assert snapshots["curriculum_stage_unrolls_0"].tolist() == [1, 2]
+        assert snapshots["curriculum_checkpoint_error_full_0"].shape == (2, 4)
+        assert snapshots["correlation_corrected_0"].shape == (4,)
 
 
 def test_solver_self_reference_skips_training_below_refinement_floor(

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -186,6 +186,7 @@ def test_delayed_credit_curriculum_declares_one_nog_wig_protocol():
     assert run["dataset"]["train_seeds"] == list(range(32))
     assert run["dataset"]["k0"] == 4.0
     assert run["evaluation"]["rollout_frames"] == 120
+    assert run["evaluation"]["first_interval_error_tolerance"] == 0.15
     assert training["include_one_step_baseline"] is True
     assert training["loss_mode"] == "solver_mediated"
     assert training["solver_loss_weight"] == 1.0

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -174,7 +174,7 @@ def test_reference_sensitivity_declares_independent_converged_targets():
         assert dataset["reference_convergence_tolerance"] == 0.005
 
 
-def test_delayed_credit_curriculum_declares_one_nog_wig_protocol():
+def test_terminal_credit_curriculum_declares_one_nog_wig_protocol():
     from mosaic.benchmarks.problems import get_config
 
     cfg = get_config("ns-grid")
@@ -188,14 +188,14 @@ def test_delayed_credit_curriculum_declares_one_nog_wig_protocol():
     assert run["evaluation"]["rollout_frames"] == 120
     assert run["evaluation"]["first_interval_error_tolerance"] == 0.15
     assert training["include_one_step_baseline"] is True
-    assert training["loss_mode"] == "solver_mediated"
+    assert training["loss_mode"] == "solver_terminal_mediated"
     assert training["solver_loss_weight"] == 1.0
-    assert training["local_loss_weight"] == 0.05
+    assert training["local_loss_weight"] == 0.0
     assert training["warmup_intervals"] == 2
+    assert training["check_grad_stages"] is True
     assert training["architecture"] == "periodic_resnet"
     assert training["residual_blocks"] == 5
     assert [stage["unroll"] for stage in training["curriculum"]] == [
-        1,
         2,
         4,
         8,

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -196,7 +196,7 @@ def test_paper_aligned_curriculum_declares_one_nog_wig_protocol():
         16,
         32,
     ]
-    assert sum(stage["updates"] for stage in training["curriculum"]) == 12000
+    assert sum(stage["updates"] for stage in training["curriculum"]) == 11000
 
 
 def test_curriculum_normalization_preserves_stage_learning_rates():

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -34,6 +34,7 @@ from mosaic.benchmarks.problems.navier_stokes_grid.ics import _tgv, _tgv_analyti
 from mosaic.benchmarks.problems.navier_stokes_grid.plots import (
     _periodic_vorticity_2d,
     _plot_solver_in_loop_curriculum_correlations,
+    _plot_solver_in_loop_curriculum_fd,
     _plot_solver_in_loop_curriculum_fields,
     _plot_solver_in_loop_curriculum_rollouts,
     _plot_solver_in_loop_curriculum_spectra,
@@ -1042,6 +1043,8 @@ def test_curriculum_plots_render_all_training_protocols(tmp_path):
         "correlation_one_step_0": np.asarray([1.0, 0.995, 0.985, 0.97]),
         "correlation_stop_gradient_0": np.asarray([1.0, 0.998, 0.99, 0.98]),
         "correlation_corrected_0": np.asarray([1.0, 0.999, 0.996, 0.99]),
+        "fd_epsilon_0": np.asarray([1e-1, 1e-2, 1e-3]),
+        "fd_rel_error_samples_0": np.asarray([[0.2, 0.01, 0.04], [0.3, 0.02, 0.05]]),
         "curriculum_stage_unrolls_0": np.asarray([1, 2]),
         "curriculum_checkpoint_error_native_0": np.asarray([0.0, 0.02, 0.04, 0.06]),
         "curriculum_checkpoint_error_full_0": np.asarray(
@@ -1070,6 +1073,7 @@ def test_curriculum_plots_render_all_training_protocols(tmp_path):
         _plot_solver_in_loop_curriculum_correlations(
             arrays, ["jax-cfd"], tmp_path, save=True
         ),
+        _plot_solver_in_loop_curriculum_fd(arrays, ["jax-cfd"], tmp_path, save=True),
         _plot_solver_in_loop_curriculum_summary(
             data,
             arrays,
@@ -1090,6 +1094,7 @@ def test_curriculum_plots_render_all_training_protocols(tmp_path):
     for filename in (
         "solver_in_loop_curriculum_rollouts.png",
         "solver_in_loop_curriculum_correlations.png",
+        "solver_in_loop_curriculum_fd.png",
         "solver_in_loop_curriculum_summary.png",
         "solver_in_loop_curriculum_fields.png",
         "solver_in_loop_curriculum_spectra.png",
@@ -1186,6 +1191,8 @@ def test_solver_in_loop_runs_recurrently_through_dummy(tmp_path, monkeypatch):
     assert metrics["completed"] is True
     assert metrics["final_grad_norm"] > 0
     assert metrics["end_to_end_fd_rel_error"] < 5e-2
+    assert metrics["end_to_end_fd_rel_error_max"] < 5e-2
+    assert len(metrics["fd_check_summary"]) == 2
     assert metrics["native_final_rollout_error"] >= 0
     assert metrics["native_final_rollout_error_p95"] >= 0
     assert metrics["long_closure_error_p95"] < 1e-6
@@ -1206,6 +1213,8 @@ def test_solver_in_loop_runs_recurrently_through_dummy(tmp_path, monkeypatch):
     assert (out_dir / "result.json").exists()
     with np.load(out_dir / "corrector_fields.npz") as snapshots:
         assert snapshots["solver_vjp_log_lift_samples_0"].shape == (2, 1)
+        assert snapshots["fd_epsilon_0"].shape == (5,)
+        assert snapshots["fd_rel_error_samples_0"].shape == (2, 5)
 
 
 def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -1281,6 +1281,11 @@ def test_solver_in_loop_runs_recurrently_through_dummy(tmp_path, monkeypatch):
     assert metrics["end_to_end_fd_rel_error"] < 5e-2
     assert metrics["end_to_end_fd_rel_error_max"] < 5e-2
     assert len(metrics["fd_check_summary"]) == 2
+    assert len(metrics["fd_horizon_summary"]) == 2
+    for check in metrics["fd_check_summary"]:
+        assert np.isfinite(check["finite_difference_at_best_epsilon"])
+        assert np.isfinite(check["autodiff_directional_derivative"])
+        assert check["absolute_directional_error"] >= 0
     assert metrics["native_final_rollout_error"] >= 0
     assert metrics["native_final_rollout_error_p95"] >= 0
     assert metrics["long_closure_error_p95"] < 1e-6
@@ -1303,6 +1308,19 @@ def test_solver_in_loop_runs_recurrently_through_dummy(tmp_path, monkeypatch):
         assert snapshots["solver_vjp_log_lift_samples_0"].shape == (2, 1)
         assert snapshots["fd_epsilon_0"].shape == (5,)
         assert snapshots["fd_rel_error_samples_0"].shape == (2, 5)
+        assert snapshots["fd_directional_finite_difference_samples_0"].shape == (
+            2,
+            5,
+        )
+        assert snapshots["fd_directional_autodiff_samples_0"].shape == (2, 5)
+        assert snapshots["fd_stage_unroll_0"].tolist() == [2]
+        assert snapshots["fd_stage_rel_error_samples_0"].shape == (2, 1, 5)
+        assert snapshots["fd_stage_finite_difference_samples_0"].shape == (
+            2,
+            1,
+            5,
+        )
+        assert snapshots["fd_stage_autodiff_samples_0"].shape == (2, 1, 5)
 
 
 def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
@@ -1348,7 +1366,9 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
                     "hidden_channels": 4,
                     "kernel_size": 3,
                     "model_seeds": [0],
-                    "check_grad": False,
+                    "check_grad": True,
+                    "check_grad_stages": True,
+                    "fd_epsilon": 1e-3,
                 },
                 "evaluation": {
                     "rollout_frames": 3,
@@ -1374,6 +1394,7 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
     assert metrics["training_local_loss_weight"] == 0.05
     assert metrics["one_step_training_solver_intervals_per_seed"] == 2
     assert len(metrics["curriculum_checkpoint_summary"]) == 2
+    assert [entry["unroll"] for entry in metrics["fd_horizon_summary"]] == [1, 2]
     assert metrics["unrolling_geometric_lift_nog_over_one"] > 0
     assert metrics["solver_vjp_geometric_lift"] > 0
 
@@ -1390,6 +1411,8 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
             2,
             4,
         )
+        assert snapshots["fd_stage_unroll_0"].tolist() == [1, 2]
+        assert snapshots["fd_stage_rel_error_samples_0"].shape == (1, 2, 5)
         assert snapshots["correlation_corrected_0"].shape == (4,)
         assert snapshots["correlation_corrected_samples_0"].shape == (1, 1, 4)
 

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -1268,7 +1268,7 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
     tmp_path,
     monkeypatch,
 ):
-    """The opt-in curriculum keeps all three paper protocols in one result."""
+    """The opt-in curriculum exercises sparse delayed solver credit end to end."""
     from mosaic.benchmarks.problems import get_config
 
     monkeypatch.setenv("MOSAIC_RESULTS_DIR", str(tmp_path))
@@ -1287,7 +1287,7 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
                     "reference_substeps": 1,
                     "train_seeds": [0],
                     "test_seeds": [100],
-                    "train_frames": 3,
+                    "train_frames": 4,
                     "k0": 2.0,
                 },
                 "training": {
@@ -1299,7 +1299,10 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
                     ],
                     "include_one_step_baseline": True,
                     "one_step_updates": 2,
-                    "loss_mode": "mean",
+                    "loss_mode": "solver_mediated",
+                    "solver_loss_weight": 1.0,
+                    "local_loss_weight": 0.05,
+                    "warmup_intervals": 1,
                     "loss_normalization": "solver_baseline",
                     "hidden_channels": 4,
                     "kernel_size": 3,
@@ -1324,7 +1327,10 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
     assert metrics["completed"] is True
     assert metrics["n_updates"] == 2
     assert metrics["one_step_n_updates"] == 2
-    assert metrics["training_solver_intervals_per_seed"] == 3
+    assert metrics["training_solver_intervals_per_seed"] == 5
+    assert metrics["training_warmup_solver_intervals_per_seed"] == 2
+    assert metrics["training_loss_mode"] == "solver_mediated"
+    assert metrics["training_local_loss_weight"] == 0.05
     assert metrics["one_step_training_solver_intervals_per_seed"] == 2
     assert len(metrics["curriculum_checkpoint_summary"]) == 2
     assert metrics["unrolling_geometric_lift_nog_over_one"] > 0

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -174,7 +174,7 @@ def test_reference_sensitivity_declares_independent_converged_targets():
         assert dataset["reference_convergence_tolerance"] == 0.005
 
 
-def test_paper_aligned_curriculum_declares_one_nog_wig_protocol():
+def test_delayed_credit_curriculum_declares_one_nog_wig_protocol():
     from mosaic.benchmarks.problems import get_config
 
     cfg = get_config("ns-grid")
@@ -182,11 +182,15 @@ def test_paper_aligned_curriculum_declares_one_nog_wig_protocol():
     run = inspect.signature(experiment.fn).parameters["_kw"].default["runs"][0]
     training = run["training"]
 
-    assert run["physics"]["steps"] == 1
+    assert run["physics"]["steps"] == 4
     assert run["dataset"]["train_seeds"] == list(range(32))
-    assert run["evaluation"]["rollout_frames"] == 300
+    assert run["dataset"]["k0"] == 4.0
+    assert run["evaluation"]["rollout_frames"] == 120
     assert training["include_one_step_baseline"] is True
-    assert training["loss_mode"] == "mean"
+    assert training["loss_mode"] == "solver_mediated"
+    assert training["solver_loss_weight"] == 1.0
+    assert training["local_loss_weight"] == 0.05
+    assert training["warmup_intervals"] == 2
     assert training["architecture"] == "periodic_resnet"
     assert training["residual_blocks"] == 5
     assert [stage["unroll"] for stage in training["curriculum"]] == [
@@ -195,9 +199,8 @@ def test_paper_aligned_curriculum_declares_one_nog_wig_protocol():
         4,
         8,
         16,
-        32,
     ]
-    assert sum(stage["updates"] for stage in training["curriculum"]) == 11000
+    assert sum(stage["updates"] for stage in training["curriculum"]) == 4000
 
 
 def test_curriculum_normalization_preserves_stage_learning_rates():
@@ -768,6 +771,46 @@ def test_training_window_threads_corrected_velocity_and_native_state(monkeypatch
     np.testing.assert_array_equal(calls[1][0], 12.0 * np.ones_like(targets[0]))
 
 
+def test_solver_mediated_loss_requires_the_solver_vjp(monkeypatch):
+    def _advance(_t, _ctx, velocity, *, frame_steps, native_state=None):
+        del frame_steps, native_state
+        return 2.0 * jnp.asarray(velocity), None
+
+    monkeypatch.setattr(
+        "mosaic.benchmarks.problems.navier_stokes_grid.solver_in_loop._solver_advance",
+        _advance,
+    )
+    monkeypatch.setattr(
+        "mosaic.benchmarks.problems.navier_stokes_grid.solver_in_loop."
+        "corrected_velocity",
+        lambda model, velocity, **_kwargs: velocity + model,
+    )
+    targets = jnp.ones((3, 1, 1, 1, 1))
+    ctx = SimpleNamespace(domain_extent=2.0 * np.pi)
+
+    def objective(model, differentiate_solver):
+        return _window_loss(
+            model,
+            targets,
+            t=None,
+            ctx=ctx,
+            frame_steps=1,
+            velocity_scale=1.0,
+            differentiate_solver=differentiate_solver,
+            loss_mode="solver_mediated",
+            solver_loss_weight=1.0,
+            local_loss_weight=0.0,
+            loss_scale=1.0,
+        )
+
+    full_loss, full_grad = jax.value_and_grad(objective)(jnp.asarray(0.0), True)
+    stopped_loss, stopped_grad = jax.value_and_grad(objective)(jnp.asarray(0.0), False)
+
+    assert float(full_loss) == float(stopped_loss)
+    assert abs(float(full_grad)) > 1.0
+    assert float(stopped_grad) == 0.0
+
+
 def test_stop_gradient_cuts_velocity_and_native_state():
     def stopped(value):
         velocity, native_state = _stop_recurrent_gradient(
@@ -1050,6 +1093,9 @@ def test_curriculum_plots_render_all_training_protocols(tmp_path):
         "curriculum_checkpoint_error_full_0": np.asarray(
             [[0.0, 0.015, 0.03, 0.045], [0.0, 0.005, 0.01, 0.015]]
         ),
+        "curriculum_checkpoint_error_nog_0": np.asarray(
+            [[0.0, 0.018, 0.036, 0.054], [0.0, 0.01, 0.02, 0.03]]
+        ),
     }
     data = {
         "by_solver": {
@@ -1091,6 +1137,7 @@ def test_curriculum_plots_render_all_training_protocols(tmp_path):
     _save_solver_in_loop_curriculum_animation(arrays, ["jax-cfd"], tmp_path)
 
     assert all(figure is not None for figure in figures)
+    assert figures[3].axes[2].get_ylabel() == "WIG / NOG rollout lift [×]"
     for filename in (
         "solver_in_loop_curriculum_rollouts.png",
         "solver_in_loop_curriculum_correlations.png",

--- a/tests/test_xlb_3d_surrogate.py
+++ b/tests/test_xlb_3d_surrogate.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the fixed-task XLB 3D full-field surrogate."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+pytest.importorskip("tesseract_core.runtime")
+pytest.importorskip("mosaic_shared")
+
+_API_PATH = (
+    Path(__file__).parents[1]
+    / "mosaic"
+    / "tesseracts"
+    / "navier-stokes-grid"
+    / "xlb-3d-surrogate"
+    / "tesseract_api.py"
+)
+_SPEC = importlib.util.spec_from_file_location("xlb_3d_surrogate_api", _API_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_API = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_API)
+
+
+def _weights(width: int = 4, modes: int = 2):
+    rng = np.random.default_rng(2026)
+    weights = {
+        "input_scale": jnp.asarray(0.2, dtype=jnp.float32),
+        "correction_scale": jnp.full((3,), 0.1, dtype=jnp.float32),
+        "w_lift": jnp.asarray(
+            rng.normal(scale=0.05, size=(3, width)),
+            dtype=jnp.float32,
+        ),
+        "w_out": jnp.asarray(
+            rng.normal(scale=0.05, size=(width, 3)),
+            dtype=jnp.float32,
+        ),
+        "w_local_0": jnp.eye(width, dtype=jnp.float32),
+    }
+    shape = (modes, modes, modes, width, width)
+    for quadrant in range(4):
+        weights[f"spec_0_{quadrant}_real"] = jnp.asarray(
+            rng.normal(scale=0.01, size=shape),
+            dtype=jnp.float32,
+        )
+        weights[f"spec_0_{quadrant}_imag"] = jnp.asarray(
+            rng.normal(scale=0.01, size=shape),
+            dtype=jnp.float32,
+        )
+    return weights
+
+
+def test_full_field_shape_and_zero_state(monkeypatch):
+    monkeypatch.setattr(_API, "_WIDTH", 4)
+    monkeypatch.setattr(_API, "_MODES", 2)
+    monkeypatch.setattr(_API, "_LAYERS", 1)
+    initial = jnp.zeros((_API._N, _API._N, _API._N, 3), dtype=jnp.float32)
+    result = _API._surrogate_forward(initial, _weights())
+    assert result.shape == initial.shape
+    assert np.all(np.isfinite(np.asarray(result)))
+    assert np.allclose(np.asarray(result), 0.0, atol=1e-7)
+
+
+def test_full_field_vjp_is_finite(monkeypatch):
+    monkeypatch.setattr(_API, "_WIDTH", 4)
+    monkeypatch.setattr(_API, "_MODES", 2)
+    monkeypatch.setattr(_API, "_LAYERS", 1)
+    weights = _weights()
+    initial = jnp.zeros((_API._N, _API._N, _API._N, 3), dtype=jnp.float32)
+    initial = initial.at[1, 2, 3, 0].set(0.1)
+
+    def field_sum(value):
+        return jnp.sum(_API._surrogate_forward(value, weights) ** 2)
+
+    gradient = jax.grad(field_sum)(initial)
+    assert gradient.shape == initial.shape
+    assert np.all(np.isfinite(np.asarray(gradient)))

--- a/tests/test_xlb_3d_surrogate.py
+++ b/tests/test_xlb_3d_surrogate.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import importlib.util
-import sys
 from pathlib import Path
 
 import jax
@@ -29,11 +28,7 @@ _DATA_PATH = _API_PATH.with_name("training_data.py")
 _SPEC = importlib.util.spec_from_file_location("xlb_3d_surrogate_api", _API_PATH)
 assert _SPEC is not None and _SPEC.loader is not None
 _API = importlib.util.module_from_spec(_SPEC)
-sys.path.insert(0, str(_API_PATH.parent))
-try:
-    _SPEC.loader.exec_module(_API)
-finally:
-    sys.path.pop(0)
+_SPEC.loader.exec_module(_API)
 _DATA_SPEC = importlib.util.spec_from_file_location(
     "xlb_3d_surrogate_training_data",
     _DATA_PATH,

--- a/tests/test_xlb_3d_surrogate.py
+++ b/tests/test_xlb_3d_surrogate.py
@@ -62,6 +62,7 @@ def test_full_field_shape_and_zero_state(monkeypatch):
     monkeypatch.setattr(_API, "_WIDTH", 4)
     monkeypatch.setattr(_API, "_MODES", 2)
     monkeypatch.setattr(_API, "_LAYERS", 1)
+    monkeypatch.setattr(_API, "_ROLLOUT_STEPS", 3)
     initial = jnp.zeros((_API._N, _API._N, _API._N, 3), dtype=jnp.float32)
     result = _API._surrogate_forward(initial, _weights())
     assert result.shape == initial.shape
@@ -73,6 +74,7 @@ def test_full_field_vjp_is_finite(monkeypatch):
     monkeypatch.setattr(_API, "_WIDTH", 4)
     monkeypatch.setattr(_API, "_MODES", 2)
     monkeypatch.setattr(_API, "_LAYERS", 1)
+    monkeypatch.setattr(_API, "_ROLLOUT_STEPS", 3)
     weights = _weights()
     initial = jnp.zeros((_API._N, _API._N, _API._N, 3), dtype=jnp.float32)
     initial = initial.at[1, 2, 3, 0].set(0.1)
@@ -83,3 +85,18 @@ def test_full_field_vjp_is_finite(monkeypatch):
     gradient = jax.grad(field_sum)(initial)
     assert gradient.shape == initial.shape
     assert np.all(np.isfinite(np.asarray(gradient)))
+
+
+def test_forward_reuses_one_macro_step_operator(monkeypatch):
+    monkeypatch.setattr(_API, "_WIDTH", 4)
+    monkeypatch.setattr(_API, "_MODES", 2)
+    monkeypatch.setattr(_API, "_LAYERS", 1)
+    monkeypatch.setattr(_API, "_ROLLOUT_STEPS", 3)
+    weights = _weights()
+    initial = jnp.zeros((_API._N, _API._N, _API._N, 3), dtype=jnp.float32)
+    initial = initial.at[1, 2, 3, 0].set(0.1)
+    expected = initial[None]
+    for _ in range(3):
+        expected = _API._one_step(expected, weights)
+    result = _API._surrogate_forward(initial, weights)
+    assert np.allclose(np.asarray(result), np.asarray(expected[0]), atol=1e-7)

--- a/tests/test_xlb_3d_surrogate.py
+++ b/tests/test_xlb_3d_surrogate.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import jax
@@ -24,10 +25,22 @@ _API_PATH = (
     / "xlb-3d-surrogate"
     / "tesseract_api.py"
 )
+_DATA_PATH = _API_PATH.with_name("training_data.py")
 _SPEC = importlib.util.spec_from_file_location("xlb_3d_surrogate_api", _API_PATH)
 assert _SPEC is not None and _SPEC.loader is not None
 _API = importlib.util.module_from_spec(_SPEC)
-_SPEC.loader.exec_module(_API)
+sys.path.insert(0, str(_API_PATH.parent))
+try:
+    _SPEC.loader.exec_module(_API)
+finally:
+    sys.path.pop(0)
+_DATA_SPEC = importlib.util.spec_from_file_location(
+    "xlb_3d_surrogate_training_data",
+    _DATA_PATH,
+)
+assert _DATA_SPEC is not None and _DATA_SPEC.loader is not None
+_DATA = importlib.util.module_from_spec(_DATA_SPEC)
+_DATA_SPEC.loader.exec_module(_DATA)
 
 
 def _weights(width: int = 4, modes: int = 2):
@@ -100,3 +113,16 @@ def test_forward_reuses_one_macro_step_operator(monkeypatch):
         expected = _API._one_step(expected, weights)
     result = _API._surrogate_forward(initial, weights)
     assert np.allclose(np.asarray(result), np.asarray(expected[0]), atol=1e-7)
+
+
+def test_training_distribution_is_reproducible_and_full_field():
+    first = _DATA.make_inputs(10, 123)
+    second = _DATA.make_inputs(10, 123)
+
+    fields, amplitudes, families = first
+    assert fields.shape == (10, _API._N, _API._N, _API._N, 3)
+    assert amplitudes.shape == (10,)
+    assert families.shape == (10,)
+    assert np.all(np.isfinite(fields))
+    for left, right in zip(first, second, strict=True):
+        assert np.array_equal(left, right)


### PR DESCRIPTION
## Outcome

Stacked on #116. This PR evaluates two distinct uses of learned physics models:

| study | learned model's role | question | current result |
|---|---|---|---|
| 3D XLB surrogate | replaces a fixed 100-step solver map | does forward fidelity preserve inverse behavior? | No. The 16k checkpoint improves forward error but worsens projected-L-BFGS IC recovery; recovery is also optimizer-dependent. |
| 2D solver-in-loop corrector | acts sparsely inside a native solver rollout | when does differentiation through the solver materially help? | In the terminal-credit regime, WIG improves the native rollout for all six one-seed admission cells; the three-seed production matrix is still running. |

The 3D model is a full-field neural operator applied autoregressively for 20
macro-steps. Its learned map has a finite-difference-consistent VJP, but it is
neither a kernel-level speedup nor a drop-in inverse for XLB observations. The
study shows that forward error and local Jacobian summaries are insufficient
selection criteria for an inverse task: the learned objective can admit a
different low-residual IC branch.

The opt-in 2D study asks a different question. A corrector acts every four
native steps, two warm-up intervals are detached, and the loss is evaluated
only after the final solver interval. Under this objective NOG is exactly the
native-solver control, while WIG is trainable only through the solver VJP. At
the admission budget, WIG/native rollout improvement ranges from `1.194×` to
`1.503×` across JAX-CFD, INS.jl, PhiFlow, PICT, Warp-NS, and XLB, and all six
suffix finite-difference checks pass (`0.036%–1.170%` best relative error).
These are admission results, not final production statistics; jobs
`1699012–1699029` are running offline on Kander.

Together, the studies separate replacing a solver with a surrogate from
learning a corrector through a solver. They also separate recurrent exposure
from solver-gradient credit: one-step supervision is solver-dependent, while
the terminal-credit construction makes the numerical solver the only path from
a learned correction to the training objective.

## Scope and implementation

The Tesseract accepts and returns the complete `16×16×16×3` velocity field for
one fixed periodic task:

| quantity | fixed value |
|---|---:|
| domain | `[0, 2π]³`, fully periodic |
| resolution | `N=16` |
| viscosity | `ν=0.01` |
| solver step | `dt=0.02` |
| horizon | 100 XLB steps |
| recovery initialization | zero velocity |
| recovery seeds | 0, 1, 2 |

One width-32, six-mode, six-block 3D FNO advances five XLB steps
(`ΔT=0.1`). The same weights are reused for 20 autoregressive macro-steps; this
is not an IC-to-final-state regressor. An exact viscous skip and Helmholtz
projection are applied at every macro-step. Drag is exactly zero, matching the
other solvers on this obstacle-free task; there is no learned drag head.

The PR:

- adds the `xlb-3d-surrogate` Tesseract and its fixed-task exclusions;
- admits it only to the two matching 3D recovery cells;
- packages the shared inference/training model and final checkpoint;
- keeps trajectory generation, training-data construction, and curriculum
  training reproducible beside the Tesseract;
- keeps cluster submission, datasets, intermediate checkpoints, and evaluation
  orchestration outside the repository.

Only the inference API, shared model, and final weights enter the runtime image.

## Training and held-out evaluation

The checkpoint uses 16,384 native continuous XLB KBC D3Q27 trajectories, split
12,288/2,048/2,048 for training/validation/test. Each trajectory contains the
IC plus 20 full-field snapshots at five-step intervals. XLB populations evolve
continuously and are not reconstructed from equilibrium between snapshots. The
generated final frame matches the canonical 100-step float32 teacher call with
maximum absolute difference zero.

Training uses rollout curriculum `1 → 2 → 4 → 8 → 12 → 20`, followed by
12,000 full-horizon updates. Recovery seeds 0/1/2 are excluded from the
dataset.

- dataset SHA-256:
  `4836fba4e6a8524af7a552c5977721118e726afa21db9a9f4d0b612a879a0005`
- checkpoint SHA-256:
  `1ea04a7333981d1bfb836461d6fd6d89ae12f31c64ea40701c2607f03fb4107f`

![Autoregressive curriculum and rollout error](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/autoregressive_curriculum.png)

On the three excluded recovery seeds, the final-field relative L2 error is
4.418%, 4.191%, and 4.317% (**4.309% mean**); mean field cosine is
**0.999076**.

The held-out test split has 2,048 trajectories. Relative-error aggregates use
the 1,982 trajectories with IC amplitude `≥0.05`: mean final error is 7.219%,
median 5.348%, and p95 17.163%. The other 66 trajectories have amplitude
`0<a<0.05`; relative error is ill-conditioned as the target norm approaches
zero, so those cases are reported separately with absolute RMS error rather
than folded into the headline relative-error statistic.

A follow-up against the current recurrent-state XLB image reproduces the
forward and JVP headline values exactly, including the 7.219% held-out mean,
4.309% excluded-seed mean, 18.24% low-frequency JVP error, and 26.00%
full-spectrum JVP error.

![Autoregressive full-field final slices](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/forward_full_field_slices.png)

## Primary benchmark: solver-self recovery

The benchmark contract is solver-self recovery: each solver generates its own
final observation and differentiates through itself to recover the IC. Both
optimizer variants start from zero, run for at most 100 iterations, use the
same zoom line search, and evaluate seeds 0/1/2.

The plots retain PhiFlow, Warp-NS, and Exponax as benchmark context, but the
surrogate claim below uses only the matched XLB teacher and its two checkpoints;
it does not depend on ranking solvers with different forward solutions.

| optimizer / solver checkpoint | seed 0 | seed 1 | seed 2 | mean |
|---|---:|---:|---:|---:|
| L-BFGS / XLB | 4.96% | 5.17% | 6.12% | **5.42%** |
| L-BFGS / surrogate 4k | 6.94% | 7.81% | 9.56% | **8.10%** |
| L-BFGS / surrogate 16k | 17.31% | 15.70% | 17.10% | **16.70%** |
| projected L-BFGS / XLB | 4.70% | 5.02% | 5.94% | **5.22%** |
| projected L-BFGS / surrogate 4k | 6.97% | 7.85% | 9.54% | **8.12%** |
| projected L-BFGS / surrogate 16k | 17.32% | 15.59% | 17.19% | **16.70%** |

`bfgs_proj` follows the paper definition: it projects the gradient before the
L-BFGS update; it does not separately project the quasi-Newton iterate. For
surrogate seed 0, unconstrained/projected final `max|∇·u₀|` is
`1.49e-2/1.43e-2`, with maxima `1.52e-2/1.43e-2` over optimization.

The 16k checkpoint reaches an objective around `1e-8` and slightly lower
divergence than the 4k checkpoint while recovering an IC with roughly twice
the error. The learned objective therefore admits a different inverse branch;
low self-target residual is not evidence of correct IC recovery.

![Full 4k and 16k optimization comparison](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/checkpoint_optimization_comparison.png)

![L-BFGS optimizer and divergence ablation](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/recovery_optimizer_ablation.png)

## Optimizer interaction control

Adam changes the result materially. Its learning rate was selected independently
for each solver from `{1e-4, 3e-4, 1e-3, 3e-3, 1e-2, 3e-2}` using only mean
self-target MSE on calibration seeds 100/101/102. The selected rate was then
frozen before evaluating seeds 0/1/2. No test IC error was used for selection.

Adam projects both the gradient and every accepted iterate onto the
divergence-free subspace. The iterate projection is necessary because Adam's
coordinatewise moment scaling does not preserve a projected search direction.
Without it, the recovered fields reach `max|∇·u₀|≈2.4–3.8` and are not a valid
physical comparison.

| solver / checkpoint | projected Adam, 300 updates | projected Adam, 1,000 updates |
|---|---:|---:|
| XLB | 40.63% | 37.07% |
| surrogate 4k | 46.95% | 43.62% |
| surrogate 16k | **33.99%** | **30.37%** |
| Exponax (context) | 5.19% | — |
| Warp-NS (context) | 0.116% | — |
| PhiFlow (context) | 4.38% over two finite trials; 1/3 non-finite | — |

At the tested finite budgets, the matched XLB/surrogate ordering reverses: the
16k surrogate has the lowest mean IC error of those three under this
projected-Adam protocol. Absolute Adam recovery nevertheless remains worse
than L-BFGS for every matched checkpoint. No optimizer state is transferred
from network training. The reversal establishes sensitivity to the recovery
optimizer and protocol; it does not isolate whether the cause is Adam's update
geometry, iterate projection, learning-rate or horizon choice, the
parameter-training procedure, or transient convergence to different
low-residual regions.

The contextual solvers make the interaction even clearer, but are not used for
the XLB-surrogate claim because solver-self targets do not establish physical
forward agreement. L-BFGS's zoom-line-search oracle evaluations were not stored
in the earlier artifacts, so optimizer steps in this control are deliberately
not presented as a compute-matched efficiency comparison. The constraint
handling also differs: Adam projects both gradients and iterates, while the
existing `bfgs_proj` path projects gradients only. Adam rates were calibrated
for 100 updates using observable residual rather than IC error, then reused for
300/1,000 updates; XLB and the 4k surrogate selected the upper grid boundary
`3e-2`, so their rates are not bracketed.

![Projected Adam and L-BFGS optimizer interaction](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/optimizer_interaction_adam.png)

![Paper-style recovery convergence](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/recovery_convergence_comparison.png)

![Recovered initial and final full fields](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/full_field_recovery.png)

![Full 3D IC recovery evolution](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/recovery_evolution.gif)

## Why improved forward fidelity does not predict recovery

A matched 4k/16k checkpoint comparison separates conventional held-out
overfitting from differences in inverse geometry:

| metric | 4,096 trajectories | 16,384 trajectories |
|---|---:|---:|
| excluded-seed forward error | 7.473% | **4.309%** |
| held-out final error (`a≥0.05`) | 9.837% | **7.219%** |
| low-frequency JVP error (`|k|≤4`) | **17.64%** | 18.24% |
| full-spectrum JVP error | 38.28% | **26.00%** |
| L-BFGS self-recovery mean IC error | **8.10%** | 16.70% |
| projected-L-BFGS self-recovery mean IC error | **8.12%** | 16.70% |

Forward-error improvements do not track recovery under the primary L-BFGS
protocol; for these checkpoints, forward-only model selection is insufficient.

At exactly zero, the two checkpoints have nearly identical self-target descent
alignment with the true-IC direction. Immediately away from zero, the 16k
checkpoint turns away:

| amplitude on the true-IC ray | 4k cosine | 16k cosine |
|---:|---:|---:|
| 0.00 | 0.847 | 0.845 |
| 0.05 | 0.825 | 0.419 |
| 0.10 | 0.807 | 0.150 |
| 0.25 | 0.776 | 0.184 |

The learned correction is amplitude-gated. At the zero cold start its first
derivative is effectively the fixed viscous skip, so additional trajectory
data cannot repair the measured 49.34% radial JVP error at the starting point
without changing the architecture or objective.

![Inverse diagnostic explanation](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/inverse_diagnostic_explanation.png)

![Dataset scaling, derivatives, and inverse-gradient alignment](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/data_scaling_recovery_path.png)

### Derivative-informed training audit

Two leakage-safe follow-ups test the obvious remedies. The first removes the
amplitude gate while preserving the zero fixed point through the bias-free
network. The second fine-tunes that model with a `0.1` directional-JVP loss
against XLB, using training-base directions only and selecting on validation
field/JVP error.

| metric | gated baseline | no gate | no gate + JVP loss |
|---|---:|---:|---:|
| held-out final error (`a≥0.05`) | 7.219% | 7.313% | **6.859%** |
| low-frequency JVP error | 18.24% | 16.58% | **16.48%** |
| full-spectrum JVP error | 26.00% | 24.85% | **24.64%** |
| zero-start radial JVP error | 49.34% | **17.73%** | 20.45% |
| projected-L-BFGS recovery | **16.70%** | 33.69% | 23.63% |
| projected-Adam recovery (300 updates) | **33.99%** | 55.57% | 65.81% |

Removing the gate fixes the specific zero-derivative restriction, and explicit
JVP training improves the ordinary forward/JVP metrics further. Neither
ablation beats the gated baseline under the tested projected-L-BFGS or
300-update projected-Adam protocols, so the packaged gated checkpoint is
retained. This is consistent with random training-base JVP directions being a
weak proxy for recovery-path sensitivities, but it does not isolate that as the
cause or show that derivative-informed training generally fails. A stronger
follow-up should sample optimization trajectories and supervise their
task-relevant sensitivities directly.

![Derivative-aware training improves proxies but not recovery](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/derivative_training_ablation.png)

### Task-aware Sobolev training

The stronger follow-up trains the surrogate to reproduce the gradient actually
consumed by recovery. For the final-field MSE `L(x, y)`, it matches projected
directional derivatives
`<P ∇x Lsurrogate(x, y), v>` against XLB. This is first-derivative,
task-aware [Sobolev training](https://arxiv.org/abs/1706.04859); differentiating
that derivative loss with respect to network parameters uses mixed
second-order autodiff ("double backprop"). It does not supervise an explicit
teacher Hessian.

The leakage-safe dataset uses 96 training and 24 validation optimization paths
from the original split, with snapshots at updates
`{0, 1, 2, 5, 10, 20, 40, 80}` and four deterministic unit divergence-free
directions per state (two `|k|≤4`, two full-spectrum). Benchmark seeds 0–2 and
Adam calibration seeds 100–102 are excluded. All arms start from the packaged
gated 16k checkpoint. A field-only continuation and Sobolev weights
`{1e-1, 1e-2, 1e-3}` receive 1,000 matched updates; validation
`field relative L2 + task-gradient relative L2` selects `λ=1e-3`. Only that
selected derivative arm is evaluated on benchmark seeds.

| metric | packaged start | field-only continuation | task-Sobolev `λ=1e-3` |
|---|---:|---:|---:|
| validation task-gradient relative L2 | 5.305 | 4.568 | **4.088** |
| validation task-gradient cosine | 0.553 | 0.571 | **0.599** |
| held-out final-field error | **7.219%** | 7.219% | 7.506% |
| excluded-seed forward error | **4.309%** | 4.343% | 4.528% |
| low-frequency JVP error | 18.24% | 17.55% | **17.17%** |
| full-spectrum JVP error | 26.00% | 25.67% | **25.26%** |
| projected-L-BFGS self-recovery | **16.70%** | — | 17.05% |
| projected-Adam self-recovery, LR `1e-2` | **33.99%** | — | 34.10% |
| XLB-target cross-model IC error | **37.43%** | — | 42.19% |

Residual-only Adam calibration initially appears to reverse this conclusion:
it selects `1e-2` for the packaged checkpoint and the upper-grid `3e-2` for
task-Sobolev, producing 33.99% and 63.06% IC error. Crossed fixed-rate controls
identify a learning-rate/inverse-branch effect instead: at `1e-2`, packaged and
Sobolev obtain 33.99% and 34.10%; at `3e-2`, they obtain 63.43% and 63.06%.
The larger rate reaches a slightly smaller surrogate residual while recovering
a much worse IC. The matched-rate result, not the calibration-selected
cross-checkpoint contrast, is the appropriate comparison.

The selected Sobolev checkpoint therefore improves held-out average path
gradient agreement but does not improve self- or XLB-target recovery. This does
not show that task gradients or Sobolev training are generally ineffective.
The present study uses four directional sketches, Adam-path data only, one
fine-tuning seed, and retains the zero-start amplitude gate. It instead shows
that average local sensitivity agreement is insufficient to preserve the
global inverse branch. This is consistent with derivative-informed neural
operator work such as
[DINO](https://doi.org/10.1016/j.jcp.2023.112555), while the closest
optimization-trajectory study recommends solver feedback when a learned
optimizer path leaves its training distribution
([Cheng et al.](https://arxiv.org/abs/2506.13120)). The packaged checkpoint is
therefore retained.

![Task-aware Sobolev validation and recovery transfer](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/task_sobolev_followup.png)

## Cross-model negative control

Self-recovery does not establish that the surrogate can invert an
XLB-generated observation. In the cross-model control, projected L-BFGS
differentiates through the surrogate while targeting an XLB final field:

| metric | seed 0 | seed 1 | seed 2 | mean |
|---|---:|---:|---:|---:|
| final IC error | 39.22% | 40.95% | 32.12% | **37.43%** |
| best saved IC error | 17.52% | 18.89% | 17.56% | **17.99%** |
| surrogate residual | 1.62% | 1.71% | 2.02% | **1.78%** |
| XLB re-evaluation residual | 14.86% | 19.79% | 18.65% | **17.77%** |

The surrogate objective decreases while the IC moves onto a
surrogate-specific inverse branch. This checkpoint must not be presented as a
drop-in inverse for XLB observations.

![XLB-target objective and IC-error divergence](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/cross_model_recovery.png)

## Derivative checks

### Finite differences

Central finite differences use seeds 0/1/2, ten shared unit-norm directions per
seed, and a 12-point relative-ε sweep:

| objective / best-ε aggregate | XLB | surrogate |
|---|---:|---:|
| paper energy `sum(u_T²)` median error | `6.77e-6` | `6.63e-3` |
| paper energy mean cosine | ≈1.000000 | 0.999984 |
| recovery MSE at zero median error | `1.32e-1` | `2.56e-4` |
| recovery MSE at zero mean cosine | 0.991669 | ≈1.000000 |

The surrogate VJP is tightly finite-difference-consistent for the actual
zero-start recovery objective. Its distinct recovery behavior is therefore
not an autodiff implementation error: it accurately differentiates the
learned map.
For XLB, the zero-start direction is close but the best finite-difference
magnitude remains approximate, so this table is not used to claim exact XLB
gradient magnitude at zero.

![Finite-difference gradient checks](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/finite_difference_checks.png)

### Local Jacobian diagnostics

These are complementary local audits, not predictors of the global
zero-to-solution optimization basin:

1. **Restricted 512D:** the complete real divergence-free Fourier input
   subspace through `|k|≤4`, with the full `N=16` output retained.
2. **Adapted block-grid 1536D:** an orthonormal `8³` block-grid
   lift/restriction around the fixed `N=16` recovery map, followed by a dense
   SVD.

The second audit covers every coordinate of the adapted coarse block-grid map.
It is not the full 12,288D production Jacobian and is distinct from the
paper's native `N=8` Taylor–Green physics.

| audit | metric | XLB | surrogate 4k | surrogate 16k |
|---|---|---:|---:|---:|
| restricted 512D | mean `κ(J)` | 6.864 | 7.740 | 7.142 |
| restricted 512D | mean `κ(JᵀJ)` | 47.17 | 59.98 | 51.05 |
| restricted 512D | Frobenius relative error | — | 13.50% | 8.84% |
| restricted 512D | Frobenius cosine | — | 0.9914 | 0.9961 |
| adapted block-grid 1536D | raw `κ(J)` | `2.790e7` | `3.747e10` | `7.476e10` |
| adapted block-grid 1536D | resolved `κ(J)` | `5.319e3` | `4.890e3` | `5.445e3` |
| adapted block-grid 1536D | Frobenius relative error | — | 32.98% | 32.94% |
| adapted block-grid 1536D | Frobenius cosine | — | 0.9442 | 0.9443 |

The similar scalar condition numbers do not imply equal Jacobians. Scaling to
16k improves the restricted low-frequency Jacobian, leaves the adapted
block-grid agreement essentially unchanged, and worsens the unresolved raw
spectral tail. The raw tails fall below the float32 rank tolerance; resolved
condition numbers are reported separately.

![Checkpoint Jacobian comparison](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/checkpoint_conditioning_comparison.png)

![Restricted and adapted block-grid Jacobians](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/jacobian_conditioning.png)

## Runtime

Two matched RTX 5090 blocks counterbalance solver order and contribute 40 warm
trials per solver:

| RTX 5090 kernel | XLB | surrogate | surrogate / XLB |
|---|---:|---:|---:|
| forward | 4.794 ms | 7.350 ms | 1.53× |
| VJP | 15.198 ms | 14.771 ms | 0.97× |

The surrogate executes all 20 shared operator applications in forward and
reverse. It is not a forward speedup; VJP cost is effectively at parity
(0.97× in the counterbalanced result and 1.03× in the earlier independent
measurement). Solver-scoped three-seed harness times are also close: 32.81 s
surrogate versus 32.09 s XLB for L-BFGS, and 31.51 s versus 32.50 s with
projection. Including result-script setup and serialization gives 34.73 s
versus 34.21 s and 33.38 s versus 35.78 s, respectively. These wall times
include RPC, callbacks, optimizer bookkeeping, projection, and line search,
and should not be interpreted as kernel timings.

![Recovery accuracy and timing](https://raw.githubusercontent.com/pasteurlabs/mosaic/pr-118-local-results/pr-118/optimization_summary.png)

## Autoregressive solver-in-loop study

The opt-in `optimization/solver_in_loop_curriculum` experiment targets a
regime where the numerical solver is the only route from a learned action to
the training objective. A zero-initialized corrector acts once every four native
steps inside a recurrent free rollout. After two stopped-gradient pushforward
intervals, the loss is evaluated only on the terminal state returned by the
last solver interval; no local corrected-state target is present.

The controls are:

- **ONE**, immediate one-step supervision from reference states;
- **NOG**, the identical recurrent terminal objective with every solver response
  detached; with zero local weight it is exactly the native-solver control;
- **WIG**, the identical recurrent rollout with full credit through the solver.

An analytical test proves that terminal WIG and NOG have equal forward
objectives while only WIG receives a non-zero parameter gradient.

| quantity | value |
|---|---:|
| candidate grid / native step | `32²` / `dt=0.02` |
| correction cadence | every 4 native solver steps |
| production reference | `128²` pseudo-spectral |
| convergence audit | gated `256²` pseudo-spectral |
| IC spectrum | `k₀=4`, `σₖ=0.75`, amplitude `0.5` |
| train / held-out ICs | 32 / 8 |
| warm-up | 2 stopped-gradient correction intervals |
| differentiated curriculum | `2 → 4 → 8 → 16` intervals |
| maximum differentiated horizon | 64 native solver steps |
| free-running evaluation | 120 correction intervals / 480 native steps |

The result bundle retains per-seed raw FD/AD slopes, horizon-conditioned FD
sweeps, training and native-step accounting, correlations, physics diagnostics,
spectra, full fields, and the reference/solver/ONE/NOG/WIG rollout GIF.

### JAX-CFD admission result

Budget-matched 275-update calibrations separate the candidate regimes:

| regime | WIG reduction | NOG reduction | WIG/NOG | best valid FD error |
|---|---:|---:|---:|---:|
| dense direct loss (`1698666`) | 0.909× | 0.636× | 1.429× | 0.213% |
| sparse downstream loss (`1698667`) | 1.351× | 1.282× | 1.054× | — |
| **terminal downstream loss** (`1698866`) | **1.519×** | 1.000× | **1.519×** | **0.128%** |

The sparse regime shows the literature distinction clearly: recurrent forward
exposure supplies most of its gain (NOG is 30.95× better than ONE), while the
solver VJP adds 5.4%. The dense control has a larger relative VJP separation but
neither learned arm improves the native rollout. The canonical terminal regime
uses a task for which the solver VJP is genuinely required and gives the best
absolute correction at this calibration budget.

Terminal WIG is harmful at the early horizon-2 and horizon-4 checkpoints, then
crosses 1.063× at horizon 8 and reaches 1.488× at horizon 16. The corrected FD
check freezes the detached warm-up state and perturbs only the differentiated
suffix. Its best relative errors are 0.000%, 0.012%, 0.209%, 0.497%, and 0.128%
at horizons 1, 2, 4, 8, and 16; at horizon 16 the raw slopes are FD `−0.428728`
and AD `−0.429829`. The horizon-1 zero/zero result confirms that the omitted
production stage has no trainable terminal credit.

### Six-solver admission

The exact canonical four-stage schedule passes its one-seed admission cell for
every solver:

| solver | job | WIG / native | ONE / native | best suffix FD |
|---|---:|---:|---:|---:|
| JAX-CFD | `1698887` | 1.494× | 0.041× | 1.170% |
| INS.jl | `1698888` | 1.352× | 0.027× | 0.241% |
| PhiFlow | `1698889` | 1.250× | non-finite rollout | 0.036% |
| PICT | `1698890` | **1.503×** | 1.400× | 0.269% |
| Warp-NS | `1698891` | 1.194× | 1.148× | 0.289% |
| XLB | `1698892` | 1.372× | 0.082× | 0.308% |

NOG is the exact native-solver control in every cell. All six references pass
the common accuracy gate, all six WIG correctors improve their native rollout,
and all six solver VJPs pass the suffix FD check. ONE is useful for PICT and
Warp-NS, harmful for JAX-CFD, INS.jl, and XLB, and non-finite for PhiFlow. This
is why one-step supervision is not the primary comparison. PICT takes 48:47 for
275 updates versus 27–29 minutes for the other cells, so the 4,000-update draft
default does not fit a fair four-hour allocation. The canonical production
budget is therefore 1,000 updates per seed (`100→180→270→450` by horizon).
The three-seed, six-solver offline matrix is running as jobs `1699012–1699029`;
production artifacts are not yet present.

All experiments use the same Kander Slurm and Pyxis tooling and solver images as
the parent study. No hosted benchmark run is used.

This design follows the distinction between inference-distribution exposure and
long-term gradients in
[Differentiability in Unrolled Training of Neural Physics Simulators](https://arxiv.org/abs/2402.12971)
and the downstream solver-response objective used by
[Solver-in-the-Loop](https://proceedings.neurips.cc/paper/2020/hash/43e4e6a6f341e00671e123714de019a8-Abstract.html).


## Offline provenance and validation

No hosted benchmark run is required for this draft; `benchmark:none` remains
attached. All published experiments ran offline through Slurm and
Pyxis/Enroot.

- native trajectories: `1693649`; curriculum: `1693872`; fine-tune: `1694476`
- forward/JVP evaluation: `1696191`; 4k control: `1693974`
- restricted conditioning: `1696373`; adapted block-grid conditioning:
  `1696374`
- cross-model recovery: `1696375`; inverse-path diagnostic: `1696590`
- finite differences: XLB `1697019`; surrogate `1697017`
- packaged timing: `1696546`
- 4k L-BFGS/projected recovery: `1691080` / `1691085`
- 16k L-BFGS/projected recovery: `1696547` / `1696548`
- runtime package build and Pyxis round-trip: `1696556`
- rebased full validation: `1697321`; rebuilt package round-trip: `1697322`
- matched timing blocks: `1697367` and `1697363`; held-out/JVP follow-up:
  `1697360`
- artifact-manifest verification: `1697378`; immutable-source focused gate:
  `1697379`

The runtime image passed its API and Pyxis/Enroot round-trip checks. The
published artifact manifest verifies the dataset, split, checkpoint, source,
figures, JSON results, and dense-Jacobian checksums.

Validation:

- prior 3D surrogate head full suite: `522 passed, 3 skipped`
- final immutable-source surrogate gate: `5 passed`
- combined-head integration tests: `40 passed`
- `ruff check`, `ruff format --check`, and `git diff --check` pass
- combined-head GitHub CI passes on Python 3.12 and 3.14
- focused solver-loop suite: `37 passed`

Raw results and checksums:
[artifact index](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/README.md),
[manifest](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/manifest.json),
[evaluation](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/surrogate_evaluation.json),
[current-XLB evaluation follow-up](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/followup_evaluation_16k.json),
[order-balanced XLB timing](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/followup_timing_xlb.json),
[order-balanced surrogate timing](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/followup_timing_surrogate.json),
[inverse-path diagnostic](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/inverse_path_gradient_alignment.json),
[XLB finite differences](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/finite_difference_xlb.json),
[surrogate finite differences](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/finite_difference_surrogate.json),
[restricted conditioning](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/jacobian_conditioning.json),
[4k restricted conditioning](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/jacobian_conditioning_4k.json),
[adapted block-grid conditioning](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/jacobian_paper_protocol.json),
[4k adapted block-grid conditioning](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/jacobian_paper_protocol_4k.json),
[dense adapted Jacobians](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/jacobian_paper_protocol_matrices.npz),
[surrogate recovery](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/recovery_surrogate.json),
[4k surrogate recovery](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/recovery_surrogate_4k.json),
and [XLB-target recovery](https://github.com/pasteurlabs/mosaic/blob/pr-118-local-results/pr-118/cross_recovery.json).