### PR TITLE
feat(domain): add autoregressive solver-loop curriculum

### DIFF
--- a/mosaic/benchmarks/core/utils.py
+++ b/mosaic/benchmarks/core/utils.py
@@ -142,6 +142,25 @@ def _debug_run(run: dict) -> None:
             training[key] = min(training[key], cap)
     if training:
         training["check_grad"] = False
+    if "curriculum" in training:
+        debug_curriculum = []
+        for stage in list(training["curriculum"])[:2]:
+            debug_curriculum.append(
+                {
+                    **stage,
+                    "unroll": min(int(stage["unroll"]), 2),
+                    "updates": 1,
+                }
+            )
+        training["curriculum"] = debug_curriculum
+        training["unroll"] = max(int(stage["unroll"]) for stage in debug_curriculum)
+        training["max_updates"] = sum(
+            int(stage["updates"]) for stage in debug_curriculum
+        )
+        if "one_step_updates" in training:
+            training["one_step_updates"] = training["max_updates"]
+    if "residual_blocks" in training:
+        training["residual_blocks"] = min(int(training["residual_blocks"]), 1)
     if "model_seeds" in training:
         training["model_seeds"] = list(training["model_seeds"])[:1]
     dataset = run.get("dataset", {})
@@ -199,11 +218,9 @@ def exclusion_lookup(
     # Full path: "<suite>", "<suite>/<exp>", "<suite>/<exp>/<sub>".
     parts: list[str] = [suite]
     if experiment:
-        for p in experiment.split("/"):
-            parts.append(p)
+        parts.extend(experiment.split("/"))
     if sub:
-        for p in sub.split("/"):
-            parts.append(p)
+        parts.extend(sub.split("/"))
     # Try longest prefix first.
     for n in range(len(parts), 0, -1):
         key = "/".join(parts[:n])

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -590,7 +590,7 @@ problem.add_experiment(
                 "amplitude": 0.5,
             },
             "training": {
-                "max_updates": 12000,
+                "max_updates": 11000,
                 "unroll": 32,
                 "curriculum": [
                     {"unroll": 1, "updates": 1000, "lr": 1e-4},
@@ -598,10 +598,10 @@ problem.add_experiment(
                     {"unroll": 4, "updates": 1500, "lr": 1e-4},
                     {"unroll": 8, "updates": 2000, "lr": 1e-4},
                     {"unroll": 16, "updates": 2500, "lr": 5e-5},
-                    {"unroll": 32, "updates": 4000, "lr": 2.5e-5},
+                    {"unroll": 32, "updates": 3000, "lr": 2.5e-5},
                 ],
                 "include_one_step_baseline": True,
-                "one_step_updates": 12000,
+                "one_step_updates": 11000,
                 # The original SOL_n objective supervises every corrected
                 # state; omit the solver-terminal diagnostic used by the
                 # compact VJP audit.

--- a/mosaic/benchmarks/problems/navier_stokes_grid/config.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/config.py
@@ -71,6 +71,7 @@ from .physics import DIAGNOSTICS, make_inputs
 from .plots import (
     plot_drag_opt,
     plot_solver_in_loop,
+    plot_solver_in_loop_curriculum,
     plot_solver_in_loop_reference_sensitivity,
     plot_solver_in_loop_self_reference,
     plot_solver_in_loop_tgv,
@@ -544,6 +545,94 @@ problem.add_experiment(
         }
     ],
     plot=plot_solver_in_loop,
+)
+
+
+problem.add_experiment(
+    "optimization/solver_in_loop_curriculum",
+    solver_in_loop,
+    description=(
+        "Paper-aligned autoregressive correction study separating one-step "
+        "supervision (ONE), recurrent exposure without temporal solver gradients "
+        "(NOG), and full recurrent solver differentiation (WIG). The corrector is "
+        "trained with a 1→2→4→8→16→32 look-ahead curriculum and evaluated in a "
+        "300-interval free rollout."
+    ),
+    plot_description=(
+        "Curriculum checkpoints, ONE/NOG/WIG held-out errors, long-horizon "
+        "correlation and physics, final full fields, and autoregressive GIFs."
+    ),
+    runs=[
+        {
+            "ic": {"name": "multimode", "seed": 0},
+            "physics": {
+                "N": 32,
+                "nu": 0.001,
+                "dt": 0.02,
+                # Match the paper's hybrid-step semantics: the neural
+                # corrector intervenes after every native solver step.
+                "steps": 1,
+            },
+            "dataset": {
+                "reference_kind": "pseudo_spectral_multimode",
+                "reference_factor": 4,
+                "reference_substeps": 4,
+                "reference_audit_factor": 8,
+                "reference_audit_substeps": 8,
+                "reference_audit_seeds": [0, 100],
+                "reference_audit_frames": [1, 32, 96, 300],
+                "reference_convergence_tolerance": 0.005,
+                "train_seeds": list(range(32)),
+                "test_seeds": list(range(100, 108)),
+                "train_frames": 96,
+                "k0": 2.0,
+                "sigma_k": 0.5,
+                "amplitude": 0.5,
+            },
+            "training": {
+                "max_updates": 12000,
+                "unroll": 32,
+                "curriculum": [
+                    {"unroll": 1, "updates": 1000, "lr": 1e-4},
+                    {"unroll": 2, "updates": 1000, "lr": 1e-4},
+                    {"unroll": 4, "updates": 1500, "lr": 1e-4},
+                    {"unroll": 8, "updates": 2000, "lr": 1e-4},
+                    {"unroll": 16, "updates": 2500, "lr": 5e-5},
+                    {"unroll": 32, "updates": 4000, "lr": 2.5e-5},
+                ],
+                "include_one_step_baseline": True,
+                "one_step_updates": 12000,
+                # The original SOL_n objective supervises every corrected
+                # state; omit the solver-terminal diagnostic used by the
+                # compact VJP audit.
+                "loss_mode": "mean",
+                "solver_loss_weight": 0.0,
+                "loss_normalization": "solver_baseline",
+                "loss_scale_floor": 1e-6,
+                "lr": 1e-4,
+                "clip_norm": 5.0,
+                "architecture": "periodic_resnet",
+                "hidden_channels": 32,
+                "kernel_size": 5,
+                "residual_blocks": 5,
+                "seed": 2026,
+                "model_seeds": [0, 1, 2],
+                "check_grad": True,
+                "fd_epsilon": 1e-2,
+            },
+            "evaluation": {
+                "rollout_frames": 300,
+                "seen_ic_trajectories": 8,
+                "checkpoint_ic_trajectories": 2,
+                "checkpoint_rollout_frames": 100,
+                "stable_error_threshold": 1.0,
+                "correlation_threshold": 0.95,
+                "first_interval_error_tolerance": 0.05,
+                "native_long_error_tolerance": 1.0,
+            },
+        }
+    ],
+    plot=plot_solver_in_loop_curriculum,
 )
 
 

--- a/mosaic/benchmarks/problems/navier_stokes_grid/corrector.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/corrector.py
@@ -83,30 +83,120 @@ class PeriodicResidualCNN(eqx.Module):
         return self.layers[-1](x)
 
 
+class PeriodicResNetCorrector(eqx.Module):
+    """Paper-scale periodic residual corrector with two convolutions per block."""
+
+    stem: eqx.nn.Conv2d
+    blocks: tuple[tuple[eqx.nn.Conv2d, eqx.nn.Conv2d], ...]
+    head: eqx.nn.Conv2d
+    architecture: str = eqx.field(static=True)
+    hidden_channels: int = eqx.field(static=True)
+    kernel_size: int = eqx.field(static=True)
+    residual_blocks: int = eqx.field(static=True)
+
+    def __init__(
+        self,
+        key: jax.Array,
+        *,
+        hidden_channels: int,
+        kernel_size: int,
+        residual_blocks: int,
+    ) -> None:
+        if kernel_size % 2 != 1:
+            raise ValueError("kernel_size must be odd")
+        if residual_blocks < 1:
+            raise ValueError("residual_blocks must be positive")
+        keys = iter(jax.random.split(key, 2 * residual_blocks + 2))
+
+        def conv(cin: int, cout: int, layer_key: jax.Array) -> eqx.nn.Conv2d:
+            layer = eqx.nn.Conv2d(
+                cin,
+                cout,
+                kernel_size,
+                padding=kernel_size // 2,
+                padding_mode="CIRCULAR",
+                key=layer_key,
+            )
+            fan_in = kernel_size * kernel_size * cin
+            weight = jax.random.normal(
+                layer_key, layer.weight.shape, dtype=jnp.float32
+            ) * np.sqrt(2.0 / fan_in)
+            return eqx.tree_at(
+                lambda value: (value.weight, value.bias),
+                layer,
+                (weight, jnp.zeros((cout, 1, 1), dtype=jnp.float32)),
+            )
+
+        self.stem = conv(2, hidden_channels, next(keys))
+        self.blocks = tuple(
+            (
+                conv(hidden_channels, hidden_channels, next(keys)),
+                conv(hidden_channels, hidden_channels, next(keys)),
+            )
+            for _ in range(residual_blocks)
+        )
+        head_key = next(keys)
+        head = eqx.nn.Conv2d(
+            hidden_channels,
+            2,
+            kernel_size,
+            padding=kernel_size // 2,
+            padding_mode="CIRCULAR",
+            key=head_key,
+        )
+        self.head = eqx.tree_at(
+            lambda value: (value.weight, value.bias),
+            head,
+            (
+                jnp.zeros_like(head.weight),
+                jnp.zeros((2, 1, 1), dtype=jnp.float32),
+            ),
+        )
+        self.architecture = "periodic_resnet"
+        self.hidden_channels = hidden_channels
+        self.kernel_size = kernel_size
+        self.residual_blocks = residual_blocks
+
+    def __call__(self, velocity: jax.Array) -> jax.Array:
+        """Map a channel-first velocity field to an additive correction."""
+        x = jax.nn.gelu(self.stem(velocity))
+        for first, second in self.blocks:
+            x = jax.nn.gelu(x + second(jax.nn.gelu(first(x))))
+        return self.head(x)
+
+
 def init_corrector(
     key: jax.Array,
     *,
     hidden_channels: int = 32,
     kernel_size: int = 5,
     architecture: str = "periodic_residual_cnn",
-) -> PeriodicResidualCNN:
+    residual_blocks: int = 5,
+) -> PeriodicResidualCNN | PeriodicResNetCorrector:
     """Initialise the benchmark-owned Equinox corrector.
 
     The final layer starts at zero, so the initial corrected rollout is exactly
     the underlying solver. The first update trains the readout; subsequent
     updates propagate through the feature layers.
     """
-    if architecture != "periodic_residual_cnn":
-        raise ValueError(f"unknown corrector architecture: {architecture!r}")
-    return PeriodicResidualCNN(
-        key,
-        hidden_channels=hidden_channels,
-        kernel_size=kernel_size,
-    )
+    if architecture == "periodic_residual_cnn":
+        return PeriodicResidualCNN(
+            key,
+            hidden_channels=hidden_channels,
+            kernel_size=kernel_size,
+        )
+    if architecture == "periodic_resnet":
+        return PeriodicResNetCorrector(
+            key,
+            hidden_channels=hidden_channels,
+            kernel_size=kernel_size,
+            residual_blocks=residual_blocks,
+        )
+    raise ValueError(f"unknown corrector architecture: {architecture!r}")
 
 
 def apply_corrector(
-    model: PeriodicResidualCNN,
+    model: PeriodicResidualCNN | PeriodicResNetCorrector,
     velocity: jax.Array,
     *,
     velocity_scale: float | jax.Array,
@@ -156,7 +246,7 @@ def project_periodic_correction(delta: jax.Array, domain_extent: float) -> jax.A
 
 
 def corrected_velocity(
-    model: PeriodicResidualCNN,
+    model: PeriodicResidualCNN | PeriodicResNetCorrector,
     provisional: jax.Array,
     *,
     velocity_scale: float | jax.Array,
@@ -557,6 +647,7 @@ def finite_volume_reference_trajectory(
 
 
 __all__ = [
+    "PeriodicResNetCorrector",
     "PeriodicResidualCNN",
     "apply_corrector",
     "centered_divergence_rms",

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -1700,6 +1700,662 @@ def _save_solver_in_loop_animation(
     _save_animation(animation, "solver_in_loop_trajectory", out_dir, fps=6)
 
 
+def plot_solver_in_loop_curriculum(
+    cfg: Problem,
+    *,
+    save: bool = True,
+    suffix: str = "",
+    **kwargs: Any,
+) -> list:
+    """Plot the paper-aligned ONE/NOG/WIG curriculum and long rollout."""
+    figs = plot_solver_in_loop(
+        cfg,
+        save=save,
+        suffix=suffix,
+        exp_key="solver_in_loop_curriculum",
+        title="Autoregressive corrector curriculum",
+        **kwargs,
+    )
+    out_dir = experiment_dir(
+        results_dir(),
+        cfg.name,
+        "optimization",
+        f"solver_in_loop_curriculum{suffix}",
+    )
+    result_path = out_dir / "result.json"
+    fields_path = out_dir / "corrector_fields.npz"
+    if not result_path.exists() or not fields_path.exists():
+        return figs
+    data = v1_to_legacy(load_json(result_path))
+    arrays = try_load_npz(fields_path)
+    names = [str(value) for value in arrays.get("solver_names", np.array([])).tolist()]
+    if not names:
+        return figs
+
+    for figure in (
+        _plot_solver_in_loop_curriculum_rollouts(arrays, names, out_dir, save=save),
+        _plot_solver_in_loop_curriculum_correlations(
+            arrays,
+            names,
+            out_dir,
+            save=save,
+        ),
+        _plot_solver_in_loop_curriculum_summary(
+            data,
+            arrays,
+            names,
+            out_dir,
+            save=save,
+        ),
+        _plot_solver_in_loop_curriculum_fields(arrays, names, out_dir, save=save),
+        _plot_solver_in_loop_curriculum_spectra(arrays, names, out_dir, save=save),
+    ):
+        if figure is not None:
+            figs.append(figure)
+    if save:
+        _save_solver_in_loop_curriculum_animation(arrays, names, out_dir)
+    return figs
+
+
+def _curriculum_rows(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+) -> list[tuple[int, str]]:
+    """Return curriculum-capable cells in canonical solver order."""
+    rows = [
+        (index, name)
+        for index, name in enumerate(names)
+        if np.asarray(arrays.get(f"error_one_step_{index}", np.array([]))).size
+    ]
+    solver_order = {alias: index for index, alias in enumerate(NS_ORDER)}
+    rows.sort(
+        key=lambda row: solver_order.get(
+            resolve_solver_alias(row[1]) or row[1],
+            len(solver_order),
+        )
+    )
+    return rows
+
+
+def _plot_solver_in_loop_curriculum_rollouts(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Show long free-rollout error for ONE, NOG, WIG, and solver only."""
+    rows = _curriculum_rows(arrays, names)
+    if not rows:
+        return None
+    plt.rcParams.update(RCPARAMS)
+    ncols = 3
+    nrows = int(np.ceil(len(rows) / ncols))
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, 1.85 * nrows),
+        squeeze=False,
+        layout="constrained",
+    )
+    times = np.asarray(arrays.get("evaluation_times", np.array([])))
+    semantics = (
+        ("error_uncorrected", "Solver only", ":", "0.45"),
+        ("error_one_step", "ONE", "-.", "#D95F02"),
+        ("error_stop_gradient", "NOG", "--", "#7570B3"),
+        ("error_corrected", "WIG", "-", "#1B9E77"),
+    )
+    for axis, (index, name) in zip(axes.ravel(), rows, strict=False):
+        for prefix, label, linestyle, color in semantics:
+            values = np.asarray(arrays.get(f"{prefix}_{index}", np.array([])))
+            if values.size < 2:
+                continue
+            x = times[: values.size] if times.size else np.arange(values.size)
+            axis.plot(
+                x[1:],
+                np.maximum(values[1:], 1e-12),
+                label=label,
+                linestyle=linestyle,
+                color=color,
+            )
+        axis.set_yscale("log")
+        axis.set_xlabel("Physical time")
+        axis.set_ylabel("Relative $L^2$ error")
+        axis.set_title(solver_props(name)[0])
+    for axis in axes.ravel()[len(rows) :]:
+        axis.axis("off")
+    axes.ravel()[0].legend(loc="best", fontsize=6.5)
+    fig.suptitle("Fully autoregressive held-out rollouts")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_rollouts", out_dir)
+    return fig
+
+
+def _plot_solver_in_loop_curriculum_correlations(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Show long-horizon field correlation for all training protocols."""
+    rows = _curriculum_rows(arrays, names)
+    if not rows:
+        return None
+    plt.rcParams.update(RCPARAMS)
+    ncols = 3
+    nrows = int(np.ceil(len(rows) / ncols))
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, 1.85 * nrows),
+        squeeze=False,
+        layout="constrained",
+    )
+    times = np.asarray(arrays.get("evaluation_times", np.array([])))
+    semantics = (
+        ("correlation_uncorrected", "Solver only", ":", "0.45"),
+        ("correlation_one_step", "ONE", "-.", "#D95F02"),
+        ("correlation_stop_gradient", "NOG", "--", "#7570B3"),
+        ("correlation_corrected", "WIG", "-", "#1B9E77"),
+    )
+    for axis, (index, name) in zip(axes.ravel(), rows, strict=False):
+        for prefix, label, linestyle, color in semantics:
+            values = np.asarray(arrays.get(f"{prefix}_{index}", np.array([])))
+            if values.size < 2:
+                continue
+            x = times[: values.size] if times.size else np.arange(values.size)
+            axis.plot(
+                x,
+                values,
+                label=label,
+                linestyle=linestyle,
+                color=color,
+            )
+        axis.axhline(0.95, color="0.6", linestyle=":", linewidth=0.8)
+        axis.set_ylim(-0.05, 1.02)
+        axis.set_xlabel("Physical time")
+        axis.set_ylabel("Field correlation")
+        axis.set_title(solver_props(name)[0])
+    for axis in axes.ravel()[len(rows) :]:
+        axis.axis("off")
+    axes.ravel()[0].legend(loc="best", fontsize=6.5)
+    fig.suptitle("Held-out correlation decay (threshold 0.95)")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_correlations", out_dir)
+    return fig
+
+
+def _plot_solver_in_loop_curriculum_summary(
+    data: dict[str, Any],
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Decompose recurrent exposure, temporal gradients, horizon, and cost."""
+    rows = _curriculum_rows(arrays, names)
+    if not rows:
+        return None
+    by_solver = data.get("by_solver", {})
+    labels = [solver_props(name)[0] for _index, name in rows]
+    colors = [solver_props(name)[1] for _index, name in rows]
+    positions = np.arange(len(rows), dtype=float)
+    width = 0.24
+
+    def metric(name: str, key: str) -> float:
+        value = by_solver.get(name, {}).get(key)
+        return float(value) if value is not None else np.nan
+
+    one_gain = [
+        metric(name, "one_step_geometric_error_reduction") for _index, name in rows
+    ]
+    nog_gain = [
+        metric(name, "stop_gradient_geometric_error_reduction") for _index, name in rows
+    ]
+    wig_gain = [metric(name, "geometric_error_reduction") for _index, name in rows]
+    unrolling_lift = [
+        100.0 * (metric(name, "unrolling_geometric_lift_nog_over_one") - 1.0)
+        for _index, name in rows
+    ]
+    vjp_lift = [
+        100.0 * (metric(name, "solver_vjp_geometric_lift") - 1.0)
+        for _index, name in rows
+    ]
+
+    plt.rcParams.update(RCPARAMS)
+    fig, axes = plt.subplots(
+        2,
+        2,
+        figsize=(TEXTWIDTH, 4.6),
+        squeeze=False,
+        layout="constrained",
+    )
+    ax_gain, ax_decomposition, ax_horizon, ax_cost = axes.ravel()
+    for offset, values, label, alpha in (
+        (-width, one_gain, "ONE", 0.35),
+        (0.0, nog_gain, "NOG", 0.65),
+        (width, wig_gain, "WIG", 0.95),
+    ):
+        ax_gain.bar(
+            positions + offset,
+            values,
+            width,
+            color=colors,
+            alpha=alpha,
+            label=label,
+        )
+    ax_gain.axhline(1.0, color="0.45", linestyle=":", linewidth=1.0)
+    ax_gain.set_xticks(positions, labels, rotation=35, ha="right")
+    ax_gain.set_ylabel("Geometric error reduction [×]")
+    ax_gain.set_title("Absolute correctability")
+    ax_gain.legend(fontsize=6.5)
+
+    ax_decomposition.bar(
+        positions - width / 2,
+        unrolling_lift,
+        width,
+        color=colors,
+        alpha=0.45,
+        label="NOG / ONE",
+    )
+    ax_decomposition.bar(
+        positions + width / 2,
+        vjp_lift,
+        width,
+        color=colors,
+        alpha=0.95,
+        label="WIG / NOG",
+    )
+    ax_decomposition.axhline(0.0, color="0.45", linestyle=":", linewidth=1.0)
+    ax_decomposition.set_xticks(positions, labels, rotation=35, ha="right")
+    ax_decomposition.set_ylabel("Incremental rollout lift [%]")
+    ax_decomposition.set_title("Exposure versus temporal credit")
+    ax_decomposition.legend(fontsize=6.5)
+
+    for index, name in rows:
+        unrolls = np.asarray(
+            arrays.get(f"curriculum_stage_unrolls_{index}", np.array([]))
+        )
+        full = np.asarray(
+            arrays.get(f"curriculum_checkpoint_error_full_{index}", np.array([]))
+        )
+        native = np.asarray(
+            arrays.get(f"curriculum_checkpoint_error_native_{index}", np.array([]))
+        )
+        if not unrolls.size or full.ndim != 2 or native.size < 2:
+            continue
+        reductions = [
+            np.exp(
+                np.mean(
+                    np.log(
+                        (native[1 : stage_error.size] + 1e-12)
+                        / (stage_error[1:] + 1e-12)
+                    )
+                )
+            )
+            for stage_error in full
+        ]
+        _label, color, _linestyle, marker = solver_props(name)
+        ax_horizon.plot(
+            unrolls,
+            reductions,
+            color=color,
+            marker=marker,
+            label=_label,
+        )
+    ax_horizon.axhline(1.0, color="0.45", linestyle=":", linewidth=1.0)
+    ax_horizon.set_xscale("log", base=2)
+    ax_horizon.set_xticks([1, 2, 4, 8, 16, 32], [1, 2, 4, 8, 16, 32])
+    ax_horizon.set_xlabel("Curriculum look-ahead")
+    ax_horizon.set_ylabel("WIG error reduction [×]")
+    ax_horizon.set_title("Checkpoint quality versus horizon")
+
+    one_cost = [metric(name, "one_step_training_wall_time_s") for _index, name in rows]
+    nog_cost = [
+        metric(name, "stop_gradient_training_wall_time_s") for _index, name in rows
+    ]
+    wig_cost = [metric(name, "training_wall_time_s") for _index, name in rows]
+    ax_cost.bar(
+        positions,
+        one_cost,
+        color=colors,
+        alpha=0.35,
+        label="ONE",
+    )
+    ax_cost.bar(
+        positions,
+        nog_cost,
+        bottom=one_cost,
+        color=colors,
+        alpha=0.65,
+        label="NOG",
+    )
+    ax_cost.bar(
+        positions,
+        wig_cost,
+        bottom=np.asarray(one_cost) + np.asarray(nog_cost),
+        color=colors,
+        alpha=0.95,
+        label="WIG",
+    )
+    ax_cost.set_xticks(positions, labels, rotation=35, ha="right")
+    ax_cost.set_ylabel("Training wall time [s]")
+    ax_cost.set_title("Measured training cost")
+    ax_cost.legend(fontsize=6.5)
+
+    _solver_loop_legend(fig, [name for _index, name in rows])
+    fig.suptitle("ONE/NOG/WIG decomposition and curriculum")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_summary", out_dir)
+    return fig
+
+
+def _curriculum_rollouts(
+    arrays: dict[str, np.ndarray],
+    solver_index: int,
+) -> tuple[np.ndarray, ...] | None:
+    """Return reference, native, ONE, NOG, and WIG rollouts for one cell."""
+    values = (
+        _solver_reference_rollout(arrays, solver_index),
+        np.asarray(arrays.get(f"rollout_uncorrected_{solver_index}", np.array([]))),
+        np.asarray(arrays.get(f"rollout_one_step_{solver_index}", np.array([]))),
+        np.asarray(arrays.get(f"rollout_stop_gradient_{solver_index}", np.array([]))),
+        np.asarray(arrays.get(f"rollout_corrected_{solver_index}", np.array([]))),
+    )
+    return values if all(value.size for value in values) else None
+
+
+def _plot_solver_in_loop_curriculum_fields(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Render final reference, solver, ONE, NOG, and WIG vorticity fields."""
+    rows = [
+        (index, name, rollouts)
+        for index, name in _curriculum_rows(arrays, names)
+        if (rollouts := _curriculum_rollouts(arrays, index)) is not None
+    ]
+    if not rows:
+        return None
+    fields = [
+        [_periodic_vorticity_2d(trajectory[-1]) for trajectory in rollouts]
+        for _index, _name, rollouts in rows
+    ]
+    vmax = (
+        float(
+            np.percentile(
+                np.abs(
+                    np.concatenate([field.ravel() for row in fields for field in row])
+                ),
+                99.0,
+            )
+        )
+        or 1.0
+    )
+    plt.rcParams.update(RCPARAMS)
+    fig, axes = plt.subplots(
+        len(rows),
+        5,
+        figsize=(TEXTWIDTH, max(2.0, 0.8 * len(rows))),
+        squeeze=False,
+        layout="constrained",
+    )
+    image = None
+    for row_index, ((_solver_index, name, _rollouts), row_fields) in enumerate(
+        zip(rows, fields, strict=True)
+    ):
+        for column, field in enumerate(row_fields):
+            image = axes[row_index, column].imshow(
+                field.T,
+                origin="lower",
+                cmap="RdBu_r",
+                vmin=-vmax,
+                vmax=vmax,
+                interpolation="nearest",
+            )
+            axes[row_index, column].set_xticks([])
+            axes[row_index, column].set_yticks([])
+        axes[row_index, 0].set_ylabel(
+            solver_props(name)[0],
+            rotation=0,
+            ha="right",
+            va="center",
+            labelpad=8,
+        )
+    for axis, title in zip(
+        axes[0],
+        ("Reference", "Solver", "ONE", "NOG", "WIG"),
+        strict=True,
+    ):
+        axis.set_title(title)
+    if image is not None:
+        colorbar = fig.colorbar(
+            image,
+            ax=axes.ravel().tolist(),
+            location="right",
+            shrink=0.82,
+            pad=0.02,
+        )
+        colorbar.set_label(r"Vorticity $\omega$")
+    fig.suptitle("Final fully autoregressive held-out fields")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_fields", out_dir)
+    return fig
+
+
+def _isotropic_energy_spectrum(velocity: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return shell-summed kinetic-energy spectrum on a periodic square."""
+    ux, uy = _vel_components_2d(np.asarray(velocity))
+    n = ux.shape[0]
+    ux_hat = np.fft.fft2(ux) / (n * n)
+    uy_hat = np.fft.fft2(uy) / (n * n)
+    energy = 0.5 * (np.abs(ux_hat) ** 2 + np.abs(uy_hat) ** 2)
+    wave = np.fft.fftfreq(n) * n
+    kx, ky = np.meshgrid(wave, wave, indexing="ij")
+    shells = np.rint(np.sqrt(kx**2 + ky**2)).astype(int)
+    shell_energy = np.bincount(
+        shells.ravel(),
+        weights=energy.ravel(),
+        minlength=n // 2 + 1,
+    )[: n // 2 + 1]
+    wavenumbers = np.arange(shell_energy.size)
+    return wavenumbers[1:], shell_energy[1:]
+
+
+def _plot_solver_in_loop_curriculum_spectra(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Compare final energy spectra for every autoregressive training mode."""
+    rows = [
+        (index, name, rollouts)
+        for index, name in _curriculum_rows(arrays, names)
+        if (rollouts := _curriculum_rollouts(arrays, index)) is not None
+    ]
+    if not rows:
+        return None
+    plt.rcParams.update(RCPARAMS)
+    ncols = 3
+    nrows = int(np.ceil(len(rows) / ncols))
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, 1.85 * nrows),
+        squeeze=False,
+        layout="constrained",
+    )
+    semantics = (
+        ("Reference", "--", "0.2"),
+        ("Solver", ":", "0.45"),
+        ("ONE", "-.", "#D95F02"),
+        ("NOG", "--", "#7570B3"),
+        ("WIG", "-", "#1B9E77"),
+    )
+    for axis, (_index, name, rollouts) in zip(
+        axes.ravel(),
+        rows,
+        strict=False,
+    ):
+        for trajectory, (label, linestyle, color) in zip(
+            rollouts,
+            semantics,
+            strict=True,
+        ):
+            wavenumber, spectrum = _isotropic_energy_spectrum(trajectory[-1])
+            axis.loglog(
+                wavenumber,
+                np.maximum(spectrum, 1e-16),
+                label=label,
+                linestyle=linestyle,
+                color=color,
+            )
+        axis.set_xlabel("Wavenumber $k$")
+        axis.set_ylabel("$E(k)$")
+        axis.set_title(solver_props(name)[0])
+    for axis in axes.ravel()[len(rows) :]:
+        axis.axis("off")
+    axes.ravel()[0].legend(loc="best", fontsize=6.0)
+    fig.suptitle("Final held-out kinetic-energy spectra")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_spectra", out_dir)
+    return fig
+
+
+def _save_solver_in_loop_curriculum_animation(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+) -> None:
+    """Animate reference, native, ONE, NOG, and WIG held-out trajectories."""
+    rows = [
+        (index, name, rollouts)
+        for index, name in _curriculum_rows(arrays, names)
+        if (rollouts := _curriculum_rollouts(arrays, index)) is not None
+    ]
+    if not rows:
+        return
+    available_frames = min(
+        trajectory.shape[0]
+        for _index, _name, rollouts in rows
+        for trajectory in rollouts
+    )
+    frame_indices = np.unique(
+        np.linspace(
+            0,
+            available_frames - 1,
+            num=min(available_frames, 24),
+            dtype=int,
+        )
+    )
+    vorticity = [
+        [
+            [_periodic_vorticity_2d(trajectory[frame]) for frame in frame_indices]
+            for trajectory in rollouts
+        ]
+        for _index, _name, rollouts in rows
+    ]
+    vmax = (
+        float(
+            np.percentile(
+                np.abs(
+                    np.concatenate(
+                        [
+                            field.ravel()
+                            for row in vorticity
+                            for mode in row
+                            for field in mode
+                        ]
+                    )
+                ),
+                99.0,
+            )
+        )
+        or 1.0
+    )
+    plt.rcParams.update(RCPARAMS)
+    fig, axes = plt.subplots(
+        len(rows),
+        5,
+        figsize=(TEXTWIDTH, max(2.0, 0.8 * len(rows))),
+        dpi=100,
+        squeeze=False,
+        layout="constrained",
+    )
+    images: list[tuple[Any, int, int]] = []
+    for row_index, (_solver_index, name, _rollouts) in enumerate(rows):
+        for column in range(5):
+            image = axes[row_index, column].imshow(
+                vorticity[row_index][column][0].T,
+                origin="lower",
+                cmap="RdBu_r",
+                vmin=-vmax,
+                vmax=vmax,
+                interpolation="nearest",
+                animated=True,
+            )
+            images.append((image, row_index, column))
+            axes[row_index, column].set_xticks([])
+            axes[row_index, column].set_yticks([])
+        axes[row_index, 0].set_ylabel(
+            solver_props(name)[0],
+            rotation=0,
+            ha="right",
+            va="center",
+            labelpad=8,
+        )
+    for axis, title_text in zip(
+        axes[0],
+        ("Reference", "Solver", "ONE", "NOG", "WIG"),
+        strict=True,
+    ):
+        axis.set_title(title_text)
+    colorbar = fig.colorbar(
+        images[-1][0],
+        ax=axes.ravel().tolist(),
+        location="right",
+        shrink=0.82,
+        pad=0.02,
+    )
+    colorbar.set_label(r"Vorticity $\omega$")
+    all_times = np.asarray(arrays.get("evaluation_times", np.array([])))
+    times = (
+        all_times[frame_indices]
+        if all_times.size >= available_frames
+        else np.arange(frame_indices.size)
+    )
+    title = fig.suptitle("Autoregressive curriculum rollout at $t=0$")
+
+    def _update(frame: int) -> tuple[Any, ...]:
+        for image, row_index, column in images:
+            image.set_data(vorticity[row_index][column][frame].T)
+        title.set_text(
+            f"Autoregressive curriculum rollout at $t={float(times[frame]):g}$"
+        )
+        return tuple([image for image, _row, _column in images] + [title])
+
+    animation = manimation.FuncAnimation(
+        fig,
+        _update,
+        frames=len(frame_indices),
+        interval=180,
+        blit=False,
+    )
+    _save_animation(
+        animation,
+        "solver_in_loop_curriculum_trajectory",
+        out_dir,
+        fps=6,
+    )
+
+
 def plot_drag_opt(
     cfg: Problem,
     *,

--- a/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/plots.py
@@ -1740,6 +1740,12 @@ def plot_solver_in_loop_curriculum(
             out_dir,
             save=save,
         ),
+        _plot_solver_in_loop_curriculum_fd(
+            arrays,
+            names,
+            out_dir,
+            save=save,
+        ),
         _plot_solver_in_loop_curriculum_summary(
             data,
             arrays,
@@ -1883,6 +1889,78 @@ def _plot_solver_in_loop_curriculum_correlations(
     fig.suptitle("Held-out correlation decay (threshold 0.95)")
     if save:
         save_fig(fig, "solver_in_loop_curriculum_correlations", out_dir)
+    return fig
+
+
+def _plot_solver_in_loop_curriculum_fd(
+    arrays: dict[str, np.ndarray],
+    names: list[str],
+    out_dir: Path,
+    *,
+    save: bool,
+) -> plt.Figure | None:
+    """Show directional finite-difference agreement across epsilon and seeds."""
+    rows = [
+        (index, name)
+        for index, name in _curriculum_rows(arrays, names)
+        if np.asarray(arrays.get(f"fd_rel_error_samples_{index}", np.array([]))).size
+    ]
+    if not rows:
+        return None
+    plt.rcParams.update(RCPARAMS)
+    ncols = 3
+    nrows = int(np.ceil(len(rows) / ncols))
+    fig, axes = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(TEXTWIDTH, 1.85 * nrows),
+        squeeze=False,
+        layout="constrained",
+    )
+    for axis, (index, name) in zip(axes.ravel(), rows, strict=False):
+        epsilons = np.asarray(arrays.get(f"fd_epsilon_{index}", np.array([])))
+        errors = np.asarray(arrays.get(f"fd_rel_error_samples_{index}", np.array([])))
+        if epsilons.size == 0 or errors.ndim != 2:
+            axis.axis("off")
+            continue
+        _label, color, _linestyle, marker = solver_props(name)
+        for seed_errors in errors:
+            axis.plot(
+                epsilons,
+                np.maximum(seed_errors, 1e-12),
+                color=color,
+                alpha=0.22,
+                linewidth=0.8,
+            )
+        median = np.median(errors, axis=0)
+        axis.plot(
+            epsilons,
+            np.maximum(median, 1e-12),
+            color=color,
+            marker=marker,
+            linewidth=1.4,
+            label="median; faint = seed",
+        )
+        best_index = int(np.argmin(median))
+        axis.scatter(
+            [epsilons[best_index]],
+            [max(float(median[best_index]), 1e-12)],
+            color=color,
+            edgecolor="black",
+            linewidth=0.4,
+            zorder=3,
+        )
+        axis.set_xscale("log")
+        axis.set_yscale("log")
+        axis.set_xlabel("FD perturbation $\\epsilon$")
+        axis.set_ylabel("Relative FD/AD error")
+        axis.set_title(_label)
+        axis.legend(fontsize=6)
+    for axis in axes.ravel()[len(rows) :]:
+        axis.axis("off")
+    fig.suptitle("End-to-end solver-VJP finite-difference sweep")
+    if save:
+        save_fig(fig, "solver_in_loop_curriculum_fd", out_dir)
     return fig
 
 

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -67,6 +67,8 @@ class _TrainingResult(NamedTuple):
     grad_norms: list[float]
     update_times: list[float]
     fd_error: float | None
+    fd_epsilons: tuple[float, ...]
+    fd_errors: tuple[float, ...]
     completed: bool
     stage_models: tuple[Any, ...]
     stage_unrolls: tuple[int, ...]
@@ -882,6 +884,19 @@ def _train_corrector(
     loss_mode = str(training.get("loss_mode", "mean"))
     solver_loss_weight = float(training.get("solver_loss_weight", 0.1))
     fd_epsilon = float(training.get("fd_epsilon", 1e-2))
+    configured_fd_epsilons = training.get("fd_epsilons")
+    if configured_fd_epsilons is None:
+        fd_epsilons = (
+            10.0 * fd_epsilon,
+            3.0 * fd_epsilon,
+            fd_epsilon,
+            0.3 * fd_epsilon,
+            0.1 * fd_epsilon,
+        )
+    else:
+        fd_epsilons = tuple(float(value) for value in configured_fd_epsilons)
+    if not fd_epsilons or any(value <= 0 for value in fd_epsilons):
+        raise ValueError("training.fd_epsilons must contain positive values")
     maximum_unroll = max(stage.unroll for stage in stages)
     if train.shape[1] < maximum_unroll + 1:
         raise ValueError(
@@ -909,6 +924,7 @@ def _train_corrector(
     grad_norms: list[float] = []
     update_times: list[float] = []
     fd_error: float | None = None
+    fd_error_curve: tuple[float, ...] = ()
     completed = True
     stage_models: list[Any] = []
     stage_boundaries: list[int] = []
@@ -952,13 +968,17 @@ def _train_corrector(
                 and differentiate_solver
                 and bool(training.get("check_grad", True))
             ):
-                fd_error = _directional_fd(
-                    loss_fn,
-                    model,
-                    grads,
-                    jax.random.PRNGKey(model_seed + 1),
-                    epsilon=fd_epsilon,
+                fd_error_curve = tuple(
+                    _directional_fd(
+                        loss_fn,
+                        model,
+                        grads,
+                        jax.random.PRNGKey(model_seed + 1),
+                        epsilon=epsilon,
+                    )
+                    for epsilon in fd_epsilons
                 )
+                fd_error = min(fd_error_curve)
             updates, opt_state = optimiser.update(
                 grads,
                 opt_state,
@@ -978,6 +998,8 @@ def _train_corrector(
         grad_norms=grad_norms,
         update_times=update_times,
         fd_error=fd_error,
+        fd_epsilons=fd_epsilons if fd_error_curve else (),
+        fd_errors=fd_error_curve,
         completed=completed,
         stage_models=tuple(stage_models),
         stage_unrolls=tuple(stage.unroll for stage in stages[: len(stage_models)]),
@@ -1204,6 +1226,8 @@ def _std(values: list[float]) -> float:
         "update_time_stop_gradient_samples",
         "update_time_one_step",
         "update_time_one_step_samples",
+        "fd_epsilon",
+        "fd_rel_error_samples",
         "error_corrected",
         "error_corrected_samples",
         "error_corrected_seed_std",
@@ -1467,6 +1491,9 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     grad_norms_by_seed: list[list[float]] = []
     update_times_by_seed: list[list[float]] = []
     fd_errors: list[float | None] = []
+    fd_model_seeds: list[int] = []
+    fd_epsilons_by_seed: list[tuple[float, ...]] = []
+    fd_error_curves_by_seed: list[tuple[float, ...]] = []
     completed_by_seed: list[bool] = []
     training_walls: list[float] = []
     stop_gradient_losses_by_seed: list[list[float]] = []
@@ -1497,10 +1524,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     for seed_idx, model_seed in enumerate(model_seeds):
         seed_training = {
             **training,
-            # One end-to-end FD check is enough for a shared architecture and
-            # solver VJP; repeating it for initialisation replicates adds cost
-            # without strengthening the paired training comparison.
-            "check_grad": bool(training.get("check_grad", True)) and seed_idx == 0,
+            "check_grad": bool(training.get("check_grad", True)),
         }
         started = time.perf_counter()
         full_training = _train_corrector(
@@ -1519,6 +1543,8 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         grad_norms = full_training.grad_norms
         update_times = full_training.update_times
         fd_error = full_training.fd_error
+        fd_epsilons = full_training.fd_epsilons
+        fd_error_curve = full_training.fd_errors
         completed = full_training.completed
         training_walls.append(time.perf_counter() - started)
 
@@ -1696,6 +1722,10 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         grad_norms_by_seed.append(grad_norms)
         update_times_by_seed.append(update_times)
         fd_errors.append(fd_error)
+        if fd_error_curve:
+            fd_model_seeds.append(model_seed)
+            fd_epsilons_by_seed.append(fd_epsilons)
+            fd_error_curves_by_seed.append(fd_error_curve)
         completed_by_seed.append(completed)
         stop_gradient_losses_by_seed.append(stop_gradient_losses)
         stop_gradient_grad_norms_by_seed.append(stop_gradient_grad_norms)
@@ -1908,6 +1938,27 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             ],
             axis=0,
         )
+    fd_epsilon_array = np.asarray([], dtype=np.float32)
+    fd_error_samples = np.empty((0, 0), dtype=np.float32)
+    fd_check_summary: list[dict[str, Any]] = []
+    if fd_error_curves_by_seed:
+        if len(set(fd_epsilons_by_seed)) != 1:
+            raise RuntimeError("FD epsilon grids differ across model seeds")
+        fd_epsilon_array = np.asarray(fd_epsilons_by_seed[0], dtype=np.float32)
+        fd_error_samples = np.asarray(fd_error_curves_by_seed, dtype=np.float32)
+        fd_check_summary = [
+            {
+                "model_seed": model_seed,
+                "best_epsilon": float(fd_epsilon_array[int(np.argmin(curve))]),
+                "best_relative_error": float(np.min(curve)),
+                "max_relative_error": float(np.max(curve)),
+            }
+            for model_seed, curve in zip(
+                fd_model_seeds,
+                fd_error_samples,
+                strict=True,
+            )
+        ]
 
     metrics = {
         **reference_audit,
@@ -2074,6 +2125,11 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         if stop_gradient_grad_norms.size
         else None,
         "end_to_end_fd_rel_error": _mean_optional(fd_errors),
+        "end_to_end_fd_rel_error_max": max(
+            (value for value in fd_errors if value is not None),
+            default=None,
+        ),
+        "fd_check_summary": fd_check_summary,
         "final_divergence_rms": divergence_rms(first_corrected[-1], ctx.domain_extent)
         if first_corrected is not None
         else None,
@@ -2331,6 +2387,8 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         "update_time_stop_gradient_samples": _stack_curves(
             stop_gradient_update_times_by_seed
         ),
+        "fd_epsilon": fd_epsilon_array,
+        "fd_rel_error_samples": fd_error_samples,
         "error_corrected": np.asarray(corrected_error, dtype=np.float32),
         "error_corrected_samples": corrected_errors_array.astype(np.float32),
         "error_corrected_seed_std": np.asarray(

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -1157,6 +1157,17 @@ def _mean_curve(curves: list[list[float]]) -> np.ndarray:
     ).astype(np.float32)
 
 
+def _stack_curves(curves: list[list[float]]) -> np.ndarray:
+    """Stack the common completed prefix of repeated optimization curves."""
+    if not curves:
+        return np.empty((0, 0), dtype=np.float32)
+    common_length = min(len(curve) for curve in curves)
+    return np.stack(
+        [np.asarray(curve[:common_length]) for curve in curves],
+        axis=0,
+    ).astype(np.float32)
+
+
 def _mean_optional(values: list[float | None]) -> float | None:
     """Average present scalar measurements from repeated model seeds."""
     present = [float(value) for value in values if value is not None]
@@ -1174,35 +1185,55 @@ def _std(values: list[float]) -> float:
     snapshot_filename="corrector_fields.npz",
     snapshot_prefixes=(
         "loss",
+        "loss_samples",
         "loss_seed_std",
         "loss_stop_gradient",
+        "loss_stop_gradient_samples",
         "loss_stop_gradient_seed_std",
         "loss_one_step",
+        "loss_one_step_samples",
         "grad_norm",
+        "grad_norm_samples",
         "grad_norm_stop_gradient",
+        "grad_norm_stop_gradient_samples",
         "grad_norm_one_step",
+        "grad_norm_one_step_samples",
         "update_time",
+        "update_time_samples",
         "update_time_stop_gradient",
+        "update_time_stop_gradient_samples",
         "update_time_one_step",
+        "update_time_one_step_samples",
         "error_corrected",
+        "error_corrected_samples",
         "error_corrected_seed_std",
         "error_corrected_ic_std",
         "error_stop_gradient",
+        "error_stop_gradient_samples",
         "error_stop_gradient_seed_std",
         "error_stop_gradient_ic_std",
         "error_uncorrected",
+        "error_uncorrected_samples",
         "error_uncorrected_ic_std",
         "error_seen_corrected",
+        "error_seen_corrected_samples",
         "error_seen_stop_gradient",
+        "error_seen_stop_gradient_samples",
         "error_seen_uncorrected",
         "error_one_step",
+        "error_one_step_samples",
         "error_one_step_seed_std",
         "error_one_step_ic_std",
         "error_seen_one_step",
+        "error_seen_one_step_samples",
         "correlation_corrected",
+        "correlation_corrected_samples",
         "correlation_stop_gradient",
+        "correlation_stop_gradient_samples",
         "correlation_one_step",
+        "correlation_one_step_samples",
         "correlation_uncorrected",
+        "correlation_uncorrected_samples",
         "rollout_log_gain_samples",
         "stop_gradient_log_gain_samples",
         "solver_vjp_log_lift_samples",
@@ -1212,8 +1243,10 @@ def _std(values: list[float]) -> float:
         "curriculum_stage_unrolls",
         "curriculum_stage_boundaries",
         "curriculum_checkpoint_error_full",
+        "curriculum_checkpoint_error_full_samples",
         "curriculum_checkpoint_error_full_seed_std",
         "curriculum_checkpoint_error_nog",
+        "curriculum_checkpoint_error_nog_samples",
         "curriculum_checkpoint_error_nog_seed_std",
         "curriculum_checkpoint_error_native",
         "rollout_corrected",
@@ -2272,23 +2305,34 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         ]
     snapshots = {
         "loss": losses,
+        "loss_samples": _stack_curves(losses_by_seed),
         "loss_seed_std": np.asarray(loss_seed_std, dtype=np.float32),
         "loss_stop_gradient": stop_gradient_losses,
+        "loss_stop_gradient_samples": _stack_curves(stop_gradient_losses_by_seed),
         "loss_stop_gradient_seed_std": np.asarray(
             stop_gradient_loss_seed_std,
             dtype=np.float32,
         ),
         "grad_norm": grad_norms,
+        "grad_norm_samples": _stack_curves(grad_norms_by_seed),
         "grad_norm_stop_gradient": np.asarray(
             stop_gradient_grad_norms,
             dtype=np.float32,
         ),
+        "grad_norm_stop_gradient_samples": _stack_curves(
+            stop_gradient_grad_norms_by_seed
+        ),
         "update_time": update_times,
+        "update_time_samples": _stack_curves(update_times_by_seed),
         "update_time_stop_gradient": np.asarray(
             stop_gradient_update_times,
             dtype=np.float32,
         ),
+        "update_time_stop_gradient_samples": _stack_curves(
+            stop_gradient_update_times_by_seed
+        ),
         "error_corrected": np.asarray(corrected_error, dtype=np.float32),
+        "error_corrected_samples": corrected_errors_array.astype(np.float32),
         "error_corrected_seed_std": np.asarray(
             corrected_error_seed_std,
             dtype=np.float32,
@@ -2301,6 +2345,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             stop_gradient_error,
             dtype=np.float32,
         ),
+        "error_stop_gradient_samples": stop_gradient_errors_array.astype(np.float32),
         "error_stop_gradient_seed_std": np.asarray(
             stop_gradient_error_seed_std,
             dtype=np.float32,
@@ -2310,6 +2355,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             dtype=np.float32,
         ),
         "error_uncorrected": np.asarray(uncorrected_error, dtype=np.float32),
+        "error_uncorrected_samples": uncorrected_errors_array.astype(np.float32),
         "error_uncorrected_ic_std": np.asarray(
             uncorrected_error_ic_std,
             dtype=np.float32,
@@ -2318,9 +2364,13 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             seen_corrected_error,
             dtype=np.float32,
         ),
+        "error_seen_corrected_samples": seen_corrected_errors_array.astype(np.float32),
         "error_seen_stop_gradient": np.asarray(
             seen_stop_gradient_error,
             dtype=np.float32,
+        ),
+        "error_seen_stop_gradient_samples": (
+            seen_stop_gradient_errors_array.astype(np.float32)
         ),
         "error_seen_uncorrected": np.asarray(
             seen_uncorrected_error,
@@ -2330,13 +2380,22 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             corrected_correlation,
             dtype=np.float32,
         ),
+        "correlation_corrected_samples": np.stack(
+            corrected_correlations_by_seed
+        ).astype(np.float32),
         "correlation_stop_gradient": np.asarray(
             stop_gradient_correlation,
             dtype=np.float32,
         ),
+        "correlation_stop_gradient_samples": np.stack(
+            stop_gradient_correlations_by_seed
+        ).astype(np.float32),
         "correlation_uncorrected": np.asarray(
             uncorrected_correlation,
             dtype=np.float32,
+        ),
+        "correlation_uncorrected_samples": (
+            uncorrected_correlations_array.astype(np.float32)
         ),
         "rollout_log_gain_samples": rollout_log_gain_samples.astype(np.float32),
         "stop_gradient_log_gain_samples": stop_gradient_log_gain_samples.astype(
@@ -2356,9 +2415,17 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         snapshots.update(
             {
                 "loss_one_step": one_step_losses,
+                "loss_one_step_samples": _stack_curves(one_step_losses_by_seed),
                 "grad_norm_one_step": one_step_grad_norms,
+                "grad_norm_one_step_samples": _stack_curves(
+                    one_step_grad_norms_by_seed
+                ),
                 "update_time_one_step": one_step_update_times,
+                "update_time_one_step_samples": _stack_curves(
+                    one_step_update_times_by_seed
+                ),
                 "error_one_step": np.asarray(one_step_error, dtype=np.float32),
+                "error_one_step_samples": one_step_errors_array.astype(np.float32),
                 "error_one_step_seed_std": np.asarray(
                     one_step_error_seed_std,
                     dtype=np.float32,
@@ -2371,12 +2438,18 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
                     seen_one_step_error,
                     dtype=np.float32,
                 ),
+                "error_seen_one_step_samples": np.stack(
+                    seen_one_step_errors_by_seed
+                ).astype(np.float32),
                 "correlation_one_step": np.asarray(
                     one_step_correlation,
                     dtype=np.float32,
                 )
                 if one_step_correlation is not None
                 else np.asarray([], dtype=np.float32),
+                "correlation_one_step_samples": np.stack(
+                    one_step_correlations_by_seed
+                ).astype(np.float32),
                 "one_step_rollout_log_gain_samples": (
                     one_step_rollout_log_gain_samples.astype(np.float32)
                 ),
@@ -2405,12 +2478,18 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
                 "curriculum_checkpoint_error_full": checkpoint_full_error.astype(
                     np.float32
                 ),
+                "curriculum_checkpoint_error_full_samples": np.stack(
+                    checkpoint_full_errors_by_seed
+                ).astype(np.float32),
                 "curriculum_checkpoint_error_full_seed_std": (
                     checkpoint_full_seed_std.astype(np.float32)
                 ),
                 "curriculum_checkpoint_error_nog": checkpoint_stop_error.astype(
                     np.float32
                 ),
+                "curriculum_checkpoint_error_nog_samples": np.stack(
+                    checkpoint_stop_errors_by_seed
+                ).astype(np.float32),
                 "curriculum_checkpoint_error_nog_seed_std": (
                     checkpoint_stop_seed_std.astype(np.float32)
                 ),

--- a/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/solver_in_loop.py
@@ -51,6 +51,68 @@ _NATIVE_STATE_SUPPORT: weakref.WeakKeyDictionary[Any, bool] = (
 )
 
 
+class _TrainingStage(NamedTuple):
+    """One recurrent-lookahead stage in a corrector curriculum."""
+
+    unroll: int
+    updates: int
+    lr: float
+
+
+class _TrainingResult(NamedTuple):
+    """A trained corrector plus its curriculum checkpoints and traces."""
+
+    model: Any
+    losses: list[float]
+    grad_norms: list[float]
+    update_times: list[float]
+    fd_error: float | None
+    completed: bool
+    stage_models: tuple[Any, ...]
+    stage_unrolls: tuple[int, ...]
+    stage_boundaries: tuple[int, ...]
+    stage_learning_rates: tuple[float, ...]
+
+
+def _training_stages(training: dict[str, Any]) -> tuple[_TrainingStage, ...]:
+    """Normalize a fixed-horizon run or explicit curriculum into stages."""
+    default_lr = float(training.get("lr", 1e-4))
+    configured = training.get("curriculum")
+    if configured is None:
+        configured = [
+            {
+                "unroll": int(training.get("unroll", 4)),
+                "updates": int(training.get("max_updates", 100)),
+                "lr": default_lr,
+            }
+        ]
+    if not isinstance(configured, (list, tuple)) or not configured:
+        raise ValueError("training.curriculum must be a non-empty list")
+
+    stages: list[_TrainingStage] = []
+    for index, stage in enumerate(configured):
+        if not isinstance(stage, dict):
+            raise TypeError(f"training.curriculum[{index}] must be a mapping")
+        normalized = _TrainingStage(
+            unroll=int(stage["unroll"]),
+            updates=int(stage["updates"]),
+            lr=float(stage.get("lr", default_lr)),
+        )
+        if normalized.unroll < 1:
+            raise ValueError(f"training.curriculum[{index}].unroll must be positive")
+        if normalized.updates < 1:
+            raise ValueError(f"training.curriculum[{index}].updates must be positive")
+        if normalized.lr <= 0:
+            raise ValueError(f"training.curriculum[{index}].lr must be positive")
+        stages.append(normalized)
+    return tuple(stages)
+
+
+def _maximum_training_unroll(training: dict[str, Any]) -> int:
+    """Return the largest look-ahead required by a training configuration."""
+    return max(stage.unroll for stage in _training_stages(training))
+
+
 def _dataset_digest(config: dict[str, Any]) -> str:
     """Stable short identifier for generated reference data."""
     payload = json.dumps(config, sort_keys=True, separators=(",", ":")).encode()
@@ -270,7 +332,7 @@ def _make_reference_datasets(
     test_seeds = tuple(int(v) for v in dataset.get("test_seeds", [100, 101]))
     train_frames = int(dataset.get("train_frames", 16))
     eval_frames = int(evaluation.get("rollout_frames", 32))
-    unroll = int(training.get("unroll", 4))
+    unroll = _maximum_training_unroll(training)
     n_frames = max(train_frames, eval_frames, unroll)
     config = {
         "reference_kind": str(
@@ -464,7 +526,7 @@ def _make_solver_self_reference_datasets(
     all_seeds = train_seeds + test_seeds
     train_frames = int(dataset.get("train_frames", 16))
     eval_frames = int(evaluation.get("rollout_frames", 32))
-    unroll = int(training.get("unroll", 4))
+    unroll = _maximum_training_unroll(training)
     n_frames = max(train_frames, eval_frames, unroll)
 
     fine_n = n * reference_factor
@@ -808,22 +870,22 @@ def _train_corrector(
     loss_scale: float,
     differentiate_solver: bool,
     model_seed: int,
-) -> tuple[Any, list[float], list[float], list[float], float | None, bool]:
-    """Train one solver-specific corrector with a fixed stochastic schedule."""
-    max_updates = int(training.get("max_updates", 100))
-    unroll = int(training.get("unroll", 4))
-    lr = float(training.get("lr", 1e-4))
+) -> _TrainingResult:
+    """Train one solver-specific corrector through a fixed or staged look-ahead."""
+    stages = _training_stages(training)
     clip_norm = float(training.get("clip_norm", 1.0))
     seed = int(training.get("seed", 2026))
     hidden_channels = int(training.get("hidden_channels", 32))
     kernel_size = int(training.get("kernel_size", 5))
     architecture = str(training.get("architecture", "periodic_residual_cnn"))
+    residual_blocks = int(training.get("residual_blocks", 5))
     loss_mode = str(training.get("loss_mode", "mean"))
     solver_loss_weight = float(training.get("solver_loss_weight", 0.1))
     fd_epsilon = float(training.get("fd_epsilon", 1e-2))
-    if unroll < 1 or train.shape[1] < unroll + 1:
+    maximum_unroll = max(stage.unroll for stage in stages)
+    if train.shape[1] < maximum_unroll + 1:
         raise ValueError(
-            "training.unroll must be positive and fit inside dataset.train_frames"
+            "the largest training look-ahead must fit inside dataset.train_frames"
         )
     if loss_mode not in {"mean", "terminal", "solver_terminal"}:
         raise ValueError(f"unknown training.loss_mode: {loss_mode!r}")
@@ -835,10 +897,11 @@ def _train_corrector(
         hidden_channels=hidden_channels,
         kernel_size=kernel_size,
         architecture=architecture,
+        residual_blocks=residual_blocks,
     )
     optimiser = optax.chain(
         optax.clip_by_global_norm(clip_norm),
-        optax.adam(lr),
+        optax.adam(stages[0].lr),
     )
     opt_state = optimiser.init(eqx.filter(model, eqx.is_inexact_array))
     rng = np.random.RandomState(seed)
@@ -847,55 +910,80 @@ def _train_corrector(
     update_times: list[float] = []
     fd_error: float | None = None
     completed = True
+    stage_models: list[Any] = []
+    stage_boundaries: list[int] = []
 
-    for update in range(max_updates):
-        update_started = time.perf_counter()
-        trajectory_idx = int(rng.randint(train.shape[0]))
-        max_start = train.shape[1] - unroll - 1
-        start = int(rng.randint(max_start + 1)) if max_start > 0 else 0
-        targets = jnp.asarray(train[trajectory_idx, start : start + unroll + 1])
-
-        loss_fn = partial(
-            _window_loss,
-            targets=targets,
-            t=t,
-            ctx=ctx,
-            frame_steps=frame_steps,
-            velocity_scale=velocity_scale,
-            differentiate_solver=differentiate_solver,
-            loss_mode=loss_mode,
-            solver_loss_weight=solver_loss_weight,
-            loss_scale=loss_scale,
+    for stage_index, stage in enumerate(stages):
+        optimiser = optax.chain(
+            optax.clip_by_global_norm(clip_norm),
+            optax.adam(stage.lr),
         )
-
-        loss, grads = eqx.filter_value_and_grad(loss_fn)(model)
-        loss_value = float(loss)
-        grad_norm = float(optax.tree.norm(grads))
-        if not np.isfinite(loss_value) or not np.isfinite(grad_norm):
-            completed = False
-            break
-        if (
-            update == 0
-            and differentiate_solver
-            and bool(training.get("check_grad", True))
-        ):
-            fd_error = _directional_fd(
-                loss_fn,
-                model,
-                grads,
-                jax.random.PRNGKey(model_seed + 1),
-                epsilon=fd_epsilon,
+        for stage_update in range(stage.updates):
+            update_started = time.perf_counter()
+            trajectory_idx = int(rng.randint(train.shape[0]))
+            max_start = train.shape[1] - stage.unroll - 1
+            start = int(rng.randint(max_start + 1)) if max_start > 0 else 0
+            targets = jnp.asarray(
+                train[trajectory_idx, start : start + stage.unroll + 1]
             )
-        updates, opt_state = optimiser.update(
-            grads,
-            opt_state,
-            eqx.filter(model, eqx.is_inexact_array),
-        )
-        model = eqx.apply_updates(model, updates)
-        losses.append(loss_value)
-        grad_norms.append(grad_norm)
-        update_times.append(time.perf_counter() - update_started)
-    return model, losses, grad_norms, update_times, fd_error, completed
+
+            loss_fn = partial(
+                _window_loss,
+                targets=targets,
+                t=t,
+                ctx=ctx,
+                frame_steps=frame_steps,
+                velocity_scale=velocity_scale,
+                differentiate_solver=differentiate_solver,
+                loss_mode=loss_mode,
+                solver_loss_weight=solver_loss_weight,
+                loss_scale=loss_scale,
+            )
+
+            loss, grads = eqx.filter_value_and_grad(loss_fn)(model)
+            loss_value = float(loss)
+            grad_norm = float(optax.tree.norm(grads))
+            if not np.isfinite(loss_value) or not np.isfinite(grad_norm):
+                completed = False
+                break
+            if (
+                stage_index == len(stages) - 1
+                and stage_update == 0
+                and differentiate_solver
+                and bool(training.get("check_grad", True))
+            ):
+                fd_error = _directional_fd(
+                    loss_fn,
+                    model,
+                    grads,
+                    jax.random.PRNGKey(model_seed + 1),
+                    epsilon=fd_epsilon,
+                )
+            updates, opt_state = optimiser.update(
+                grads,
+                opt_state,
+                eqx.filter(model, eqx.is_inexact_array),
+            )
+            model = eqx.apply_updates(model, updates)
+            losses.append(loss_value)
+            grad_norms.append(grad_norm)
+            update_times.append(time.perf_counter() - update_started)
+        stage_models.append(model)
+        stage_boundaries.append(len(losses))
+        if not completed:
+            break
+    return _TrainingResult(
+        model=model,
+        losses=losses,
+        grad_norms=grad_norms,
+        update_times=update_times,
+        fd_error=fd_error,
+        completed=completed,
+        stage_models=tuple(stage_models),
+        stage_unrolls=tuple(stage.unroll for stage in stages[: len(stage_models)]),
+        stage_boundaries=tuple(stage_boundaries),
+        stage_learning_rates=tuple(stage.lr for stage in stages[: len(stage_models)]),
+    )
 
 
 def _evaluate_rollout(
@@ -937,6 +1025,7 @@ def _evaluate_rollout(
 class _ReferenceEvaluation(NamedTuple):
     first_rollout: np.ndarray | None
     errors: np.ndarray
+    correlations: np.ndarray
     final_states: np.ndarray
 
 
@@ -952,6 +1041,7 @@ def _evaluate_reference_set(
 ) -> _ReferenceEvaluation:
     """Evaluate several ICs, retaining the first rollout and every final state."""
     errors: list[list[float]] = []
+    correlations: list[list[float]] = []
     final_states: list[np.ndarray] = []
     first_rollout: np.ndarray | None = None
     for reference in references:
@@ -965,12 +1055,29 @@ def _evaluate_reference_set(
             corrected=corrected,
         )
         errors.append(reference_errors)
+        reference_correlations = []
+        for predicted, target in zip(rollout, reference, strict=True):
+            predicted_flat = np.asarray(predicted, dtype=np.float64).ravel()
+            target_flat = np.asarray(target, dtype=np.float64).ravel()
+            predicted_flat -= np.mean(predicted_flat)
+            target_flat -= np.mean(target_flat)
+            reference_correlations.append(
+                float(
+                    np.vdot(predicted_flat, target_flat).real
+                    / (
+                        np.linalg.norm(predicted_flat) * np.linalg.norm(target_flat)
+                        + 1e-12
+                    )
+                )
+            )
+        correlations.append(reference_correlations)
         final_states.append(rollout[-1])
         if first_rollout is None:
             first_rollout = rollout
     return _ReferenceEvaluation(
         first_rollout=first_rollout,
         errors=np.asarray(errors, dtype=np.float64),
+        correlations=np.asarray(correlations, dtype=np.float64),
         final_states=np.asarray(final_states),
     )
 
@@ -981,6 +1088,14 @@ def _first_unstable(errors: list[float], threshold: float) -> int:
         if not np.isfinite(error) or error > threshold:
             return idx
     return len(errors) - 1
+
+
+def _first_below(values: list[float], threshold: float) -> int:
+    """Return first frame below a quality threshold, or the completed horizon."""
+    for idx, value in enumerate(values):
+        if not np.isfinite(value) or value < threshold:
+            return idx
+    return len(values) - 1
 
 
 def _rollout_log_gain(
@@ -1062,10 +1177,13 @@ def _std(values: list[float]) -> float:
         "loss_seed_std",
         "loss_stop_gradient",
         "loss_stop_gradient_seed_std",
+        "loss_one_step",
         "grad_norm",
         "grad_norm_stop_gradient",
+        "grad_norm_one_step",
         "update_time",
         "update_time_stop_gradient",
+        "update_time_one_step",
         "error_corrected",
         "error_corrected_seed_std",
         "error_corrected_ic_std",
@@ -1077,11 +1195,30 @@ def _std(values: list[float]) -> float:
         "error_seen_corrected",
         "error_seen_stop_gradient",
         "error_seen_uncorrected",
+        "error_one_step",
+        "error_one_step_seed_std",
+        "error_one_step_ic_std",
+        "error_seen_one_step",
+        "correlation_corrected",
+        "correlation_stop_gradient",
+        "correlation_one_step",
+        "correlation_uncorrected",
         "rollout_log_gain_samples",
         "stop_gradient_log_gain_samples",
         "solver_vjp_log_lift_samples",
+        "one_step_rollout_log_gain_samples",
+        "unrolling_log_lift_samples",
+        "wig_over_one_log_lift_samples",
+        "curriculum_stage_unrolls",
+        "curriculum_stage_boundaries",
+        "curriculum_checkpoint_error_full",
+        "curriculum_checkpoint_error_full_seed_std",
+        "curriculum_checkpoint_error_nog",
+        "curriculum_checkpoint_error_nog_seed_std",
+        "curriculum_checkpoint_error_native",
         "rollout_corrected",
         "rollout_stop_gradient",
+        "rollout_one_step",
         "rollout_uncorrected",
         "reference_rollout",
     ),
@@ -1143,6 +1280,16 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             },
         }
     velocity_scale = float(np.sqrt(np.mean(train**2)) + 1e-8)
+    include_one_step = bool(training.get("include_one_step_baseline", False))
+    curriculum_stages = _training_stages(training)
+    checkpoint_trajectory_count = min(
+        int(evaluation.get("checkpoint_ic_trajectories", 2)),
+        test.shape[0],
+    )
+    checkpoint_rollout_frames = min(
+        int(evaluation.get("checkpoint_rollout_frames", test.shape[1] - 1)),
+        test.shape[1] - 1,
+    )
 
     configured_seeds = training.get("model_seeds")
     if configured_seeds is None:
@@ -1207,6 +1354,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     )
     first_uncorrected = uncorrected_eval.first_rollout
     uncorrected_errors_array = uncorrected_eval.errors
+    uncorrected_correlations_array = uncorrected_eval.correlations
     recurrent_final_states = uncorrected_eval.final_states
     seen_uncorrected_eval = _evaluate_reference_set(
         t,
@@ -1295,10 +1443,23 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     stop_gradient_training_walls: list[float] = []
     corrected_errors_by_seed: list[np.ndarray] = []
     stop_gradient_errors_by_seed: list[np.ndarray] = []
+    corrected_correlations_by_seed: list[np.ndarray] = []
+    stop_gradient_correlations_by_seed: list[np.ndarray] = []
     seen_corrected_errors_by_seed: list[np.ndarray] = []
     seen_stop_gradient_errors_by_seed: list[np.ndarray] = []
+    one_step_losses_by_seed: list[list[float]] = []
+    one_step_grad_norms_by_seed: list[list[float]] = []
+    one_step_update_times_by_seed: list[list[float]] = []
+    one_step_completed_by_seed: list[bool] = []
+    one_step_training_walls: list[float] = []
+    one_step_errors_by_seed: list[np.ndarray] = []
+    one_step_correlations_by_seed: list[np.ndarray] = []
+    seen_one_step_errors_by_seed: list[np.ndarray] = []
+    checkpoint_full_errors_by_seed: list[np.ndarray] = []
+    checkpoint_stop_errors_by_seed: list[np.ndarray] = []
     first_corrected: np.ndarray | None = None
     first_stop_gradient: np.ndarray | None = None
+    first_one_step: np.ndarray | None = None
 
     for seed_idx, model_seed in enumerate(model_seeds):
         seed_training = {
@@ -1309,14 +1470,7 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             "check_grad": bool(training.get("check_grad", True)) and seed_idx == 0,
         }
         started = time.perf_counter()
-        (
-            model,
-            losses,
-            grad_norms,
-            update_times,
-            fd_error,
-            completed,
-        ) = _train_corrector(
+        full_training = _train_corrector(
             t,
             ctx,
             train,
@@ -1327,17 +1481,16 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             differentiate_solver=True,
             model_seed=model_seed,
         )
+        model = full_training.model
+        losses = full_training.losses
+        grad_norms = full_training.grad_norms
+        update_times = full_training.update_times
+        fd_error = full_training.fd_error
+        completed = full_training.completed
         training_walls.append(time.perf_counter() - started)
 
         stop_gradient_started = time.perf_counter()
-        (
-            stop_gradient_model,
-            stop_gradient_losses,
-            stop_gradient_grad_norms,
-            stop_gradient_update_times,
-            _stop_gradient_fd_error,
-            stop_gradient_completed,
-        ) = _train_corrector(
+        stop_training = _train_corrector(
             t,
             ctx,
             train,
@@ -1348,7 +1501,54 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             differentiate_solver=False,
             model_seed=model_seed,
         )
+        stop_gradient_model = stop_training.model
+        stop_gradient_losses = stop_training.losses
+        stop_gradient_grad_norms = stop_training.grad_norms
+        stop_gradient_update_times = stop_training.update_times
+        stop_gradient_completed = stop_training.completed
         stop_gradient_training_walls.append(time.perf_counter() - stop_gradient_started)
+
+        one_step_model = None
+        one_step_training: _TrainingResult | None = None
+        if include_one_step:
+            one_step_updates = int(
+                training.get(
+                    "one_step_updates",
+                    sum(stage.updates for stage in curriculum_stages),
+                )
+            )
+            one_step_config = {
+                **training,
+                "unroll": 1,
+                "max_updates": one_step_updates,
+                "curriculum": [
+                    {
+                        "unroll": 1,
+                        "updates": one_step_updates,
+                        "lr": float(training.get("lr", 1e-4)),
+                    }
+                ],
+                "loss_mode": "mean",
+                "solver_loss_weight": 0.0,
+                "check_grad": False,
+            }
+            one_step_started = time.perf_counter()
+            one_step_training = _train_corrector(
+                t,
+                ctx,
+                train,
+                frame_steps=frame_steps,
+                training=one_step_config,
+                velocity_scale=velocity_scale,
+                loss_scale=training_loss_scale,
+                # With a true reference state at the beginning of every
+                # one-step sample, the solver output does not depend on model
+                # parameters. Stopping it is therefore mathematically exact.
+                differentiate_solver=False,
+                model_seed=model_seed,
+            )
+            one_step_training_walls.append(time.perf_counter() - one_step_started)
+            one_step_model = one_step_training.model
 
         corrected_eval = _evaluate_reference_set(
             t,
@@ -1392,6 +1592,68 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             corrected=True,
         )
         seen_seed_stop_gradient_errors = seen_stop_gradient_eval.errors
+        if one_step_model is not None and one_step_training is not None:
+            one_step_eval = _evaluate_reference_set(
+                t,
+                ctx,
+                one_step_model,
+                test,
+                frame_steps=frame_steps,
+                velocity_scale=velocity_scale,
+                corrected=True,
+            )
+            seen_one_step_eval = _evaluate_reference_set(
+                t,
+                ctx,
+                one_step_model,
+                seen_references,
+                frame_steps=frame_steps,
+                velocity_scale=velocity_scale,
+                corrected=True,
+            )
+            one_step_losses_by_seed.append(one_step_training.losses)
+            one_step_grad_norms_by_seed.append(one_step_training.grad_norms)
+            one_step_update_times_by_seed.append(one_step_training.update_times)
+            one_step_completed_by_seed.append(one_step_training.completed)
+            one_step_errors_by_seed.append(one_step_eval.errors)
+            one_step_correlations_by_seed.append(one_step_eval.correlations)
+            seen_one_step_errors_by_seed.append(seen_one_step_eval.errors)
+            if seed_idx == 0:
+                first_one_step = one_step_eval.first_rollout
+
+        if len(full_training.stage_models) > 1:
+            checkpoint_references = test[
+                :checkpoint_trajectory_count, : checkpoint_rollout_frames + 1
+            ]
+            full_checkpoint_errors: list[np.ndarray] = []
+            stop_checkpoint_errors: list[np.ndarray] = []
+            for full_stage_model, stop_stage_model in zip(
+                full_training.stage_models,
+                stop_training.stage_models,
+                strict=True,
+            ):
+                full_stage_eval = _evaluate_reference_set(
+                    t,
+                    ctx,
+                    full_stage_model,
+                    checkpoint_references,
+                    frame_steps=frame_steps,
+                    velocity_scale=velocity_scale,
+                    corrected=True,
+                )
+                stop_stage_eval = _evaluate_reference_set(
+                    t,
+                    ctx,
+                    stop_stage_model,
+                    checkpoint_references,
+                    frame_steps=frame_steps,
+                    velocity_scale=velocity_scale,
+                    corrected=True,
+                )
+                full_checkpoint_errors.append(np.mean(full_stage_eval.errors, axis=0))
+                stop_checkpoint_errors.append(np.mean(stop_stage_eval.errors, axis=0))
+            checkpoint_full_errors_by_seed.append(np.stack(full_checkpoint_errors))
+            checkpoint_stop_errors_by_seed.append(np.stack(stop_checkpoint_errors))
         if seed_idx == 0:
             first_corrected = corrected_rollout
             first_stop_gradient = stop_gradient_rollout
@@ -1408,11 +1670,22 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         stop_gradient_completed_by_seed.append(stop_gradient_completed)
         corrected_errors_by_seed.append(seed_corrected_errors)
         stop_gradient_errors_by_seed.append(seed_stop_gradient_errors)
+        corrected_correlations_by_seed.append(corrected_eval.correlations)
+        stop_gradient_correlations_by_seed.append(stop_gradient_eval.correlations)
         seen_corrected_errors_by_seed.append(seen_seed_corrected_errors)
         seen_stop_gradient_errors_by_seed.append(seen_seed_stop_gradient_errors)
 
     corrected_errors_array = np.stack(corrected_errors_by_seed)
     stop_gradient_errors_array = np.stack(stop_gradient_errors_by_seed)
+    corrected_correlation = np.mean(
+        np.stack(corrected_correlations_by_seed),
+        axis=(0, 1),
+    )
+    stop_gradient_correlation = np.mean(
+        np.stack(stop_gradient_correlations_by_seed),
+        axis=(0, 1),
+    )
+    uncorrected_correlation = np.mean(uncorrected_correlations_array, axis=0)
     seen_corrected_errors_array = np.stack(seen_corrected_errors_by_seed)
     seen_stop_gradient_errors_array = np.stack(seen_stop_gradient_errors_by_seed)
     corrected_error, corrected_error_seed_std, corrected_error_ic_std = (
@@ -1433,12 +1706,35 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         _seen_stop_gradient_error_seed_std,
         _seen_stop_gradient_error_ic_std,
     ) = _ensemble_curve_stats(seen_stop_gradient_errors_array)
+    one_step_error: np.ndarray | None = None
+    one_step_error_seed_std: np.ndarray | None = None
+    one_step_error_ic_std: np.ndarray | None = None
+    seen_one_step_error: np.ndarray | None = None
+    one_step_errors_array: np.ndarray | None = None
+    one_step_correlation: np.ndarray | None = None
+    if include_one_step:
+        one_step_errors_array = np.stack(one_step_errors_by_seed)
+        (
+            one_step_error,
+            one_step_error_seed_std,
+            one_step_error_ic_std,
+        ) = _ensemble_curve_stats(one_step_errors_array)
+        seen_one_step_error = _ensemble_curve_stats(
+            np.stack(seen_one_step_errors_by_seed)
+        )[0]
+        one_step_correlation = np.mean(
+            np.stack(one_step_correlations_by_seed),
+            axis=(0, 1),
+        )
     losses = _mean_curve(losses_by_seed)
     stop_gradient_losses = _mean_curve(stop_gradient_losses_by_seed)
+    one_step_losses = _mean_curve(one_step_losses_by_seed)
     grad_norms = _mean_curve(grad_norms_by_seed)
     stop_gradient_grad_norms = _mean_curve(stop_gradient_grad_norms_by_seed)
+    one_step_grad_norms = _mean_curve(one_step_grad_norms_by_seed)
     update_times = _mean_curve(update_times_by_seed)
     stop_gradient_update_times = _mean_curve(stop_gradient_update_times_by_seed)
+    one_step_update_times = _mean_curve(one_step_update_times_by_seed)
     loss_seed_std = (
         np.std(np.stack([curve[: len(losses)] for curve in losses_by_seed]), axis=0)
         if losses.size
@@ -1459,10 +1755,12 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     )
     training_wall = float(np.sum(training_walls))
     stop_gradient_training_wall = float(np.sum(stop_gradient_training_walls))
+    one_step_training_wall = float(np.sum(one_step_training_walls))
     total_updates = sum(len(curve) for curve in losses_by_seed)
     stop_gradient_total_updates = sum(
         len(curve) for curve in stop_gradient_losses_by_seed
     )
+    one_step_total_updates = sum(len(curve) for curve in one_step_losses_by_seed)
     steady_update_times = [
         value
         for seed_times in update_times_by_seed
@@ -1471,6 +1769,11 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     stop_gradient_steady_update_times = [
         value
         for seed_times in stop_gradient_update_times_by_seed
+        for value in (seed_times[1:] if len(seed_times) > 1 else seed_times)
+    ]
+    one_step_steady_update_times = [
+        value
+        for seed_times in one_step_update_times_by_seed
         for value in (seed_times[1:] if len(seed_times) > 1 else seed_times)
     ]
 
@@ -1505,7 +1808,24 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
     rollout_log_gain = float(np.mean(rollout_log_gain_samples))
     stop_gradient_log_gain = float(np.mean(stop_gradient_log_gain_samples))
     solver_vjp_log_lift = float(np.mean(solver_vjp_log_lift_samples))
+    one_step_rollout_log_gain_samples: np.ndarray | None = None
+    unrolling_log_lift_samples: np.ndarray | None = None
+    wig_over_one_log_lift_samples: np.ndarray | None = None
+    if one_step_errors_array is not None:
+        one_step_rollout_log_gain_samples = _rollout_log_gain_samples(
+            uncorrected_errors_array,
+            one_step_errors_array,
+        )
+        unrolling_log_lift_samples = _rollout_log_gain_samples(
+            one_step_errors_array,
+            stop_gradient_errors_array,
+        )
+        wig_over_one_log_lift_samples = _rollout_log_gain_samples(
+            one_step_errors_array,
+            corrected_errors_array,
+        )
     threshold = float(evaluation.get("stable_error_threshold", 1.0))
+    correlation_threshold = float(evaluation.get("correlation_threshold", 0.95))
     matched_horizon_frame = min(train.shape[1] - 1, test.shape[1] - 1)
     long_horizon_frame = test.shape[1] - 1
     seen_matched_error = float(seen_corrected_error[matched_horizon_frame])
@@ -1525,6 +1845,36 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         if stop_gradient_steady_update_times
         else None
     )
+    one_step_median_update_time = (
+        float(np.median(one_step_steady_update_times))
+        if one_step_steady_update_times
+        else None
+    )
+    stage_boundaries = np.cumsum(
+        [stage.updates for stage in curriculum_stages],
+        dtype=np.int64,
+    )
+    recurrent_solver_intervals_per_seed = int(
+        sum(stage.unroll * stage.updates for stage in curriculum_stages)
+    )
+    checkpoint_full_error: np.ndarray | None = None
+    checkpoint_stop_error: np.ndarray | None = None
+    checkpoint_full_seed_std: np.ndarray | None = None
+    checkpoint_stop_seed_std: np.ndarray | None = None
+    checkpoint_native_error: np.ndarray | None = None
+    if checkpoint_full_errors_by_seed:
+        full_checkpoints = np.stack(checkpoint_full_errors_by_seed)
+        stop_checkpoints = np.stack(checkpoint_stop_errors_by_seed)
+        checkpoint_full_error = np.mean(full_checkpoints, axis=0)
+        checkpoint_stop_error = np.mean(stop_checkpoints, axis=0)
+        checkpoint_full_seed_std = np.std(full_checkpoints, axis=0)
+        checkpoint_stop_seed_std = np.std(stop_checkpoints, axis=0)
+        checkpoint_native_error = np.mean(
+            uncorrected_errors_array[
+                :checkpoint_trajectory_count, : checkpoint_rollout_frames + 1
+            ],
+            axis=0,
+        )
 
     metrics = {
         **reference_audit,
@@ -1634,6 +1984,25 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             uncorrected_error.tolist(), threshold
         )
         * interval_time,
+        "final_rollout_correlation": float(corrected_correlation[-1]),
+        "stop_gradient_final_rollout_correlation": float(stop_gradient_correlation[-1]),
+        "uncorrected_final_rollout_correlation": float(uncorrected_correlation[-1]),
+        "correlation_threshold": correlation_threshold,
+        "correlation_horizon": _first_below(
+            corrected_correlation.tolist(),
+            correlation_threshold,
+        )
+        * interval_time,
+        "stop_gradient_correlation_horizon": _first_below(
+            stop_gradient_correlation.tolist(),
+            correlation_threshold,
+        )
+        * interval_time,
+        "uncorrected_correlation_horizon": _first_below(
+            uncorrected_correlation.tolist(),
+            correlation_threshold,
+        )
+        * interval_time,
         "initial_train_loss": float(losses[0]) if losses.size else None,
         "final_train_loss": float(losses[-1]) if losses.size else None,
         "best_train_loss": float(np.min(losses)) if losses.size else None,
@@ -1736,14 +2105,28 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         "n_test_trajectories": int(test.shape[0]),
         "n_seen_ic_evaluation_trajectories": seen_trajectory_count,
         "training_frames": int(train.shape[1] - 1),
-        "training_unroll": int(training.get("unroll", 4)),
+        "training_unroll": max(stage.unroll for stage in curriculum_stages),
+        "training_curriculum": [
+            {
+                "unroll": stage.unroll,
+                "updates": stage.updates,
+                "lr": stage.lr,
+            }
+            for stage in curriculum_stages
+        ],
+        "training_stage_boundaries": stage_boundaries.tolist(),
+        "training_solver_intervals_per_seed": recurrent_solver_intervals_per_seed,
+        "training_solver_intervals_total": recurrent_solver_intervals_per_seed
+        * len(model_seeds),
         "training_loss_mode": str(training.get("loss_mode", "mean")),
         "training_solver_loss_weight": float(training.get("solver_loss_weight", 0.1)),
         "training_loss_normalization": loss_normalization,
         "training_loss_scale": training_loss_scale,
         "matched_horizon_time": matched_horizon_frame * interval_time,
         "visualization_model_seed": model_seeds[0],
-        "completed": all(completed_by_seed) and all(stop_gradient_completed_by_seed),
+        "completed": all(completed_by_seed)
+        and all(stop_gradient_completed_by_seed)
+        and (not include_one_step or all(one_step_completed_by_seed)),
         "dataset_hash": dataset_hash,
         "reference_kind": reference_kind,
         "correction_intervals": int(test.shape[1] - 1),
@@ -1751,6 +2134,142 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         "rollout_final_time": interval_time * int(test.shape[1] - 1),
         "native_state_threading": _supports_native_state(t),
     }
+    if (
+        one_step_error is not None
+        and one_step_error_seed_std is not None
+        and one_step_error_ic_std is not None
+        and one_step_rollout_log_gain_samples is not None
+        and unrolling_log_lift_samples is not None
+        and wig_over_one_log_lift_samples is not None
+    ):
+        one_step_mean_error = float(np.mean(one_step_error[1:]))
+        one_step_log_gain = float(np.mean(one_step_rollout_log_gain_samples))
+        unrolling_log_lift = float(np.mean(unrolling_log_lift_samples))
+        wig_over_one_log_lift = float(np.mean(wig_over_one_log_lift_samples))
+        metrics.update(
+            {
+                "one_step_final_rollout_error": float(one_step_error[-1]),
+                "one_step_final_rollout_error_seed_std": float(
+                    one_step_error_seed_std[-1]
+                ),
+                "one_step_final_rollout_error_ic_std": float(one_step_error_ic_std[-1]),
+                "one_step_mean_rollout_error": one_step_mean_error,
+                "one_step_geometric_error_reduction": float(np.exp(one_step_log_gain)),
+                "one_step_rollout_log_gain_seed_std": _std(
+                    np.mean(one_step_rollout_log_gain_samples, axis=1).tolist()
+                ),
+                "one_step_rollout_log_gain_ic_std": _std(
+                    np.mean(one_step_rollout_log_gain_samples, axis=0).tolist()
+                ),
+                "unrolling_geometric_lift_nog_over_one": float(
+                    np.exp(unrolling_log_lift)
+                ),
+                "unrolling_log_lift_seed_std": _std(
+                    np.mean(unrolling_log_lift_samples, axis=1).tolist()
+                ),
+                "unrolling_log_lift_ic_std": _std(
+                    np.mean(unrolling_log_lift_samples, axis=0).tolist()
+                ),
+                "wig_geometric_lift_over_one": float(np.exp(wig_over_one_log_lift)),
+                "wig_over_one_log_lift_seed_std": _std(
+                    np.mean(wig_over_one_log_lift_samples, axis=1).tolist()
+                ),
+                "wig_over_one_log_lift_ic_std": _std(
+                    np.mean(wig_over_one_log_lift_samples, axis=0).tolist()
+                ),
+                "one_step_seen_ic_matched_horizon_error": float(
+                    seen_one_step_error[matched_horizon_frame]
+                )
+                if seen_one_step_error is not None
+                else None,
+                "one_step_heldout_ic_matched_horizon_error": float(
+                    one_step_error[matched_horizon_frame]
+                ),
+                "one_step_stable_horizon": _first_unstable(
+                    one_step_error.tolist(),
+                    threshold,
+                )
+                * interval_time,
+                "one_step_final_rollout_correlation": float(one_step_correlation[-1])
+                if one_step_correlation is not None
+                else None,
+                "one_step_correlation_horizon": _first_below(
+                    one_step_correlation.tolist(),
+                    correlation_threshold,
+                )
+                * interval_time
+                if one_step_correlation is not None
+                else None,
+                "one_step_initial_train_loss": float(one_step_losses[0])
+                if one_step_losses.size
+                else None,
+                "one_step_final_train_loss": float(one_step_losses[-1])
+                if one_step_losses.size
+                else None,
+                "one_step_best_train_loss": float(np.min(one_step_losses))
+                if one_step_losses.size
+                else None,
+                "one_step_n_updates": len(one_step_losses),
+                "one_step_total_optimizer_updates": one_step_total_updates,
+                "one_step_training_wall_time_s": one_step_training_wall,
+                "one_step_seconds_per_update": one_step_training_wall
+                / max(one_step_total_updates, 1),
+                "one_step_median_update_time_s": one_step_median_update_time,
+                "one_step_final_grad_norm": float(one_step_grad_norms[-1])
+                if one_step_grad_norms.size
+                else None,
+                "one_step_training_solver_intervals_per_seed": len(one_step_losses),
+                "one_step_training_solver_intervals_total": one_step_total_updates,
+                "one_step_final_divergence_rms": divergence_rms(
+                    first_one_step[-1],
+                    ctx.domain_extent,
+                )
+                if first_one_step is not None
+                else None,
+                "one_step_final_energy_ratio_to_reference": kinetic_energy(
+                    first_one_step[-1]
+                )
+                / (kinetic_energy(test[0, -1]) + 1e-12)
+                if first_one_step is not None
+                else None,
+            }
+        )
+    if (
+        checkpoint_full_error is not None
+        and checkpoint_stop_error is not None
+        and checkpoint_native_error is not None
+    ):
+        metrics["curriculum_checkpoint_summary"] = [
+            {
+                "unroll": stage.unroll,
+                "updates_cumulative": int(stage_boundaries[index]),
+                "full_geometric_error_reduction": float(
+                    np.exp(
+                        _rollout_log_gain(
+                            checkpoint_native_error,
+                            checkpoint_full_error[index],
+                        )
+                    )
+                ),
+                "nog_geometric_error_reduction": float(
+                    np.exp(
+                        _rollout_log_gain(
+                            checkpoint_native_error,
+                            checkpoint_stop_error[index],
+                        )
+                    )
+                ),
+                "wig_geometric_lift_over_nog": float(
+                    np.exp(
+                        _rollout_log_gain(
+                            checkpoint_stop_error[index],
+                            checkpoint_full_error[index],
+                        )
+                    )
+                ),
+            }
+            for index, stage in enumerate(curriculum_stages)
+        ]
     snapshots = {
         "loss": losses,
         "loss_seed_std": np.asarray(loss_seed_std, dtype=np.float32),
@@ -1807,12 +2326,99 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
             seen_uncorrected_error,
             dtype=np.float32,
         ),
+        "correlation_corrected": np.asarray(
+            corrected_correlation,
+            dtype=np.float32,
+        ),
+        "correlation_stop_gradient": np.asarray(
+            stop_gradient_correlation,
+            dtype=np.float32,
+        ),
+        "correlation_uncorrected": np.asarray(
+            uncorrected_correlation,
+            dtype=np.float32,
+        ),
         "rollout_log_gain_samples": rollout_log_gain_samples.astype(np.float32),
         "stop_gradient_log_gain_samples": stop_gradient_log_gain_samples.astype(
             np.float32
         ),
         "solver_vjp_log_lift_samples": solver_vjp_log_lift_samples.astype(np.float32),
     }
+    if (
+        one_step_error is not None
+        and one_step_error_seed_std is not None
+        and one_step_error_ic_std is not None
+        and seen_one_step_error is not None
+        and one_step_rollout_log_gain_samples is not None
+        and unrolling_log_lift_samples is not None
+        and wig_over_one_log_lift_samples is not None
+    ):
+        snapshots.update(
+            {
+                "loss_one_step": one_step_losses,
+                "grad_norm_one_step": one_step_grad_norms,
+                "update_time_one_step": one_step_update_times,
+                "error_one_step": np.asarray(one_step_error, dtype=np.float32),
+                "error_one_step_seed_std": np.asarray(
+                    one_step_error_seed_std,
+                    dtype=np.float32,
+                ),
+                "error_one_step_ic_std": np.asarray(
+                    one_step_error_ic_std,
+                    dtype=np.float32,
+                ),
+                "error_seen_one_step": np.asarray(
+                    seen_one_step_error,
+                    dtype=np.float32,
+                ),
+                "correlation_one_step": np.asarray(
+                    one_step_correlation,
+                    dtype=np.float32,
+                )
+                if one_step_correlation is not None
+                else np.asarray([], dtype=np.float32),
+                "one_step_rollout_log_gain_samples": (
+                    one_step_rollout_log_gain_samples.astype(np.float32)
+                ),
+                "unrolling_log_lift_samples": unrolling_log_lift_samples.astype(
+                    np.float32
+                ),
+                "wig_over_one_log_lift_samples": (
+                    wig_over_one_log_lift_samples.astype(np.float32)
+                ),
+            }
+        )
+    if (
+        checkpoint_full_error is not None
+        and checkpoint_stop_error is not None
+        and checkpoint_full_seed_std is not None
+        and checkpoint_stop_seed_std is not None
+        and checkpoint_native_error is not None
+    ):
+        snapshots.update(
+            {
+                "curriculum_stage_unrolls": np.asarray(
+                    [stage.unroll for stage in curriculum_stages],
+                    dtype=np.int32,
+                ),
+                "curriculum_stage_boundaries": stage_boundaries.astype(np.int32),
+                "curriculum_checkpoint_error_full": checkpoint_full_error.astype(
+                    np.float32
+                ),
+                "curriculum_checkpoint_error_full_seed_std": (
+                    checkpoint_full_seed_std.astype(np.float32)
+                ),
+                "curriculum_checkpoint_error_nog": checkpoint_stop_error.astype(
+                    np.float32
+                ),
+                "curriculum_checkpoint_error_nog_seed_std": (
+                    checkpoint_stop_seed_std.astype(np.float32)
+                ),
+                "curriculum_checkpoint_error_native": checkpoint_native_error.astype(
+                    np.float32
+                ),
+            }
+        )
     if (
         first_corrected is not None
         and first_stop_gradient is not None
@@ -1821,6 +2427,8 @@ def solver_in_loop(t: Any, ctx: KernelContext) -> dict:
         snapshots["rollout_corrected"] = first_corrected
         snapshots["rollout_stop_gradient"] = first_stop_gradient
         snapshots["rollout_uncorrected"] = first_uncorrected
+        if first_one_step is not None:
+            snapshots["rollout_one_step"] = first_one_step
     if reference_kind == "solver_self_refined":
         snapshots["reference_rollout"] = test[0]
         shared = {

--- a/tests/test_dummy_integration.py
+++ b/tests/test_dummy_integration.py
@@ -288,6 +288,7 @@ def _maybe_shrink(cfg, problem: str, exp_key: str) -> None:
         exp_key
         in {
             "optimization/solver_in_loop",
+            "optimization/solver_in_loop_curriculum",
             "optimization/solver_in_loop_self_reference",
             "optimization/solver_in_loop_tgv",
         }
@@ -469,7 +470,7 @@ def dummy_corpus(tmp_path_factory):
                 tags = dict.fromkeys(cfg.solver_names, tag)
                 try:
                     cfg.experiments[exp_key].fn(cfg, tags)
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001 - corpus records every failure
                     errors[(problem, exp_key)] = exc
         yield {"results_root": results_root, "errors": errors}
     finally:

--- a/tests/test_dummy_integration.py
+++ b/tests/test_dummy_integration.py
@@ -470,7 +470,7 @@ def dummy_corpus(tmp_path_factory):
                 tags = dict.fromkeys(cfg.solver_names, tag)
                 try:
                     cfg.experiments[exp_key].fn(cfg, tags)
-                except Exception as exc:  # noqa: BLE001 - corpus records every failure
+                except Exception as exc:
                     errors[(problem, exp_key)] = exc
         yield {"results_root": results_root, "errors": errors}
     finally:

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -1277,9 +1277,18 @@ def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
     out_dir = tmp_path / "ns-grid" / "optimization" / "solver_in_loop_curriculum_smoke"
     with np.load(out_dir / "corrector_fields.npz") as snapshots:
         assert snapshots["error_one_step_0"].shape == (4,)
+        assert snapshots["error_one_step_samples_0"].shape == (1, 1, 4)
+        assert snapshots["error_corrected_samples_0"].shape == (1, 1, 4)
+        assert snapshots["loss_samples_0"].shape == (1, 2)
         assert snapshots["curriculum_stage_unrolls_0"].tolist() == [1, 2]
         assert snapshots["curriculum_checkpoint_error_full_0"].shape == (2, 4)
+        assert snapshots["curriculum_checkpoint_error_full_samples_0"].shape == (
+            1,
+            2,
+            4,
+        )
         assert snapshots["correlation_corrected_0"].shape == (4,)
+        assert snapshots["correlation_corrected_samples_0"].shape == (1, 1, 4)
 
 
 def test_solver_self_reference_skips_training_below_refinement_floor(

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -18,6 +18,7 @@ import numpy as np
 from mosaic.benchmarks.core.utils import _debug_run, active_solvers
 from mosaic.benchmarks.problems.navier_stokes_grid.corrector import (
     PeriodicResidualCNN,
+    PeriodicResNetCorrector,
     apply_corrector,
     centered_divergence_rms,
     divergence_rms,
@@ -32,11 +33,17 @@ from mosaic.benchmarks.problems.navier_stokes_grid.corrector import (
 from mosaic.benchmarks.problems.navier_stokes_grid.ics import _tgv, _tgv_analytic
 from mosaic.benchmarks.problems.navier_stokes_grid.plots import (
     _periodic_vorticity_2d,
+    _plot_solver_in_loop_curriculum_correlations,
+    _plot_solver_in_loop_curriculum_fields,
+    _plot_solver_in_loop_curriculum_rollouts,
+    _plot_solver_in_loop_curriculum_spectra,
+    _plot_solver_in_loop_curriculum_summary,
     _plot_solver_in_loop_diagnostics,
     _plot_solver_in_loop_fairness,
     _plot_solver_in_loop_fields,
     _plot_solver_in_loop_physics,
     _save_solver_in_loop_animation,
+    _save_solver_in_loop_curriculum_animation,
 )
 from mosaic.benchmarks.problems.navier_stokes_grid.solver_in_loop import (
     _evaluate_rollout,
@@ -46,6 +53,7 @@ from mosaic.benchmarks.problems.navier_stokes_grid.solver_in_loop import (
     _rollout_log_gain,
     _solver_advance,
     _stop_recurrent_gradient,
+    _training_stages,
     _window_loss,
     make_reference_dataset,
     solver_in_loop,
@@ -165,6 +173,48 @@ def test_reference_sensitivity_declares_independent_converged_targets():
         assert dataset["reference_convergence_tolerance"] == 0.005
 
 
+def test_paper_aligned_curriculum_declares_one_nog_wig_protocol():
+    from mosaic.benchmarks.problems import get_config
+
+    cfg = get_config("ns-grid")
+    experiment = cfg.experiments["optimization/solver_in_loop_curriculum"]
+    run = inspect.signature(experiment.fn).parameters["_kw"].default["runs"][0]
+    training = run["training"]
+
+    assert run["physics"]["steps"] == 1
+    assert run["dataset"]["train_seeds"] == list(range(32))
+    assert run["evaluation"]["rollout_frames"] == 300
+    assert training["include_one_step_baseline"] is True
+    assert training["loss_mode"] == "mean"
+    assert training["architecture"] == "periodic_resnet"
+    assert training["residual_blocks"] == 5
+    assert [stage["unroll"] for stage in training["curriculum"]] == [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+    ]
+    assert sum(stage["updates"] for stage in training["curriculum"]) == 12000
+
+
+def test_curriculum_normalization_preserves_stage_learning_rates():
+    stages = _training_stages(
+        {
+            "lr": 1e-4,
+            "curriculum": [
+                {"unroll": 1, "updates": 2},
+                {"unroll": 4, "updates": 3, "lr": 5e-5},
+            ],
+        }
+    )
+
+    assert [stage.unroll for stage in stages] == [1, 4]
+    assert [stage.updates for stage in stages] == [2, 3]
+    np.testing.assert_allclose([stage.lr for stage in stages], [1e-4, 5e-5])
+
+
 def test_self_reference_does_not_gate_the_learnable_refinement_signal():
     assert _passes_reference_accuracy_gate(
         "solver_self_refined",
@@ -209,6 +259,28 @@ def test_corrector_starts_from_the_uncorrected_solver():
     model = init_corrector(jax.random.PRNGKey(0), hidden_channels=4, kernel_size=3)
     velocity = jax.random.normal(jax.random.PRNGKey(1), (8, 8, 1, 2))
 
+    np.testing.assert_array_equal(
+        apply_corrector(model, velocity, velocity_scale=1.0),
+        jnp.zeros_like(velocity),
+    )
+
+
+def test_paper_scale_resnet_starts_at_solver_and_has_expected_capacity():
+    model = init_corrector(
+        jax.random.PRNGKey(0),
+        architecture="periodic_resnet",
+        hidden_channels=32,
+        kernel_size=5,
+        residual_blocks=5,
+    )
+    velocity = jax.random.normal(jax.random.PRNGKey(1), (8, 8, 1, 2))
+    parameter_count = sum(
+        int(leaf.size)
+        for leaf in jax.tree_util.tree_leaves(eqx.filter(model, eqx.is_inexact_array))
+    )
+
+    assert isinstance(model, PeriodicResNetCorrector)
+    assert parameter_count == 259554
     np.testing.assert_array_equal(
         apply_corrector(model, velocity, velocity_scale=1.0),
         jnp.zeros_like(velocity),
@@ -759,6 +831,42 @@ def test_debug_run_caps_corrector_training():
     assert run["evaluation"]["rollout_frames"] == 3
 
 
+def test_debug_run_caps_curriculum_and_one_step_baseline():
+    run = {
+        "physics": {"N": 32, "steps": 1},
+        "training": {
+            "max_updates": 12000,
+            "unroll": 32,
+            "curriculum": [
+                {"unroll": 1, "updates": 1000, "lr": 1e-4},
+                {"unroll": 2, "updates": 1000, "lr": 1e-4},
+                {"unroll": 4, "updates": 1500, "lr": 1e-4},
+            ],
+            "one_step_updates": 12000,
+            "residual_blocks": 5,
+            "model_seeds": [0, 1, 2],
+        },
+        "dataset": {
+            "train_seeds": list(range(32)),
+            "test_seeds": list(range(100, 108)),
+            "train_frames": 96,
+        },
+        "evaluation": {"rollout_frames": 300},
+    }
+
+    _debug_run(run)
+
+    assert run["training"]["curriculum"] == [
+        {"unroll": 1, "updates": 1, "lr": 1e-4},
+        {"unroll": 2, "updates": 1, "lr": 1e-4},
+    ]
+    assert run["training"]["max_updates"] == 2
+    assert run["training"]["unroll"] == 2
+    assert run["training"]["one_step_updates"] == 2
+    assert run["training"]["residual_blocks"] == 1
+    assert run["training"]["model_seeds"] == [0]
+
+
 def test_solver_in_loop_fields_render_reference_raw_and_corrected(tmp_path):
     n = 16
     coordinates = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
@@ -913,6 +1021,85 @@ def test_self_reference_fairness_normalizes_solver_specific_targets(tmp_path):
     assert figure.axes[0].get_title() == "Target-normalized quality"
 
 
+def test_curriculum_plots_render_all_training_protocols(tmp_path):
+    reference = np.stack([_tgv(8) * np.exp(-0.02 * frame) for frame in range(4)])
+    native = reference * np.asarray([1.0, 0.98, 0.96, 0.94])[:, None, None, None, None]
+    one = reference * np.asarray([1.0, 0.99, 0.98, 0.97])[:, None, None, None, None]
+    nog = reference * np.asarray([1.0, 0.995, 0.99, 0.985])[:, None, None, None, None]
+    wig = reference * np.asarray([1.0, 0.998, 0.996, 0.994])[:, None, None, None, None]
+    arrays = {
+        "evaluation_times": np.arange(4, dtype=np.float32) * 0.02,
+        "reference_rollout": reference,
+        "rollout_uncorrected_0": native,
+        "rollout_one_step_0": one,
+        "rollout_stop_gradient_0": nog,
+        "rollout_corrected_0": wig,
+        "error_uncorrected_0": np.asarray([0.0, 0.02, 0.04, 0.06]),
+        "error_one_step_0": np.asarray([0.0, 0.01, 0.02, 0.03]),
+        "error_stop_gradient_0": np.asarray([0.0, 0.005, 0.01, 0.015]),
+        "error_corrected_0": np.asarray([0.0, 0.002, 0.004, 0.006]),
+        "correlation_uncorrected_0": np.asarray([1.0, 0.99, 0.97, 0.94]),
+        "correlation_one_step_0": np.asarray([1.0, 0.995, 0.985, 0.97]),
+        "correlation_stop_gradient_0": np.asarray([1.0, 0.998, 0.99, 0.98]),
+        "correlation_corrected_0": np.asarray([1.0, 0.999, 0.996, 0.99]),
+        "curriculum_stage_unrolls_0": np.asarray([1, 2]),
+        "curriculum_checkpoint_error_native_0": np.asarray([0.0, 0.02, 0.04, 0.06]),
+        "curriculum_checkpoint_error_full_0": np.asarray(
+            [[0.0, 0.015, 0.03, 0.045], [0.0, 0.005, 0.01, 0.015]]
+        ),
+    }
+    data = {
+        "by_solver": {
+            "jax-cfd": {
+                "one_step_geometric_error_reduction": 1.5,
+                "stop_gradient_geometric_error_reduction": 2.0,
+                "geometric_error_reduction": 3.0,
+                "unrolling_geometric_lift_nog_over_one": 4.0 / 3.0,
+                "solver_vjp_geometric_lift": 1.5,
+                "one_step_training_wall_time_s": 1.0,
+                "stop_gradient_training_wall_time_s": 2.0,
+                "training_wall_time_s": 3.0,
+            }
+        }
+    }
+
+    figures = [
+        _plot_solver_in_loop_curriculum_rollouts(
+            arrays, ["jax-cfd"], tmp_path, save=True
+        ),
+        _plot_solver_in_loop_curriculum_correlations(
+            arrays, ["jax-cfd"], tmp_path, save=True
+        ),
+        _plot_solver_in_loop_curriculum_summary(
+            data,
+            arrays,
+            ["jax-cfd"],
+            tmp_path,
+            save=True,
+        ),
+        _plot_solver_in_loop_curriculum_fields(
+            arrays, ["jax-cfd"], tmp_path, save=True
+        ),
+        _plot_solver_in_loop_curriculum_spectra(
+            arrays, ["jax-cfd"], tmp_path, save=True
+        ),
+    ]
+    _save_solver_in_loop_curriculum_animation(arrays, ["jax-cfd"], tmp_path)
+
+    assert all(figure is not None for figure in figures)
+    for filename in (
+        "solver_in_loop_curriculum_rollouts.png",
+        "solver_in_loop_curriculum_correlations.png",
+        "solver_in_loop_curriculum_summary.png",
+        "solver_in_loop_curriculum_fields.png",
+        "solver_in_loop_curriculum_spectra.png",
+        "solver_in_loop_curriculum_trajectory.gif",
+    ):
+        rendered = tmp_path / filename
+        assert rendered.exists()
+        assert rendered.stat().st_size > 0
+
+
 def test_solver_vjp_panels_only_show_recurrence_admitted_cells(tmp_path):
     common = {
         "uncorrected_mean_rollout_error": 0.4,
@@ -1019,6 +1206,80 @@ def test_solver_in_loop_runs_recurrently_through_dummy(tmp_path, monkeypatch):
     assert (out_dir / "result.json").exists()
     with np.load(out_dir / "corrector_fields.npz") as snapshots:
         assert snapshots["solver_vjp_log_lift_samples_0"].shape == (2, 1)
+
+
+def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(
+    tmp_path,
+    monkeypatch,
+):
+    """The opt-in curriculum keeps all three paper protocols in one result."""
+    from mosaic.benchmarks.problems import get_config
+
+    monkeypatch.setenv("MOSAIC_RESULTS_DIR", str(tmp_path))
+    base = get_config("ns-grid")
+    jax_cfd = next(spec for spec in base.solvers if spec.key == "jax_cfd")
+    cfg = dataclasses.replace(base, solvers=[jax_cfd])
+    cfg.add_experiment(
+        "optimization/solver_in_loop_curriculum_smoke",
+        solver_in_loop,
+        runs=[
+            {
+                "ic": {"name": "multimode", "seed": 0},
+                "physics": {"N": 8, "nu": 0.001, "dt": 0.02, "steps": 1},
+                "dataset": {
+                    "reference_factor": 2,
+                    "reference_substeps": 1,
+                    "train_seeds": [0],
+                    "test_seeds": [100],
+                    "train_frames": 3,
+                    "k0": 2.0,
+                },
+                "training": {
+                    "max_updates": 2,
+                    "unroll": 2,
+                    "curriculum": [
+                        {"unroll": 1, "updates": 1, "lr": 1e-4},
+                        {"unroll": 2, "updates": 1, "lr": 5e-5},
+                    ],
+                    "include_one_step_baseline": True,
+                    "one_step_updates": 2,
+                    "loss_mode": "mean",
+                    "loss_normalization": "solver_baseline",
+                    "hidden_channels": 4,
+                    "kernel_size": 3,
+                    "model_seeds": [0],
+                    "check_grad": False,
+                },
+                "evaluation": {
+                    "rollout_frames": 3,
+                    "checkpoint_ic_trajectories": 1,
+                    "checkpoint_rollout_frames": 3,
+                },
+            }
+        ],
+    )
+
+    result = cfg.experiments["optimization/solver_in_loop_curriculum_smoke"].fn(
+        cfg,
+        {jax_cfd.name: f"inprocess:{_IDENTITY_DUMMY}"},
+    )
+
+    metrics = result["results"][0]["metrics"]
+    assert metrics["completed"] is True
+    assert metrics["n_updates"] == 2
+    assert metrics["one_step_n_updates"] == 2
+    assert metrics["training_solver_intervals_per_seed"] == 3
+    assert metrics["one_step_training_solver_intervals_per_seed"] == 2
+    assert len(metrics["curriculum_checkpoint_summary"]) == 2
+    assert metrics["unrolling_geometric_lift_nog_over_one"] > 0
+    assert metrics["solver_vjp_geometric_lift"] > 0
+
+    out_dir = tmp_path / "ns-grid" / "optimization" / "solver_in_loop_curriculum_smoke"
+    with np.load(out_dir / "corrector_fields.npz") as snapshots:
+        assert snapshots["error_one_step_0"].shape == (4,)
+        assert snapshots["curriculum_stage_unrolls_0"].tolist() == [1, 2]
+        assert snapshots["curriculum_checkpoint_error_full_0"].shape == (2, 4)
+        assert snapshots["correlation_corrected_0"].shape == (4,)
 
 
 def test_solver_self_reference_skips_training_below_refinement_floor(

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -196,7 +196,7 @@ def test_paper_aligned_curriculum_declares_one_nog_wig_protocol():
         16,
         32,
     ]
-    assert sum(stage["updates"] for stage in training["curriculum"]) == 12000
+    assert sum(stage["updates"] for stage in training["curriculum"]) == 11000
 
 
 def test_curriculum_normalization_preserves_stage_learning_rates():

--- a/tests/test_solver_in_loop.py
+++ b/tests/test_solver_in_loop.py
@@ -34,6 +34,7 @@ from mosaic.benchmarks.problems.navier_stokes_grid.ics import _tgv, _tgv_analyti
 from mosaic.benchmarks.problems.navier_stokes_grid.plots import (
     _periodic_vorticity_2d,
     _plot_solver_in_loop_curriculum_correlations,
+    _plot_solver_in_loop_curriculum_fd,
     _plot_solver_in_loop_curriculum_fields,
     _plot_solver_in_loop_curriculum_rollouts,
     _plot_solver_in_loop_curriculum_spectra,
@@ -1042,6 +1043,8 @@ def test_curriculum_plots_render_all_training_protocols(tmp_path):
         "correlation_one_step_0": np.asarray([1.0, 0.995, 0.985, 0.97]),
         "correlation_stop_gradient_0": np.asarray([1.0, 0.998, 0.99, 0.98]),
         "correlation_corrected_0": np.asarray([1.0, 0.999, 0.996, 0.99]),
+        "fd_epsilon_0": np.asarray([1e-1, 1e-2, 1e-3]),
+        "fd_rel_error_samples_0": np.asarray([[0.2, 0.01, 0.04], [0.3, 0.02, 0.05]]),
         "curriculum_stage_unrolls_0": np.asarray([1, 2]),
         "curriculum_checkpoint_error_native_0": np.asarray([0.0, 0.02, 0.04, 0.06]),
         "curriculum_checkpoint_error_full_0": np.asarray(
@@ -1070,6 +1073,7 @@ def test_curriculum_plots_render_all_training_protocols(tmp_path):
         _plot_solver_in_loop_curriculum_correlations(
             arrays, ["jax-cfd"], tmp_path, save=True
         ),
+        _plot_solver_in_loop_curriculum_fd(arrays, ["jax-cfd"], tmp_path, save=True),
         _plot_solver_in_loop_curriculum_summary(
             data,
             arrays,
@@ -1090,6 +1094,7 @@ def test_curriculum_plots_render_all_training_protocols(tmp_path):
     for filename in (
         "solver_in_loop_curriculum_rollouts.png",
         "solver_in_loop_curriculum_correlations.png",
+        "solver_in_loop_curriculum_fd.png",
         "solver_in_loop_curriculum_summary.png",
         "solver_in_loop_curriculum_fields.png",
         "solver_in_loop_curriculum_spectra.png",
@@ -1186,6 +1191,8 @@ def test_solver_in_loop_runs_recurrently_through_dummy(tmp_path, monkeypatch):
     assert metrics["completed"] is True
     assert metrics["final_grad_norm"] > 0
     assert metrics["end_to_end_fd_rel_error"] < 5e-2
+    assert metrics["end_to_end_fd_rel_error_max"] < 5e-2
+    assert len(metrics["fd_check_summary"]) == 2
     assert metrics["native_final_rollout_error"] >= 0
     assert metrics["native_final_rollout_error_p95"] >= 0
     assert metrics["long_closure_error_p95"] < 1e-6
@@ -1206,6 +1213,8 @@ def test_solver_in_loop_runs_recurrently_through_dummy(tmp_path, monkeypatch):
     assert (out_dir / "result.json").exists()
     with np.load(out_dir / "corrector_fields.npz") as snapshots:
         assert snapshots["solver_vjp_log_lift_samples_0"].shape == (2, 1)
+        assert snapshots["fd_epsilon_0"].shape == (5,)
+        assert snapshots["fd_rel_error_samples_0"].shape == (2, 5)
 
 
 def test_solver_in_loop_curriculum_emits_one_nog_wig_checkpoints(


### PR DESCRIPTION
## State of this PR

This stacked follow-up turns the compact temporal-credit audit in #116 into a
paper-aligned autoregressive correction study. It keeps the existing
`optimization/solver_in_loop` experiment unchanged and adds the opt-in
`optimization/solver_in_loop_curriculum` experiment.

The new experiment separates three training protocols while holding the
solver, corrector architecture, data, optimiser schedule, and free-running
evaluation fixed:

- **ONE**: one-step correction from reference states;
- **NOG**: recurrent solver–corrector training with the solver outputs stopped
  in the backward pass;
- **WIG**: the identical recurrent forward trajectory with full temporal
  differentiation through the solver.

## Protocol

- 32² candidate grid with correction after every native step (`dt=0.02`);
- 128² pseudo-spectral production target and gated 256² convergence audit;
- 32 training ICs and eight held-out ICs;
- 259,554-parameter, five-block periodic ResNet corrector;
- staged `1 → 2 → 4 → 8 → 16 → 32` look-ahead curriculum;
- 11,000 optimiser updates per training protocol and model seed;
- three paired model seeds;
- supervision at every corrected state, without the solver-terminal auxiliary
  used by #116;
- 300-step fully autoregressive held-out evaluation.

The output separates the gain from recurrent state exposure (`NOG / ONE`) from
the incremental gain from temporal solver gradients (`WIG / NOG`). It also
records curriculum checkpoint quality, a five-scale per-seed FD/AD sweep, update and wall-clock cost, correlation
horizon, energy/enstrophy/divergence diagnostics, final energy spectra, full
fields, and a five-column reference/solver/ONE/NOG/WIG rollout GIF.

## Validation

- Ruff lint and format pass on all changed files.
- 530 tests pass and three are skipped.
- The curriculum has an end-to-end in-process solver smoke covering staged
  optimisation, changed learning rates, ONE/NOG/WIG rollout arrays,
  correlations, checkpoint shapes, and rendering.

## Offline results

Production results are pending. All numerical experiments will run offline on
Kander through the same Slurm/Pyxis runner and solver images used by #116. No
hosted benchmark label will be used.

## Literature correspondence

The terminology follows the controlled ONE/NOG/WIG comparison in
[Differentiability in Unrolled Training of Neural Physics Simulators](https://arxiv.org/abs/2402.12971)
and the recurrent SOL_n protocol in
[Solver-in-the-Loop](https://proceedings.neurips.cc/paper/2020/hash/43e4e6a6f341e00671e123714de019a8-Abstract.html).