### PR TITLE
feat: surface numeric metric regressions and scope PR benchmark diffs

### DIFF
--- a/.github/scripts/post-status-comment.sh
+++ b/.github/scripts/post-status-comment.sh
@@ -6,9 +6,10 @@
 # Finds an existing comment by the bot with "## Mosaic" header and updates it,
 # or creates a new one. Requires GH_TOKEN with write permissions.
 #
-# The markdown file (the benchmark status report) is optional: PRs that ran no
-# benchmarks (benchmark:none, docs-only) skip it, since the report would just be
-# an all-zero diff against the baseline. In that case the comment is only the
+# The markdown file (the benchmark status report) is optional here, but the
+# report job now always ships one on PRs: the full status+diff when benchmarks
+# ran, or a one-line "**Benchmarks:** …" verdict when they didn't (so silence is
+# never mistaken for a clean run). When genuinely absent, the comment is only the
 # docs-preview banner.
 #
 # When DOCS_PREVIEW_URL is set, a prominent banner linking to the rendered

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -328,12 +328,31 @@ jobs:
 
       - name: Generate status report (markdown)
         if: needs.plan.outputs.should_run == 'true'
+        env:
+          RUN_LABEL: ${{ needs.plan.outputs.label }}
+          RUN_SOLVERS: ${{ needs.plan.outputs.solvers }}
+          RUN_PROBLEMS: ${{ needs.plan.outputs.problems }}
+          RUN_IS_RELEASE: ${{ needs.plan.outputs.is_release_pr }}
         run: |
+          # Coverage banner input: what actually ran this PR (see F3 in the
+          # reporting audit) so "0 regressions" is honest about scope.
+          uv run python - <<'PY' > run-scope.json
+          import json, os
+          solvers = [s for s in os.environ.get("RUN_SOLVERS", "").split(",") if s]
+          problems_raw = os.environ.get("RUN_PROBLEMS", "")
+          problems = [] if problems_raw in ("", "all") else [p for p in problems_raw.split(",") if p]
+          print(json.dumps({
+              "label": os.environ.get("RUN_LABEL", ""),
+              "solvers": solvers,
+              "problems": problems,
+              "is_release_pr": os.environ.get("RUN_IS_RELEASE") == "true",
+          }))
+          PY
           DIFF_FLAG=""
           if [[ -n "${{ steps.baseline.outputs.path }}" ]]; then
             DIFF_FLAG="--diff-against ${{ steps.baseline.outputs.path }}"
           fi
-          uv run mosaic status --format md $DIFF_FLAG > status-report.md
+          uv run mosaic status --format md $DIFF_FLAG --run-scope run-scope.json > status-report.md
 
       # ── Render docs site on GHA ────────────────────────────────────────
       # The docs are rendered here (where the full mosaic/jax stack is already
@@ -372,16 +391,38 @@ jobs:
       # can't otherwise recover: the PR number and whether benchmarks ran.
       - name: Write publish metadata
         if: github.event_name == 'pull_request'
+        env:
+          SHOULD_RUN: ${{ needs.plan.outputs.should_run }}
+          RUN_LABEL: ${{ needs.plan.outputs.label }}
+          MOSAIC_TOUCHED: ${{ needs.plan.outputs.mosaic_touched }}
         run: |
           {
             echo "pr_number=${{ github.event.pull_request.number }}"
-            echo "should_run=${{ needs.plan.outputs.should_run }}"
+            echo "should_run=${SHOULD_RUN}"
           } > publish-meta.txt
-          # Ship the status report alongside the site so the downstream comment
-          # can include it. Absent (benchmark:none) → downstream posts only the
-          # preview banner.
-          if [[ "${{ needs.plan.outputs.should_run }}" == "true" ]]; then
+          # Ship a status report alongside the site so the downstream comment
+          # always carries a benchmark verdict. When benchmarks ran, that's the
+          # full report; when they didn't (benchmark:none / unlabelled), it's a
+          # one-line explanation so silence is never mistaken for "clean" (F4).
+          if [[ "${SHOULD_RUN}" == "true" ]]; then
             cp status-report.md _site-status-report.md
+          else
+            case "${RUN_LABEL}" in
+              none)
+                VERDICT='**Benchmarks:** skipped by the `benchmark:none` label.'
+                ;;
+              "")
+                if [[ "${MOSAIC_TOUCHED}" == "true" ]]; then
+                  VERDICT='**Benchmarks:** not run — add a `benchmark:solver` or `benchmark:all` label (`mosaic/` was changed).'
+                else
+                  VERDICT='**Benchmarks:** not applicable (no `mosaic/` changes).'
+                fi
+                ;;
+              *)
+                VERDICT='**Benchmarks:** not run for this PR.'
+                ;;
+            esac
+            printf '## Mosaic status\n\n%s\n' "${VERDICT}" > _site-status-report.md
           fi
 
       - name: Upload rendered docs site

--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -200,6 +200,42 @@ mosaic status --format md > report.md     # export as markdown
 mosaic status --format json > snap.json   # machine-readable snapshot
 ```
 
+### The PR benchmark comment
+
+On a pull request, CI posts (and keeps updated) a single sticky comment
+summarising the run. It diffs this PR's results against the published `main`
+baseline and surfaces, in order of what a reviewer cares about:
+
+- **Regressions / improvements** — cells that changed *status* (e.g. a solver
+  that went `ok` → `fail`, or `fail` → `ok`).
+- **Metric changes** — solvers that stayed `ok` but whose *numbers* moved past a
+  relative threshold (gradient rel-error, converged loss, forward error). The
+  coarse status ladder alone would hide these, so an optimisation PR that
+  improves accuracy without crossing a bucket boundary still shows up.
+- **Timing (indicative)** — wall-clock shifts. These sit in a separate section
+  and are labelled *indicative*: CI runners share hardware, so timing varies
+  with load between runs. Trust the direction of a large move, not the exact
+  percentage.
+- **Resource-frontier shifts** — the sweep size at which a solver first hits an
+  OOM / timeout ceiling. A ceiling that bites at a *smaller* size than baseline
+  is a scaling regression; one that pushes further out is an improvement.
+
+A **coverage banner** at the top states what actually ran. Under the
+`benchmark:solver` label only the changed solvers on affected problems re-run,
+so "no regressions" means "no regressions *among what was measured*" — the other
+cells are shown from the baseline unchanged. A PR that runs no benchmarks
+(`benchmark:none`, or an unlabelled non-`mosaic/` change) still gets a one-line
+verdict so an empty comment is never mistaken for a clean pass.
+
+::: {.callout-note}
+Resource-frontier tracking depends on the solver container reporting a
+`failure_type` of `OOM` or `timeout`. A container that dies from memory pressure
+but reports a *generic* error is classified as a crash (a hard `fail`), not a
+frontier move. This is the safe direction — a mislabelled OOM surfaces as a
+louder regression, never a quieter one — but it means the frontier signal is
+best-effort, not an exhaustive OOM detector.
+:::
+
 ## Troubleshooting
 
 ### Container start failures

--- a/mosaic/benchmarks/cli/_status_helpers.py
+++ b/mosaic/benchmarks/cli/_status_helpers.py
@@ -18,6 +18,58 @@ from mosaic.benchmarks.core.console import console, print_rule, print_warn
 from mosaic.benchmarks.problems import get_config
 
 
+def _load_run_scope(run_scope: str | None) -> dict | None:
+    """Read and normalise a ``run-scope.json`` file, or None if absent/unreadable.
+
+    Normalises ``solvers`` / ``problems`` to lists (CI may emit comma-joined
+    strings) and coerces ``is_release_pr`` to bool. Best-effort: a missing or
+    malformed file returns None rather than raising.
+    """
+    import json as _json
+
+    if not run_scope:
+        return None
+    try:
+        with open(run_scope) as f:
+            scope = _json.load(f)
+    except Exception as exc:
+        print_warn(f"could not read --run-scope file: {exc}")
+        return None
+    solvers = scope.get("solvers") or []
+    problems = scope.get("problems") or []
+    if isinstance(solvers, str):
+        solvers = [s for s in solvers.split(",") if s]
+    if isinstance(problems, str):
+        problems = [p for p in problems.split(",") if p and p != "all"]
+    return {
+        "label": scope.get("label") or "",
+        "is_release_pr": bool(scope.get("is_release_pr")),
+        "solvers": list(solvers),
+        "problems": list(problems),
+    }
+
+
+def _diff_scope(scope: dict | None) -> dict | None:
+    """Translate a run-scope into the ``measured`` filter ``diff_snapshots`` takes.
+
+    Returns ``None`` — meaning "everything was measured, diff the whole thing" —
+    for full runs (``benchmark:all``, release PRs) and when no scope is known.
+    For a ``benchmark:solver`` run it returns ``{"problems": [...], "solvers":
+    [...]}`` so the diff attributes regressions/improvements only to the
+    (problem × solver) cells that were actually re-run this PR — every other
+    cell is carried-over baseline data and a change there is baseline drift, not
+    a PR effect (see F3 in the reporting audit).
+    """
+    if scope is None:
+        return None
+    if scope["is_release_pr"] or scope["label"] == "all":
+        return None
+    if scope["label"] == "solver" and scope["solvers"]:
+        return {"problems": scope["problems"], "solvers": scope["solvers"]}
+    # Unknown / unlabelled: no reliable measured-set, so don't over-filter.
+    return None
+
+
 def _coverage_banner(run_scope: str | None) -> str:
     """Build a one-line markdown coverage banner from a ``run-scope.json`` file.
 
@@ -28,30 +80,18 @@ def _coverage_banner(run_scope: str | None) -> str:
     may mean "almost nothing was measured". Returns ``""`` when no scope file is
     given or it can't be read (banner is best-effort, never fatal).
     """
-    import json as _json
-
-    if not run_scope:
+    scope = _load_run_scope(run_scope)
+    if scope is None:
         return ""
-    try:
-        with open(run_scope) as f:
-            scope = _json.load(f)
-    except Exception as exc:
-        print_warn(f"could not read --run-scope file: {exc}")
-        return ""
-    label = scope.get("label") or ""
-    is_release = scope.get("is_release_pr")
-    solvers = scope.get("solvers") or []
-    problems = scope.get("problems") or []
-    if isinstance(solvers, str):
-        solvers = [s for s in solvers.split(",") if s]
-    if isinstance(problems, str):
-        problems = [p for p in problems.split(",") if p and p != "all"]
-
-    if is_release or label == "all":
+    if scope["is_release_pr"] or scope["label"] == "all":
         return "**Coverage:** all solvers × all problems this run."
-    if label == "solver" and solvers:
-        s = ", ".join(f"`{x}`" for x in solvers)
-        p = ", ".join(f"`{x}`" for x in problems) if problems else "affected problems"
+    if scope["label"] == "solver" and scope["solvers"]:
+        s = ", ".join(f"`{x}`" for x in scope["solvers"])
+        p = (
+            ", ".join(f"`{x}`" for x in scope["problems"])
+            if scope["problems"]
+            else "affected problems"
+        )
         return (
             f"**Coverage:** measured {s} on {p} this run. Other cells are shown "
             f'from the baseline — "no regressions" applies only to what ran.'
@@ -112,8 +152,13 @@ def _status_emit_snapshot(
             old_snapshot = None
         if old_snapshot is not None:
             new_snapshot = snapshot_to_dict(statuses)
+            # Scope the diff to what this run actually re-measured so baseline
+            # drift on carried-over cells isn't mis-attributed as a PR change.
+            measured = _diff_scope(_load_run_scope(run_scope))
             out_parts.append(
-                render_diff_markdown(diff_snapshots(old_snapshot, new_snapshot))
+                render_diff_markdown(
+                    diff_snapshots(old_snapshot, new_snapshot, measured=measured)
+                )
             )
             diff_rendered = True
     report = render_markdown(statuses)

--- a/mosaic/benchmarks/cli/_status_helpers.py
+++ b/mosaic/benchmarks/cli/_status_helpers.py
@@ -18,16 +18,63 @@ from mosaic.benchmarks.core.console import console, print_rule, print_warn
 from mosaic.benchmarks.problems import get_config
 
 
+def _coverage_banner(run_scope: str | None) -> str:
+    """Build a one-line markdown coverage banner from a ``run-scope.json`` file.
+
+    Makes "0 regressions" honest about *what actually ran*: under
+    ``benchmark:solver`` only the changed solvers on affected problems are
+    re-run, so unchanged cells are baseline copies that can never diff. Without
+    this line a reviewer reads "0 regressions" as "everything is clean" when it
+    may mean "almost nothing was measured". Returns ``""`` when no scope file is
+    given or it can't be read (banner is best-effort, never fatal).
+    """
+    import json as _json
+
+    if not run_scope:
+        return ""
+    try:
+        with open(run_scope) as f:
+            scope = _json.load(f)
+    except Exception as exc:
+        print_warn(f"could not read --run-scope file: {exc}")
+        return ""
+    label = scope.get("label") or ""
+    is_release = scope.get("is_release_pr")
+    solvers = scope.get("solvers") or []
+    problems = scope.get("problems") or []
+    if isinstance(solvers, str):
+        solvers = [s for s in solvers.split(",") if s]
+    if isinstance(problems, str):
+        problems = [p for p in problems.split(",") if p and p != "all"]
+
+    if is_release or label == "all":
+        return "**Coverage:** all solvers × all problems this run."
+    if label == "solver" and solvers:
+        s = ", ".join(f"`{x}`" for x in solvers)
+        p = ", ".join(f"`{x}`" for x in problems) if problems else "affected problems"
+        return (
+            f"**Coverage:** measured {s} on {p} this run. Other cells are shown "
+            f'from the baseline — "no regressions" applies only to what ran.'
+        )
+    # Unknown / unlabelled: state plainly that scope is partial.
+    return (
+        "**Coverage:** partial run — some cells are shown from the baseline "
+        "rather than measured this run."
+    )
+
+
 def _status_emit_snapshot(
     problem_list: list[str],
     suite_list: list[str],
     output_format: str,
     diff_against: str | None,
+    run_scope: str | None = None,
 ) -> None:
     """Handle --format md/json: build snapshot(s) and emit to stdout.
 
     For ``json`` writes a dict snapshot; for ``md`` renders a markdown report,
-    optionally prepended with a diff against a saved snapshot file.
+    optionally prepended with a diff against a saved snapshot file and a
+    coverage banner built from ``run_scope``.
     """
     import json as _json
 
@@ -52,6 +99,10 @@ def _status_emit_snapshot(
         return
     # output_format == "md"
     out_parts: list[str] = []
+    banner = _coverage_banner(run_scope)
+    if banner:
+        out_parts.append(banner)
+    diff_rendered = False
     if diff_against:
         try:
             with open(diff_against) as f:
@@ -64,14 +115,15 @@ def _status_emit_snapshot(
             out_parts.append(
                 render_diff_markdown(diff_snapshots(old_snapshot, new_snapshot))
             )
+            diff_rendered = True
     report = render_markdown(statuses)
-    if out_parts:
-        # A diff was rendered above, so the diff is the headline. Collapse the
-        # full absolute status behind a <details> to keep the comment short —
-        # it carries baseline context the reader rarely needs at a glance.
-        # The <details>/summary must not be indented (GFM breaks HTML blocks
-        # inside list items with leading whitespace), and blank lines around
-        # the body let the inner markdown tables render.
+    if diff_rendered:
+        # The diff is the headline. Collapse the full absolute status behind a
+        # <details> to keep the comment short — it carries baseline context the
+        # reader rarely needs at a glance. The <details>/summary must not be
+        # indented (GFM breaks HTML blocks inside list items with leading
+        # whitespace), and blank lines around the body let the inner markdown
+        # tables render.
         out_parts.append(
             f"<details><summary>Full Mosaic status</summary>\n\n{report}\n</details>"
         )

--- a/mosaic/benchmarks/cli/status.py
+++ b/mosaic/benchmarks/cli/status.py
@@ -53,6 +53,13 @@ def status(
         help="Path to a JSON snapshot (produced by --format json). When set with --format md, "
         "prepend a diff section (regressions, improvements, new/removed rows) before the full tables.",
     ),
+    run_scope: str | None = typer.Option(
+        None,
+        "--run-scope",
+        help="Path to a run-scope JSON ({label, solvers, problems, is_release_pr}). "
+        "With --format md, prepend a coverage banner stating what was actually measured "
+        "this run vs. shown from the baseline.",
+    ),
     output_dir: Path | None = typer.Option(  # noqa: B008
         None,
         "--output-dir",
@@ -98,7 +105,7 @@ def status(
 
     # ── non-rich formats: skip terminal rendering and emit a snapshot ─────
     if format in ("md", "json"):
-        _status_emit_snapshot(problem_list, suite_list, format, diff_against)
+        _status_emit_snapshot(problem_list, suite_list, format, diff_against, run_scope)
         return
 
     failure_records: list[

--- a/mosaic/benchmarks/core/console.py
+++ b/mosaic/benchmarks/core/console.py
@@ -63,6 +63,28 @@ def print_skip(msg: str) -> None:
     console.print(f"[dim][SKIP] {msg}[/dim]")
 
 
+def github_annotation(level: str, msg: str, *, title: str | None = None) -> None:
+    """Emit a GitHub Actions workflow annotation when running under CI.
+
+    ``level`` is ``"warning"`` or ``"error"``. GitHub renders these on the
+    Checks tab and inline in the job log, so a per-sweep-point solver failure
+    surfaces without anyone downloading result artifacts. Outside CI (no
+    ``GITHUB_ACTIONS`` env var) this is a no-op — the plain rich message the
+    caller already printed is enough on a developer's terminal.
+
+    The message is flattened to a single line: GitHub's ``::`` command syntax
+    is line-oriented and would truncate at the first newline otherwise.
+    """
+    import os
+
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return
+    flat = " ".join(msg.splitlines())
+    title_part = f" title={title}" if title else ""
+    # Printed raw (not via rich) so GitHub's log parser sees the bare command.
+    print(f"::{level}{title_part}::{flat}", flush=True)
+
+
 def print_saved(path: object) -> None:
     """Print a cyan confirmation that a file was saved at *path*."""
     console.print(f"[cyan]  Saved \u2192 {path}[/cyan]")

--- a/mosaic/benchmarks/core/experiment.py
+++ b/mosaic/benchmarks/core/experiment.py
@@ -109,6 +109,47 @@ def _truncate_error(msg: str, limit: int = MAX_ERROR_LEN) -> str:
     return f"{msg[:head]}{marker}{msg[-tail:]}"
 
 
+def _emit_sweep_failure(
+    console_: Any,
+    color: str,
+    name: str,
+    sweep_key: str | None,
+    val: Any,
+    metrics: dict,
+) -> None:
+    """Surface a per-sweep-point solver failure in the console and CI log.
+
+    A *resource ceiling* (OOM / timeout) is an expected, platform-dependent
+    scaling limit — printed dimly and NOT annotated (it would be noise on the
+    Checks tab of every run). A real crash (compile error, NaN, container
+    death) is a bug: printed red and, under GitHub Actions, emitted as a
+    ``::warning`` so it shows on the Checks tab without anyone downloading
+    result artifacts.
+    """
+    from mosaic.benchmarks.core.console import github_annotation
+
+    failure_type = metrics.get("failure_type") or "error"
+    exc_msg = metrics.get("exc_msg") or metrics.get("error") or ""
+    short = str(exc_msg).strip().splitlines()[0][:120] if exc_msg else ""
+    label = f"{sweep_key}={val}" if sweep_key is not None else "value"
+    is_resource_ceiling = failure_type in ("OOM", "timeout")
+    if is_resource_ceiling:
+        console_.print(
+            f"  [dim]{name} {label} resource ceiling ({failure_type}) — "
+            f"expected at large sizes[/]"
+        )
+        return
+    console_.print(
+        f"  [{color}]{name}[/] [red]FAIL[/] {label} ({failure_type})"
+        + (f": {short}" if short else "")
+    )
+    github_annotation(
+        "warning",
+        f"{name} failed at {label} ({failure_type})" + (f": {short}" if short else ""),
+        title=f"Benchmark solver failure: {name}",
+    )
+
+
 def _flatten_by_solver(by_solver: dict, sweep_key: str | None) -> list[dict]:
     """Convert the kernel's ``by_solver`` accumulator into a flat results list.
 
@@ -522,23 +563,51 @@ def run_experiment(
             solver_snaps: dict[str, np.ndarray] = {}
 
             if sweep_mode == "default":
+                color = cfg.solver(name).color
                 stopped_at: int | None = None
                 for idx, val in enumerate(_sweep_values):
                     out = _call_with_sampler(name, t, val)
-                    solver_results[val] = out.get("metrics", {})
+                    metrics = out.get("metrics", {})
+                    solver_results[val] = metrics
                     _absorb(out, solver_snaps, str(idx))
-                    # Kernels may request that the framework abandon
-                    # this solver's sweep after the current value (e.g.
-                    # cost kernels do this on wall-limit-hit so a slow
-                    # solver doesn't burn the remaining trials). The
-                    # value at which we stopped is included; everything
-                    # after gets marked ``None``.
-                    if out.get("stop_sweep"):
+                    # A kernel signals it wants the sweep abandoned via
+                    # ``stop_reason`` ("wall_limit" | "error") — or, for legacy
+                    # kernels, a bare ``stop_sweep`` boolean.
+                    #
+                    # We short-circuit the remaining values on any *monotone*
+                    # stop — wall-limit, or a resource ceiling (OOM / timeout),
+                    # or a legacy kernel that short-circuits because the failure
+                    # is a function of the solver rather than the sweep value.
+                    # Larger sizes would only fare worse, so trying them wastes
+                    # time. A hard *error* (compile error, NaN) is NOT monotone
+                    # — a larger sweep value may compile/run fine (e.g. a
+                    # power-of-two grid size after a non-power-of-two crashed) —
+                    # so we log it and CONTINUE rather than hiding the untried
+                    # points behind an empty cell.
+                    stop_reason = out.get("stop_reason")
+                    if stop_reason is None and out.get("stop_sweep"):
+                        stop_reason = "wall_limit"
+                    if isinstance(metrics, dict) and metrics.get("status") == "failed":
+                        _emit_sweep_failure(
+                            console, color, name, _sweep_key, val, metrics
+                        )
+                    if stop_reason is not None and stop_reason != "error":
                         stopped_at = idx
                         break
                 if stopped_at is not None:
+                    # Distinct, visible "skipped" state — NOT ``None``/``{}``,
+                    # which is indistinguishable from "never selected". The
+                    # status classifier treats it as a benign "didn't run" and
+                    # the cost plots draw it as a gap rather than a data point.
+                    skip_reason = (
+                        f"skipped after sweep stopped at "
+                        f"{_sweep_key}={_sweep_values[stopped_at]}"
+                    )
                     for remaining in _sweep_values[stopped_at + 1 :]:
-                        solver_results[remaining] = None
+                        solver_results[remaining] = {
+                            "status": "skipped",
+                            "reason": skip_reason,
+                        }
                 _by_solver[name] = solver_results
                 if solver_snaps:
                     _snapshots[name] = solver_snaps

--- a/mosaic/benchmarks/core/harness.py
+++ b/mosaic/benchmarks/core/harness.py
@@ -47,10 +47,22 @@ def classify_failure(exc_name: str, exc_str: str) -> str:
     s = exc_str.lower()
     if exc_name == "ContainerDied":
         return "container_died"
+    # Unambiguous out-of-memory markers across CUDA / XLA / Torch / cuBLAS /
+    # cuDNN / the OS OOM-killer. Kept conservative (only memory-specific
+    # phrases) so a genuine crash is never hidden as a resource ceiling — a
+    # mislabelled OOM should surface as a louder `fail`, not a quieter frontier
+    # move (see the frontier caveat in the reporting docs).
     if (
         "resource_exhausted" in s
         or "out of memory" in s
+        or "out-of-memory" in s
+        or "oom killer" in s
+        or "oom-killer" in s
         or "cuda_error_out_of_memory" in s
+        or "cudaerrormemoryallocation" in s
+        or "cublas_status_alloc_failed" in s
+        or "cudnn_status_alloc_failed" in s
+        or "failed to allocate" in s
     ):
         return "OOM"
     if (

--- a/mosaic/benchmarks/core/status.py
+++ b/mosaic/benchmarks/core/status.py
@@ -75,14 +75,21 @@ EXCL_PERMANENT_VALUES: frozenset[str] = frozenset(c.value for c in EXCL_PERMANEN
 # A single scalar in [0.0, +1.0] summarising campaign state.  Each
 # non-categorical cell contributes its weight; categorical exclusions are
 # excluded from both numerator and denominator.
+#
+# Staleness (the ``*`` marker) does not affect the weight: it's a "re-run
+# recommended" hint for humans, not a health signal, and folding it into the
+# score made the headline number move on the incremental PR-preview path for
+# reasons a PR author couldn't see or fix (baseline cells carried over from
+# ``main`` hash-mismatch the current tree and get flagged even when the PR
+# didn't touch them). Releases always re-run the full suite from scratch, so
+# nothing is ever legitimately stale there. Keeping stale weights equal to
+# their fresh counterparts preserves the invariant "no status change ⇒ no
+# score change" that reviewers expect. The ``*`` glyph is still rendered.
 SCORE_WEIGHTS: dict[str, float] = {
     "ok": 1.00,
-    "ok*": 0.67,
     "anom": 0.53,
-    "anom*": 0.43,
     "missing": 0.33,
     "excl": 0.33,  # all non-categorical exclusions
-    "fail*": 0.17,
     "fail": 0.00,
     # "perm" (EXCLUDED + categorical) is excluded from the denominator.
 }
@@ -93,14 +100,16 @@ def cell_weight_key(cell: Cell) -> str | None:
 
     Categorical (permanent) exclusions return None — the caller should skip
     them entirely (no numerator contribution, not counted in denominator).
+
+    Staleness is intentionally ignored: a stale cell scores identically to
+    its fresh counterpart (see :data:`SCORE_WEIGHTS`).
     """
-    stale = getattr(cell, "stale", False)
     if cell.status == OK:
-        return "ok*" if stale else "ok"
+        return "ok"
     if cell.status == ANOMALY:
-        return "anom*" if stale else "anom"
+        return "anom"
     if cell.status == FAILED:
-        return "fail*" if stale else "fail"
+        return "fail"
     if cell.status == NOT_RUN:
         return "missing"
     if cell.status == EXCLUDED:
@@ -1196,12 +1205,14 @@ def format_score(score: float | None) -> str:
 # 1.0; linearly interpolated between stops. Designed to read as a traffic-light
 # ramp: red (fail) → orange → yellow → green → bright green (ok).
 #
-# Ansi (hex via rich):
+# Ansi (hex via rich). Score weights annotated where they land; intermediate
+# stops are ramp positions used for gradient fill / the status progress bar
+# (e.g. its stale-ok segment sits at 0.67), not score weights themselves:
 #   w = 0.00 → red           #cc0d0d   fail
-#   w = 0.17 → red-orange    #e03a0b   fail*
-#   w = 0.33 → orange        #f78005   missing / neutral
+#   w = 0.17 → red-orange    #e03a0b
+#   w = 0.33 → orange        #f78005   missing / neutral / excl (work)
 #   w = 0.53 → yellow        #f5d80f   anom
-#   w = 0.67 → yellow-green  #73d114   ok*
+#   w = 0.67 → yellow-green  #73d114
 #   w = 1.00 → bright green  #00e659   ok
 #   None     → dim
 #

--- a/mosaic/benchmarks/core/status.py
+++ b/mosaic/benchmarks/core/status.py
@@ -1790,7 +1790,25 @@ def _diff_metrics(
         )
 
 
-def diff_snapshots(old: dict, new: dict) -> dict:
+def _cell_measured(measured: dict | None, problem: str, solver: str) -> bool:
+    """Whether ``(problem, solver)`` was actually re-measured this run.
+
+    ``measured`` is ``None`` for a full run (everything measured → True for
+    all). Otherwise it carries ``problems`` (empty = every problem) and
+    ``solvers`` (the solvers actually re-run). A cell counts as measured only
+    when both match — carried-over baseline cells return False so their
+    transitions aren't mis-attributed to the PR.
+    """
+    if measured is None:
+        return True
+    problems = measured.get("problems") or []
+    solvers = measured.get("solvers") or []
+    problem_ok = not problems or problem in problems
+    solver_ok = not solvers or solver in solvers
+    return problem_ok and solver_ok
+
+
+def diff_snapshots(old: dict, new: dict, measured: dict | None = None) -> dict:
     """Compute transitions between two JSON snapshots produced by ``snapshot_to_dict``.
 
     Returns a dict with:
@@ -1799,6 +1817,12 @@ def diff_snapshots(old: dict, new: dict) -> dict:
       other        — same-severity transitions (e.g. missing → excl)
       added_rows   — experiment rows present in new but not old
       removed_rows — experiment rows present in old but not new
+
+    ``measured`` optionally scopes the diff to the (problem × solver) cells that
+    were actually re-run this PR (``{"problems": [...], "solvers": [...]}``);
+    cells outside it are carried-over baseline data, so any apparent transition
+    is baseline drift rather than a PR effect and is skipped. ``None`` (default)
+    diffs every cell — correct for full runs and local ``compare``.
     """
     out: dict = {
         "regressions": [],
@@ -1837,6 +1861,12 @@ def diff_snapshots(old: dict, new: dict) -> dict:
             for solver, new_cell in new_row["cells"].items():
                 old_cell = old_row["cells"].get(solver)
                 if old_cell is None:
+                    continue
+                # Skip cells this run didn't re-measure: their new value is
+                # carried-over baseline data, so a transition is baseline drift,
+                # not a PR effect (F3). Full runs / local compare pass
+                # measured=None and diff everything.
+                if not _cell_measured(measured, problem, solver):
                     continue
                 # Resource frontier move (independent of the status transition).
                 _diff_frontier(out, problem, label, solver, old_cell, new_cell)

--- a/mosaic/benchmarks/core/status.py
+++ b/mosaic/benchmarks/core/status.py
@@ -194,6 +194,20 @@ class Cell:
     # `*` on the cell's glyph (e.g. `ok*`, `anom*`), never replaces the
     # underlying status.
     stale: bool = False
+    # Resource frontier for swept experiments: the first sweep value at which
+    # the solver hit a *resource ceiling* (OOM / timeout). ``None`` when the
+    # solver ran to completion at every value. A ceiling is NOT a failure — a
+    # solver that OOMs only at the largest sizes is still OK — but the frontier
+    # is carried into the snapshot so ``diff_snapshots`` can tell when the
+    # ceiling *moves* (OOM starting earlier than baseline = regression). This
+    # is the platform-dependent case that can't be encoded as an exclusion.
+    resource_frontier: str = ""
+    # Numeric scalars for this cell, keyed by a stable metric name (see
+    # ``METRIC_SPECS``). Diffed across snapshots by ``_diff_metrics`` so a cell
+    # that stays ``ok`` still surfaces a numeric regression / improvement — the
+    # status ladder alone hides most of what optimisation PRs actually move.
+    # Empty when the suite has no comparable scalar or the solver didn't run.
+    metrics: dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -573,32 +587,100 @@ def _classify_from_v1(data: dict, solvers: list[str], checks: list) -> dict[str,
             cells[solver] = Cell(NOT_RUN)
             continue
 
-        # Check if any entry has valid metrics
+        # Walk each sweep point and classify it into one of these signals:
+        #   crash          — ``status: "failed"`` with a failure_type that is a
+        #                    real bug (error / nan / container_died, or an
+        #                    unlabelled failure). A crash at ANY size fails the
+        #                    whole cell — a larger value succeeding doesn't
+        #                    excuse it (e.g. PR #132's non-power-of-two compile
+        #                    error). The failure record carries finite mem
+        #                    fields, so ``_has_any_finite`` alone would mis-read
+        #                    it as OK — we must consult ``status`` explicitly.
+        #   resource ceiling — ``status: "failed"`` with failure_type OOM /
+        #                    timeout. This is a platform-dependent scaling
+        #                    limit, expected at large sizes and not encodable as
+        #                    an exclusion. It does NOT fail the cell; we only
+        #                    record the frontier (first value that hit it) so
+        #                    the diff can tell when the ceiling moves.
+        #   valid          — real, finite result data.
+        #   empty / skipped — ``{}`` (never ran) or a deliberately-skipped
+        #                    point; benign "didn't run", ignored.
+        #   valid: False   — the forward/gradient suites' invalid sentinel.
         has_valid = False
         has_any = False
-        reason = ""
+        fail_reason = ""
+        valid_false_reason = ""
+        frontier: str | None = None
+        _RESOURCE_CEILING = ("OOM", "timeout")
         for entry in entries:
             metrics = entry.get("metrics")
             if metrics is None:
                 continue
+            # A "skipped" point (a value the framework deliberately didn't run
+            # after an earlier ceiling / wall-limit hit) is a benign "didn't
+            # run" — treat it like an absent/empty cell.
+            if isinstance(metrics, dict) and metrics.get("status") == "skipped":
+                continue
             has_any = True
-            if isinstance(metrics, dict):
-                if metrics.get("valid") is True:
-                    has_valid = True
-                elif metrics.get("valid") is False:
-                    if not reason:
-                        reason = _reason_from_entry(metrics) or ""
-                elif _has_any_finite(metrics):
-                    has_valid = True
+            if not isinstance(metrics, dict):
+                continue
+            if metrics.get("status") == "failed":
+                if metrics.get("failure_type") in _RESOURCE_CEILING:
+                    # Resource ceiling — not a failure. Record the first value
+                    # at which it bit, in on-disk sweep order.
+                    if frontier is None:
+                        frontier = str(entry.get("sweep_value") or "")
+                elif not fail_reason:
+                    fail_reason = _fail_reason_from_metrics(metrics)
+            elif metrics.get("valid") is True:
+                has_valid = True
+            elif metrics.get("valid") is False:
+                if not valid_false_reason:
+                    valid_false_reason = _reason_from_entry(metrics) or ""
+            elif _has_any_finite(metrics):
+                has_valid = True
 
-        if not has_any:
+        frontier = frontier or ""
+        if fail_reason:
+            cells[solver] = Cell(FAILED, fail_reason, resource_frontier=frontier)
+        elif not has_any:
             cells[solver] = Cell(NOT_RUN)
         elif has_valid:
-            cells[solver] = Cell(OK)
+            cells[solver] = Cell(OK, resource_frontier=frontier)
         else:
-            cells[solver] = Cell(FAILED, reason or "all entries failed")
+            # No valid data and no real crash. If a resource ceiling was the
+            # only outcome (OOM at every attempted size), the solver can't run
+            # this experiment on this platform at all — surface it as FAILED so
+            # it isn't a silent all-empty, but keep the frontier for the diff.
+            if frontier:
+                cells[solver] = Cell(
+                    FAILED,
+                    f"resource ceiling at all sizes (from {frontier})",
+                    resource_frontier=frontier,
+                )
+            else:
+                cells[solver] = Cell(FAILED, valid_false_reason or "all entries failed")
 
     return cells
+
+
+def _fail_reason_from_metrics(metrics: dict) -> str:
+    """Build a short human-readable reason from a ``status: "failed"`` record.
+
+    Cost/timing failures carry ``failure_type`` + ``exc_type`` + ``exc_msg``
+    (see :meth:`TimedResult.as_record`); prefer those over the generic
+    ``error``/``message``/``reason`` fields the other suites use.
+    """
+    exc_type = metrics.get("exc_type")
+    exc_msg = metrics.get("exc_msg") or metrics.get("error")
+    failure_type = metrics.get("failure_type")
+    if exc_type and exc_msg:
+        head = str(exc_msg).strip().splitlines()[0][:160]
+        prefix = f"{failure_type}: " if failure_type else ""
+        return f"{prefix}{exc_type}: {head}"
+    if failure_type:
+        return str(failure_type)
+    return _reason_from_entry(metrics) or "failed"
 
 
 def _classify_result(data: dict, solvers: list[str], checks: list) -> dict[str, Cell]:
@@ -756,6 +838,174 @@ def _refine_for_suite(
         _refine_fd_check(view, cells, checks)
     elif suite == "optimization":
         _refine_recovery(view, cells, checks)
+
+
+# ── per-cell numeric metric collection ───────────────────────────────────────
+#
+# The status ladder (ok / anom / fail / …) is coarse: a solver that stays ``ok``
+# while getting 2× slower or doubling its gradient error produces no transition.
+# We therefore carry a small dict of numeric scalars per cell into the snapshot
+# so ``diff_snapshots`` can surface a same-status numeric regression /
+# improvement (see ``_diff_metrics``). These collectors run *unconditionally*
+# from ``_build_row`` — independent of whether an anomaly check is configured —
+# and compute the same scalars the ``_refine_*`` functions already use.
+
+
+# Metric name → (relative-change threshold to surface, "lower"|"higher" is
+# better, confidence). Wall-clock ("cost_time_s") is noisy across GitHub-hosted
+# runners (shared-host contention) so it gets a wide threshold and an
+# "indicative" confidence; the deterministic correctness metrics are compared
+# firmly. NOTE: this firm/indicative split assumes every benchmark run uses one
+# GH-hosted hardware class — revisit if that ever stops holding.
+METRIC_SPECS: dict[str, tuple[float, str, str]] = {
+    "rel_err": (0.15, "lower", "firm"),
+    "cosine": (0.02, "higher", "firm"),
+    "final_ratio": (0.15, "lower", "firm"),
+    "final_loss": (0.15, "lower", "firm"),
+    "fwd_error": (0.15, "lower", "firm"),
+    "cost_time_s": (0.35, "lower", "indicative"),
+}
+
+
+def _store_metric(cell: Cell, key: str, value: float | None) -> None:
+    """Record a finite metric scalar on a cell; skip None / NaN / inf."""
+    if isinstance(value, int | float) and math.isfinite(value):
+        cell.metrics[key] = float(value)
+
+
+def _collect_cost_metrics(data: dict, cells: dict[str, Cell]) -> None:
+    """Store each OK solver's median wall-clock time as ``cost_time_s``."""
+    key = "by_N" if "by_N" in data else "by_steps" if "by_steps" in data else None
+    top = data.get(key, {}) if key else data.get("by_solver", {})
+    if not isinstance(top, dict):
+        return
+    for solver, cell in cells.items():
+        if cell.status != OK:
+            continue
+        vals = top.get(solver, {})
+        if not isinstance(vals, dict):
+            continue
+        times = [
+            v["mean"]
+            for v in vals.values()
+            if isinstance(v, dict) and math.isfinite(v.get("mean", float("nan")))
+        ]
+        if times:
+            _store_metric(cell, "cost_time_s", _median(times))
+
+
+def _collect_fd_metrics(data: dict, cells: dict[str, Cell]) -> None:
+    """Store best-ε ``rel_err`` and ``cosine`` per OK solver (mirrors ``_refine_fd_check``)."""
+    by_solver = data.get("by_solver", {})
+    if not isinstance(by_solver, dict):
+        return
+    for solver, cell in cells.items():
+        if cell.status != OK:
+            continue
+        entry = by_solver.get(solver)
+        sweep = entry.get("eps_sweep") if isinstance(entry, dict) else None
+        if not isinstance(sweep, dict):
+            continue
+        best_cos = None
+        best_rel = None
+        for st in sweep.values():
+            if not isinstance(st, dict):
+                continue
+            c = st.get("cosine")
+            if isinstance(c, int | float) and math.isfinite(c):
+                best_cos = c if best_cos is None else max(best_cos, c)
+            vals = [
+                r
+                for r in (st.get("rel_error") or [])
+                if isinstance(r, int | float) and math.isfinite(r)
+            ]
+            if vals:
+                med = _median(vals)
+                best_rel = med if best_rel is None else min(best_rel, med)
+        _store_metric(cell, "rel_err", best_rel)
+        _store_metric(cell, "cosine", best_cos)
+
+
+def _collect_recovery_metrics(data: dict, cells: dict[str, Cell]) -> None:
+    """Store the worst-case ``final_ratio`` (and ``final_loss`` when present) per OK solver."""
+    top = data.get("by_solver") or data.get("by_sweep") or {}
+    if not isinstance(top, dict):
+        return
+    for solver, cell in cells.items():
+        if cell.status != OK:
+            continue
+        entry = top.get(solver)
+        if not isinstance(entry, dict):
+            continue
+        series = _worst_case_trajectory(entry)
+        if series:
+            initial = abs(series[0])
+            final = abs(series[-1])
+            if initial > 0 and math.isfinite(final):
+                _store_metric(cell, "final_ratio", final / initial)
+        # ``final_loss`` is only written by some domains (e.g. ns-3d IC
+        # recovery); store it when directly present, else fall back to the
+        # trajectory endpoint so the metric exists for every optimisation cell.
+        fl = entry.get("final_loss")
+        if isinstance(fl, int | float) and math.isfinite(fl):
+            _store_metric(cell, "final_loss", fl)
+        elif series and math.isfinite(abs(series[-1])):
+            _store_metric(cell, "final_loss", abs(series[-1]))
+
+
+def _collect_forward_metrics(data: dict, cells: dict[str, Cell]) -> None:
+    """Store each OK solver's median forward ``error`` as ``fwd_error``.
+
+    Forward results are ``by_solver[solver] = {error, valid}`` (non-swept) or
+    ``by_solver[solver][pval] = {error, valid}`` (swept). Only valid points
+    contribute; the per-solver scalar is the median across valid sweep points.
+    """
+    by_solver = data.get("by_solver", {})
+    if not isinstance(by_solver, dict):
+        return
+    for solver, cell in cells.items():
+        if cell.status != OK:
+            continue
+        entry = by_solver.get(solver)
+        if not isinstance(entry, dict):
+            continue
+        errs: list[float] = []
+        # Swept: values are per-pval dicts. Non-swept: entry is the metrics dict.
+        subs = (
+            list(entry.values())
+            if entry and all(isinstance(v, dict) for v in entry.values())
+            else [entry]
+        )
+        for sub in subs:
+            if not isinstance(sub, dict) or sub.get("valid") is False:
+                continue
+            e = sub.get("error")
+            if isinstance(e, int | float) and math.isfinite(e):
+                errs.append(float(e))
+        if errs:
+            _store_metric(cell, "fwd_error", _median(errs))
+
+
+def _collect_metrics_for_suite(
+    suite: str, exp_label: str, data: dict, cells: dict[str, Cell]
+) -> None:
+    """Populate ``cell.metrics`` with the suite's comparable numeric scalars.
+
+    Runs unconditionally (no threshold needed) so a same-status numeric shift
+    is diffable even for problems that configure no anomaly checks.
+    """
+    view = _v1_to_legacy_view(data) if data.get("schema_version") == 1 else data
+    if suite == "cost":
+        _collect_cost_metrics(view, cells)
+    elif suite == "gradient" and exp_label.split("/")[0] in (
+        "fd_check",
+        "source_fd_check",
+    ):
+        _collect_fd_metrics(view, cells)
+    elif suite == "optimization":
+        _collect_recovery_metrics(view, cells)
+    elif suite == "forward":
+        _collect_forward_metrics(view, cells)
 
 
 def _row_harness_stale(data: dict, harness_hash_cache: dict[str, str | None]) -> bool:
@@ -916,6 +1166,9 @@ def _build_row(
         return row
     checks = _lookup_check(cfg, suite, exp_label)
     row.cells = _classify_result(data, solvers, checks)
+    # Capture numeric scalars *before* anomaly refinement downgrades any OK
+    # cell — the scalar is worth diffing whether or not it trips a threshold.
+    _collect_metrics_for_suite(suite, exp_label, data, row.cells)
     _refine_for_suite(suite, exp_label, data, row.cells, checks)
     _apply_staleness(
         cfg, data, row.cells, solvers, tesseract_hash_cache, harness_hash_cache
@@ -1041,6 +1294,8 @@ def status_to_dict(st: ProblemStatus) -> dict:
                         "reason": c.reason,
                         "category": c.category,
                         "stale": c.stale,
+                        "resource_frontier": c.resource_frontier,
+                        "metrics": c.metrics,
                     }
                     for s, c in r.cells.items()
                 },
@@ -1426,6 +1681,115 @@ def render_markdown(statuses: list[ProblemStatus]) -> str:
 _SEVERITY = {OK: 0, EXCLUDED: 1, NOT_RUN: 2, ANOMALY: 3, FAILED: 4}
 
 
+def _frontier_num(v: str) -> float | None:
+    """Parse a frontier sweep-value string to a float for ordering, or None."""
+    if not v:
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _diff_frontier(
+    out: dict,
+    problem: str,
+    label: str,
+    solver: str,
+    old_cell: dict,
+    new_cell: dict,
+) -> None:
+    """Record a resource-ceiling frontier move into ``out["frontier_shifts"]``.
+
+    A frontier is the first sweep value at which the solver hit an OOM /
+    timeout. Comparing old vs new answers "did the ceiling move?":
+      * ceiling appears where there was none, or moves to a *smaller* value
+        → regression (solver now fails to scale as far as before)
+      * ceiling disappears, or moves to a *larger* value → improvement
+    Frontiers that don't parse as numbers are compared for equality only
+    (a change is reported as a neutral shift rather than a direction).
+    """
+    old_f = old_cell.get("resource_frontier", "") or ""
+    new_f = new_cell.get("resource_frontier", "") or ""
+    if old_f == new_f:
+        return
+    rec = {
+        "problem": problem,
+        "label": label,
+        "solver": solver,
+        "from_frontier": old_f,
+        "to_frontier": new_f,
+    }
+    old_n = _frontier_num(old_f)
+    new_n = _frontier_num(new_f)
+    # Direction: a ceiling that bites at a smaller size is worse. Treat "no
+    # ceiling" as +∞ (scales further is better).
+    old_v = old_n if old_n is not None else float("inf") if not old_f else None
+    new_v = new_n if new_n is not None else float("inf") if not new_f else None
+    if old_v is not None and new_v is not None:
+        rec["direction"] = "regression" if new_v < old_v else "improvement"
+    else:
+        rec["direction"] = "changed"
+    out["frontier_shifts"].append(rec)
+
+
+def _diff_metrics(
+    out: dict,
+    problem: str,
+    label: str,
+    solver: str,
+    old_cell: dict,
+    new_cell: dict,
+) -> None:
+    """Record numeric-metric shifts into ``out["metric_shifts"]``.
+
+    Only compares cells that are ``ok`` in *both* snapshots: a status
+    transition is already reported by the main diff path (comparing numbers
+    across a fail↔ok boundary is meaningless and would double-report the
+    event). For each metric present in both cells, surfaces a shift when the
+    relative change exceeds that metric's ``METRIC_SPECS`` threshold. Wall-clock
+    (``cost_time_s``) is flagged ``confidence="indicative"`` — noisy across
+    shared CI runners — while deterministic correctness metrics are ``firm``.
+    """
+    if old_cell.get("status") != OK or new_cell.get("status") != OK:
+        return
+    old_m = old_cell.get("metrics") or {}
+    new_m = new_cell.get("metrics") or {}
+    if not isinstance(old_m, dict) or not isinstance(new_m, dict):
+        return
+    for metric, (threshold, better, confidence) in METRIC_SPECS.items():
+        if metric not in old_m or metric not in new_m:
+            continue
+        old_v = old_m[metric]
+        new_v = new_m[metric]
+        if not (isinstance(old_v, int | float) and isinstance(new_v, int | float)):
+            continue
+        if not (math.isfinite(old_v) and math.isfinite(new_v)):
+            continue
+        # Relative change against the old magnitude; a near-zero baseline uses
+        # a tiny floor so a 0 → ε move doesn't report an infinite regression.
+        denom = max(abs(old_v), 1e-12)
+        pct = (new_v - old_v) / denom
+        if abs(pct) < threshold:
+            continue
+        got_bigger = new_v > old_v
+        # "lower is better": bigger = regression. "higher is better": flip.
+        is_regression = got_bigger if better == "lower" else not got_bigger
+        out["metric_shifts"].append(
+            {
+                "problem": problem,
+                "label": label,
+                "solver": solver,
+                "metric": metric,
+                "from": old_v,
+                "to": new_v,
+                "pct_change": pct,
+                "direction": "regression" if is_regression else "improvement",
+                "confidence": confidence,
+            }
+        )
+
+
 def diff_snapshots(old: dict, new: dict) -> dict:
     """Compute transitions between two JSON snapshots produced by ``snapshot_to_dict``.
 
@@ -1440,6 +1804,16 @@ def diff_snapshots(old: dict, new: dict) -> dict:
         "regressions": [],
         "improvements": [],
         "other": [],
+        # Resource-ceiling (OOM / timeout) frontier moves between snapshots,
+        # even when both cells stay OK. This is the signal a PR author cares
+        # about most for scaling behaviour: did the solver start OOMing at a
+        # *smaller* size than baseline (regression) or push the ceiling out
+        # (improvement)?
+        "frontier_shifts": [],
+        # Numeric-metric shifts between cells that stay OK in both snapshots
+        # (e.g. gradient rel-error worsened, converged loss improved). The
+        # status ladder alone hides these; see ``_diff_metrics``.
+        "metric_shifts": [],
         "added_rows": [],
         "removed_rows": [],
         # Snapshot-level score kept under underscored keys so existing callers
@@ -1464,6 +1838,10 @@ def diff_snapshots(old: dict, new: dict) -> dict:
                 old_cell = old_row["cells"].get(solver)
                 if old_cell is None:
                     continue
+                # Resource frontier move (independent of the status transition).
+                _diff_frontier(out, problem, label, solver, old_cell, new_cell)
+                # Numeric-metric shift for cells that stay OK (no status change).
+                _diff_metrics(out, problem, label, solver, old_cell, new_cell)
                 same_status = old_cell["status"] == new_cell["status"]
                 # A same-status change in category (e.g. excluded → excluded
                 # but category moved from not_implemented to categorical) is
@@ -1498,6 +1876,73 @@ def diff_snapshots(old: dict, new: dict) -> dict:
     return out
 
 
+# Human-readable labels for the metric keys in ``METRIC_SPECS``.
+_METRIC_LABELS: dict[str, str] = {
+    "rel_err": "gradient rel-error",
+    "cosine": "gradient cosine",
+    "final_ratio": "final/initial loss ratio",
+    "final_loss": "final loss",
+    "fwd_error": "forward error",
+    "cost_time_s": "median time",
+}
+
+
+def _fmt_metric_value(metric: str, value: float) -> str:
+    """Format a metric scalar: seconds for timing, else compact scientific."""
+    if metric == "cost_time_s":
+        return f"{value:.3g}s"
+    return f"{value:.3g}"
+
+
+def _fmt_metric_shift(r: dict) -> str:
+    """One bullet line for a metric shift: glyph, location, from → to (±pct)."""
+    g = "🔴" if r.get("direction") == "regression" else "🟢"
+    metric = r["metric"]
+    label = _METRIC_LABELS.get(metric, metric)
+    old_s = _fmt_metric_value(metric, r["from"])
+    new_s = _fmt_metric_value(metric, r["to"])
+    pct = r.get("pct_change", 0.0) * 100.0
+    sign = "+" if pct >= 0 else ""
+    return (
+        f"- {g} `{r['problem']}` · `{r['label']}` · **{r['solver']}** · "
+        f"{label} {old_s} → {new_s} ({sign}{pct:.0f}%)"
+    )
+
+
+def _render_metric_shifts(lines: list[str], metric_shifts: list[dict]) -> None:
+    """Render numeric-metric shifts, splitting firm from indicative (timing).
+
+    Firm (deterministic correctness) metrics go under a headline section;
+    indicative wall-clock shifts go under a clearly-labelled sub-section so a
+    contributor never mistakes a shared-runner timing wobble for a hard
+    regression (see F2 in the reporting audit).
+    """
+    firm = [r for r in metric_shifts if r.get("confidence") != "indicative"]
+    indicative = [r for r in metric_shifts if r.get("confidence") == "indicative"]
+    if firm:
+        lines.append("### 📊 Metric changes")
+        lines.append("")
+        lines.append(
+            "_Numeric shifts for solvers that stayed `ok` — the status ladder "
+            "alone wouldn't surface these._"
+        )
+        lines.append("")
+        for r in firm:
+            lines.append(_fmt_metric_shift(r))
+        lines.append("")
+    if indicative:
+        lines.append("### ⏱ Timing (indicative — shared-runner contention)")
+        lines.append("")
+        lines.append(
+            "_Wall-clock varies with CI-runner load, so treat these as "
+            "indicative rather than controlled measurements._"
+        )
+        lines.append("")
+        for r in indicative:
+            lines.append(_fmt_metric_shift(r))
+        lines.append("")
+
+
 def render_diff_markdown(diff: dict) -> str:
     """Render a snapshot diff as markdown suitable for a PR comment."""
     lines: list[str] = ["## Status diff vs base", "", _MD_LEGEND, ""]
@@ -1506,6 +1951,10 @@ def render_diff_markdown(diff: dict) -> str:
     n_oth = len(diff["other"])
     n_add = len(diff["added_rows"])
     n_rm = len(diff["removed_rows"])
+    frontier_shifts = diff.get("frontier_shifts", [])
+    n_front = len(frontier_shifts)
+    metric_shifts = diff.get("metric_shifts", [])
+    n_metric = len(metric_shifts)
 
     # Score delta header: uses snapshot-level score if present, falls back to
     # None for legacy snapshots where the field is absent.
@@ -1521,7 +1970,7 @@ def render_diff_markdown(diff: dict) -> str:
     old_score = _snap_score(diff.get("_old_snapshot"))
     new_score = _snap_score(diff.get("_new_snapshot"))
 
-    if n_reg == n_imp == n_oth == n_add == n_rm == 0:
+    if n_reg == n_imp == n_oth == n_add == n_rm == n_front == n_metric == 0:
         if old_score is not None or new_score is not None:
             lines.append(
                 f"_No status changes._ · score "
@@ -1534,7 +1983,9 @@ def render_diff_markdown(diff: dict) -> str:
     header_bits = [
         f"**{n_reg} regression(s)**",
         f"**{n_imp} improvement(s)**",
+        f"{n_metric} metric change(s)",
         f"{n_oth} other transition(s)",
+        f"{n_front} resource-frontier shift(s)",
         f"{n_add} new row(s)",
         f"{n_rm} removed row(s)",
     ]
@@ -1573,6 +2024,28 @@ def render_diff_markdown(diff: dict) -> str:
         lines.append("")
         for r in diff["improvements"]:
             lines.append(_fmt_rec(r))
+        lines.append("")
+
+    if metric_shifts:
+        _render_metric_shifts(lines, metric_shifts)
+
+    if frontier_shifts:
+        lines.append("### Resource-frontier shifts (OOM / timeout)")
+        lines.append("")
+        lines.append(
+            "_The size at which a solver first hits a resource ceiling. "
+            "A smaller frontier means it now fails to scale as far as before._"
+        )
+        lines.append("")
+        _dir_glyph = {"regression": "🔴", "improvement": "🟢", "changed": "⚪"}
+        for r in frontier_shifts:
+            g = _dir_glyph.get(r.get("direction", "changed"), "⚪")
+            old_f = r.get("from_frontier") or "none"
+            new_f = r.get("to_frontier") or "none"
+            lines.append(
+                f"- {g} `{r['problem']}` · `{r['label']}` · **{r['solver']}** · "
+                f"ceiling {old_f} → {new_f}"
+            )
         lines.append("")
 
     if diff["other"]:

--- a/mosaic/benchmarks/problems/shared/cost.py
+++ b/mosaic/benchmarks/problems/shared/cost.py
@@ -90,8 +90,34 @@ def _timed_kernel(
         record = result.as_record(grad_norm=grad_norm)
         snapshot = np.array(result.last_value)
 
-    stop = result.failure is not None or result.wall_limit_hit
-    return {"metrics": record, "snapshot": snapshot, "stop_sweep": stop}
+    # Tell the framework *why* the sweep should (or shouldn't) stop here.
+    # Two axes matter — whether to continue, and whether it's a real bug:
+    #
+    #   wall_limit  — this point was already too slow; every larger point is
+    #                 slower still. Monotone in size → stop. Not a bug.
+    #   resource    — OOM / timeout. Monotone in size (a bigger problem won't
+    #                 fit if this one didn't) → stop. Platform-dependent
+    #                 resource ceiling, NOT a solver bug: expected at large
+    #                 sizes and can't be encoded as an explicit exclusion.
+    #   error       — compile error, NaN, container death. Point-specific: a
+    #                 larger sweep value may well succeed (e.g. a power-of-two
+    #                 grid after a non-power-of-two crashed) → CONTINUE, and
+    #                 this IS a bug the report must surface.
+    #
+    # ``stop_sweep`` (legacy boolean) stays True for the two monotone stops.
+    if result.wall_limit_hit:
+        stop_reason = "wall_limit"
+    elif result.failure is not None:
+        ftype = result.failure.get("failure_type")
+        stop_reason = "resource" if ftype in ("OOM", "timeout") else "error"
+    else:
+        stop_reason = None
+    return {
+        "metrics": record,
+        "snapshot": snapshot,
+        "stop_sweep": stop_reason in ("wall_limit", "resource"),
+        "stop_reason": stop_reason,
+    }
 
 
 # ── Aggregates ───────────────────────────────────────────────────────────────

--- a/tests/core/test_harness.py
+++ b/tests/core/test_harness.py
@@ -34,6 +34,12 @@ from mosaic.benchmarks.core.harness import (
         ("RuntimeError", "RESOURCE_EXHAUSTED: out of memory on device", "OOM"),
         ("RuntimeError", "CUDA_ERROR_OUT_OF_MEMORY", "OOM"),
         ("Exception", "Operation crashed: out of memory.", "OOM"),
+        # Additional unambiguous memory-pressure markers (framework-specific).
+        ("RuntimeError", "CUBLAS_STATUS_ALLOC_FAILED", "OOM"),
+        ("RuntimeError", "cudnn_status_alloc_failed when planning conv", "OOM"),
+        ("RuntimeError", "cudaErrorMemoryAllocation", "OOM"),
+        ("XlaRuntimeError", "Failed to allocate 8.00GiB for buffer", "OOM"),
+        ("Exception", "Killed by OOM killer", "OOM"),
         # Timeout: matched by exception name
         ("TimeoutError", "deadline exceeded", "timeout"),
         ("WatchdogTimeout", "", "timeout"),

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -7,11 +7,11 @@ Replaces the binary ``% ok`` metric with a per-cell weighted sum. See
 ``core/status.py::SCORE_WEIGHTS`` for the table. The tests here pin:
 
   1. Extremes: all-ok → +1.0, all-fail → 0.0, empty → None.
-  2. Monotonicity: a cell going ok* → ok moves the score by exactly the
-     expected ΔN; a cell going ok → fail moves it by 1.0/N in the
-     other direction.
-  3. Categorical exclusions are off the books (numerator + denominator).
-  4. Boundary agreement with ``% ok``: all-ok ⇒ score=1.0 & pct=100;
+  2. Monotonicity: a cell going ok → fail moves the score by exactly 1.0/N.
+  3. Staleness invisibility: the ``*`` marker never moves the score — a
+     stale cell scores identically to its fresh counterpart.
+  4. Categorical exclusions are off the books (numerator + denominator).
+  5. Boundary agreement with ``% ok``: all-ok ⇒ score=1.0 & pct=100;
      all non-ok (fail/anom/missing) ⇒ score in [0, 0.53] & pct=0.
 """
 
@@ -113,15 +113,19 @@ class TestScoreExtremes(unittest.TestCase):
 class TestScoreTransitions(unittest.TestCase):
     """Direction and magnitude of single-cell status flips."""
 
-    def test_ok_star_to_ok_increases_over_n(self) -> None:
-        """ok* (0.67) → ok (1.00) shifts average by (1.0 − 0.67)/N."""
-        n = 4
-        before = [Cell(OK, stale=True)] + [Cell(OK) for _ in range(n - 1)]
-        after = [Cell(OK)] + [Cell(OK) for _ in range(n - 1)]
-        s_before, _ = compute_score(before)
-        s_after, _ = compute_score(after)
-        self.assertAlmostEqual(s_after - s_before, (1.0 - 0.67) / n)
-        self.assertGreater(s_after, s_before)
+    def test_stale_does_not_move_score(self) -> None:
+        """The ``*`` marker is invisible to the score.
+
+        Staleness is a "re-run recommended" hint for humans, not a health
+        signal — a stale cell scores identically to its fresh counterpart,
+        for every underlying status. This is the invariant that keeps the
+        headline score from drifting on the incremental PR-preview path when
+        carried-over baselines hash-mismatch the current tree.
+        """
+        for status in (OK, ANOMALY, FAILED):
+            fresh, _ = compute_score([Cell(status) for _ in range(4)])
+            stale, _ = compute_score([Cell(status, stale=True) for _ in range(4)])
+            self.assertAlmostEqual(fresh, stale, msg=f"stale moved score for {status}")
 
     def test_ok_to_fail_decreases_by_one_over_n(self) -> None:
         """Ok (1.0) → fail (0.0) shifts average by −1.0/N."""
@@ -134,8 +138,11 @@ class TestScoreTransitions(unittest.TestCase):
         self.assertLess(s_after, s_before)
 
     def test_transition_across_all_weight_keys(self) -> None:
-        """Every mapped weight key is reachable via some (status, stale,
-        category) combination — catches silent dead keys.
+        """Every mapped weight key is reachable via some (status, category)
+        combination — catches silent dead keys.
+
+        Stale probes are included to pin that they collapse onto the same
+        (non-star) keys as their fresh counterparts.
         """
         produced: set[str] = set()
         probes: list[Cell] = [
@@ -151,6 +158,7 @@ class TestScoreTransitions(unittest.TestCase):
         for c in probes:
             key = cell_weight_key(c)
             self.assertIsNotNone(key, f"unmapped: {c}")
+            self.assertNotIn("*", key, f"stale key leaked into score table: {key}")
             produced.add(key)  # type: ignore[arg-type]
         missing = set(SCORE_WEIGHTS.keys()) - produced
         self.assertFalse(
@@ -287,8 +295,10 @@ class TestWeightColorLadder(unittest.TestCase):
         self.assertEqual(cell_weight(c), 1.0)
         self.assertTrue(_HEX_RE.match(cell_color(c)))
 
+        # Staleness doesn't dim the weight — a stale ok weighs the same as a
+        # fresh ok. The ``*`` glyph carries the "re-run" hint on its own.
         c = Cell(OK, stale=True)
-        self.assertEqual(cell_weight(c), 0.67)
+        self.assertEqual(cell_weight(c), 1.0)
 
         c_fail = Cell(FAILED)
         self.assertEqual(cell_weight(c_fail), 0.0)

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -323,5 +323,392 @@ class TestWeightColorLadder(unittest.TestCase):
             self.assertIn(weight_emoji(w), {"🟢", "🟡", "🟠", "🔴", "—"})
 
 
+_FAIL_METRICS = {
+    "status": "failed",
+    "trials_s": [],
+    "failure_type": "error",
+    "exc_type": "RuntimeError",
+    "exc_msg": "tile_fft only supports power-of-two sizes",
+    "vram_peak_mib": 0.0,
+    "ram_peak_mib": 812.0,
+}
+_OOM_METRICS = {
+    "status": "failed",
+    "trials_s": [],
+    "failure_type": "OOM",
+    "exc_type": "RuntimeError",
+    "exc_msg": "RESOURCE_EXHAUSTED: Out of memory",
+    "vram_peak_mib": 0.0,
+    "ram_peak_mib": 800.0,
+}
+_OK_METRICS = {"mean": 0.1, "std": 0.0, "trials_s": [0.1], "vram_peak_mib": 10.0}
+_SKIP_METRICS = {"status": "skipped", "reason": "skipped after wall-limit hit at N=256"}
+
+
+class TestClassifyFromV1(unittest.TestCase):
+    """Per-sweep-point classification of schema_version=1 cost results.
+
+    Regression cover for PR #132: a solver that crashed at a subset of sweep
+    points classified as OK because the crash record still carried finite
+    ``vram_peak_mib``/``ram_peak_mib`` (so ``_has_any_finite`` returned True)
+    and the classifier never consulted ``metrics["status"] == "failed"``.
+    """
+
+    # A failure record as written by TimedResult.as_record on a crash — note
+    # the finite mem fields that used to fool _has_any_finite into "ok".
+    FAIL = _FAIL_METRICS
+    OK_M = _OK_METRICS
+    SKIP = _SKIP_METRICS
+
+    # Default sweep values line up with the ns-grid cost sweep so frontier
+    # assertions read naturally.
+    SWEEP = ("64", "128", "192", "256")
+
+    @classmethod
+    def _classify(cls, points: list[dict]):
+        from mosaic.benchmarks.core.status import _classify_from_v1
+
+        data = {
+            "schema_version": 1,
+            "results": [
+                {"solver": "s", "sweep_value": cls.SWEEP[i], "metrics": m}
+                for i, m in enumerate(points)
+            ],
+        }
+        return _classify_from_v1(data, ["s"], [])["s"]
+
+    def test_partial_crash_is_failed(self) -> None:
+        # 64 ok, 128 ok, 192 FAIL, 256 never-ran ({}) — the PR #132 shape.
+        cell = self._classify([self.OK_M, self.OK_M, self.FAIL, {}])
+        self.assertEqual(cell.status, FAILED)
+        self.assertIn("tile_fft", cell.reason)
+
+    def test_all_ok_is_ok(self) -> None:
+        self.assertEqual(self._classify([self.OK_M, self.OK_M]).status, OK)
+
+    def test_wall_limit_skips_stay_ok(self) -> None:
+        # A slow-but-working solver: real timings then deliberately-skipped
+        # larger points. Skipped != failed.
+        cell = self._classify([self.OK_M, self.OK_M, self.SKIP, self.SKIP])
+        self.assertEqual(cell.status, OK)
+
+    def test_all_skipped_is_not_run(self) -> None:
+        self.assertEqual(self._classify([self.SKIP, self.SKIP]).status, NOT_RUN)
+
+    def test_all_empty_is_failed(self) -> None:
+        self.assertEqual(self._classify([{}, {}]).status, FAILED)
+
+    def test_crash_at_first_point_is_failed(self) -> None:
+        cell = self._classify([self.FAIL, {}, {}])
+        self.assertEqual(cell.status, FAILED)
+        self.assertIn("tile_fft", cell.reason)
+
+    def test_oom_tail_stays_ok_with_frontier(self) -> None:
+        # OOM only at the largest sizes is an expected, platform-dependent
+        # resource ceiling — the solver worked everywhere it could. It stays
+        # OK, but records the frontier for the diff.
+        cell = self._classify([self.OK_M, self.OK_M, self._OOM(), self.SKIP])
+        self.assertEqual(cell.status, OK)
+        self.assertEqual(cell.resource_frontier, "192")
+
+    def test_oom_everywhere_is_failed(self) -> None:
+        # OOM at the very first size (no valid data at all) means the solver
+        # can't run this experiment on this platform — surface as FAILED, but
+        # keep the frontier.
+        cell = self._classify([self._OOM(), self.SKIP])
+        self.assertEqual(cell.status, FAILED)
+        self.assertEqual(cell.resource_frontier, "64")
+
+    def test_crash_beats_oom_for_reason(self) -> None:
+        # A real crash anywhere makes the cell FAILED even if an OOM ceiling
+        # is also present — the crash is the actionable signal.
+        cell = self._classify([self.OK_M, self.FAIL, self._OOM(), self.SKIP])
+        self.assertEqual(cell.status, FAILED)
+        self.assertIn("tile_fft", cell.reason)
+
+    @staticmethod
+    def _OOM() -> dict:
+        return dict(_OOM_METRICS)
+
+
+class TestFrontierDiff(unittest.TestCase):
+    """Resource-ceiling frontier moves surface in the snapshot diff even when
+    both cells stay OK — the "did the OOM boundary move?" signal."""
+
+    @staticmethod
+    def _snap(frontier: str) -> dict:
+        return {
+            "score": 0.9,
+            "problems": {
+                "ns-grid": {
+                    "problem": "ns-grid",
+                    "solvers": ["warp_ns"],
+                    "rows": [
+                        {
+                            "suite": "cost",
+                            "experiment": "spatial_cost",
+                            "label": "cost/spatial_cost",
+                            "cells": {
+                                "warp_ns": {
+                                    "status": "ok",
+                                    "reason": "",
+                                    "category": "",
+                                    "stale": False,
+                                    "resource_frontier": frontier,
+                                }
+                            },
+                        }
+                    ],
+                }
+            },
+        }
+
+    def test_ceiling_moves_earlier_is_regression(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        d = diff_snapshots(self._snap("256"), self._snap("128"))
+        self.assertEqual(len(d["frontier_shifts"]), 1)
+        self.assertEqual(d["frontier_shifts"][0]["direction"], "regression")
+
+    def test_ceiling_moves_later_is_improvement(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        d = diff_snapshots(self._snap("128"), self._snap("256"))
+        self.assertEqual(d["frontier_shifts"][0]["direction"], "improvement")
+
+    def test_no_frontier_change_is_silent(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        d = diff_snapshots(self._snap("128"), self._snap("128"))
+        self.assertEqual(d["frontier_shifts"], [])
+
+
+class TestMetricDiff(unittest.TestCase):
+    """Numeric-metric shifts surface between cells that stay OK in both
+    snapshots — the signal the coarse status ladder hides."""
+
+    @staticmethod
+    def _snap(metrics: dict, status: str = "ok") -> dict:
+        return {
+            "score": 0.9,
+            "problems": {
+                "ns-grid": {
+                    "problem": "ns-grid",
+                    "solvers": ["exponax"],
+                    "rows": [
+                        {
+                            "suite": "gradient",
+                            "experiment": "fd_check",
+                            "label": "gradient/fd_check",
+                            "cells": {
+                                "exponax": {
+                                    "status": status,
+                                    "reason": "",
+                                    "category": "",
+                                    "stale": False,
+                                    "resource_frontier": "",
+                                    "metrics": metrics,
+                                }
+                            },
+                        }
+                    ],
+                }
+            },
+        }
+
+    def _diff(self, old_m: dict, new_m: dict, **kw) -> dict:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        return diff_snapshots(self._snap(old_m), self._snap(new_m, **kw))
+
+    def test_firm_metric_worsening_past_threshold_is_regression(self) -> None:
+        d = self._diff({"rel_err": 1e-4}, {"rel_err": 3e-4})
+        self.assertEqual(len(d["metric_shifts"]), 1)
+        s = d["metric_shifts"][0]
+        self.assertEqual(s["metric"], "rel_err")
+        self.assertEqual(s["direction"], "regression")
+        self.assertEqual(s["confidence"], "firm")
+
+    def test_firm_metric_bettering_past_threshold_is_improvement(self) -> None:
+        d = self._diff({"rel_err": 3e-4}, {"rel_err": 1e-4})
+        self.assertEqual(d["metric_shifts"][0]["direction"], "improvement")
+
+    def test_within_threshold_is_silent(self) -> None:
+        # rel_err threshold is 0.15 → a 5% move stays quiet.
+        d = self._diff({"rel_err": 1e-4}, {"rel_err": 1.05e-4})
+        self.assertEqual(d["metric_shifts"], [])
+
+    def test_higher_is_better_metric_direction(self) -> None:
+        # cosine: higher is better (threshold 0.02 relative).
+        worse = self._diff({"cosine": 0.99}, {"cosine": 0.90})
+        self.assertEqual(worse["metric_shifts"][0]["direction"], "regression")
+        better = self._diff({"cosine": 0.90}, {"cosine": 0.99})
+        self.assertEqual(better["metric_shifts"][0]["direction"], "improvement")
+
+    def test_timing_is_indicative_and_uses_wide_threshold(self) -> None:
+        # cost_time_s threshold is 0.35 → a 20% move stays quiet.
+        quiet = self._diff({"cost_time_s": 1.0}, {"cost_time_s": 1.2})
+        self.assertEqual(quiet["metric_shifts"], [])
+        # A 90% slowdown fires, flagged indicative.
+        loud = self._diff({"cost_time_s": 1.0}, {"cost_time_s": 1.9})
+        self.assertEqual(len(loud["metric_shifts"]), 1)
+        self.assertEqual(loud["metric_shifts"][0]["confidence"], "indicative")
+
+    def test_status_change_suppresses_metric_shift(self) -> None:
+        # A cell that changes status is reported by the main diff path; a
+        # numeric compare across the boundary would double-report it.
+        d = self._diff({"rel_err": 1e-4}, {"rel_err": 3e-4}, status="anomaly")
+        self.assertEqual(d["metric_shifts"], [])
+
+    def test_missing_metric_on_either_side_is_silent(self) -> None:
+        self.assertEqual(self._diff({}, {"rel_err": 3e-4})["metric_shifts"], [])
+        self.assertEqual(self._diff({"rel_err": 1e-4}, {})["metric_shifts"], [])
+
+    def test_legacy_snapshot_without_metrics_key_diffs_cleanly(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        old = self._snap({"rel_err": 1e-4})
+        # Strip the metrics key entirely, as a pre-feature snapshot would lack it.
+        del old["problems"]["ns-grid"]["rows"][0]["cells"]["exponax"]["metrics"]
+        d = diff_snapshots(old, self._snap({"rel_err": 3e-4}))
+        self.assertEqual(d["metric_shifts"], [])
+
+    def test_nonfinite_and_zero_baseline_are_safe(self) -> None:
+        # NaN / inf never produce a shift.
+        self.assertEqual(
+            self._diff({"rel_err": float("nan")}, {"rel_err": 1e-4})["metric_shifts"],
+            [],
+        )
+        # Zero baseline uses a tiny floor rather than dividing by zero.
+        d = self._diff({"final_loss": 0.0}, {"final_loss": 1e-4})
+        self.assertEqual(len(d["metric_shifts"]), 1)
+        self.assertEqual(d["metric_shifts"][0]["direction"], "regression")
+
+    def test_render_splits_firm_from_indicative(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots, render_diff_markdown
+
+        old = self._snap({"rel_err": 1e-4})
+        new = self._snap({"rel_err": 3e-4})
+        # Add an indicative timing shift on a second row.
+        for snap, t in ((old, 1.0), (new, 1.9)):
+            snap["problems"]["ns-grid"]["rows"].append(
+                {
+                    "suite": "cost",
+                    "experiment": "scaling",
+                    "label": "cost/scaling",
+                    "cells": {
+                        "exponax": {
+                            "status": "ok",
+                            "reason": "",
+                            "category": "",
+                            "stale": False,
+                            "resource_frontier": "",
+                            "metrics": {"cost_time_s": t},
+                        }
+                    },
+                }
+            )
+        md = render_diff_markdown(diff_snapshots(old, new))
+        self.assertIn("### 📊 Metric changes", md)
+        self.assertIn("### ⏱ Timing (indicative", md)
+        self.assertIn("2 metric change(s)", md)
+
+
+class TestMetricCollection(unittest.TestCase):
+    """``_collect_metrics_for_suite`` populates ``cell.metrics`` from v1 results."""
+
+    def _collect(
+        self, suite: str, exp_label: str, data: dict, solver: str = "s"
+    ) -> Cell:
+        from mosaic.benchmarks.core.status import _collect_metrics_for_suite
+
+        cells = {solver: Cell(OK)}
+        _collect_metrics_for_suite(suite, exp_label, data, cells)
+        return cells[solver]
+
+    def test_cost_median_time(self) -> None:
+        data = {
+            "schema_version": 1,
+            "sweep": {"key": "N", "values": ["16", "32"]},
+            "results": [
+                {"solver": "s", "sweep_value": "16", "metrics": {"mean": 1.0}},
+                {"solver": "s", "sweep_value": "32", "metrics": {"mean": 3.0}},
+            ],
+        }
+        cell = self._collect("cost", "scaling", data)
+        self.assertAlmostEqual(cell.metrics["cost_time_s"], 2.0)
+
+    def test_fd_check_best_rel_err_and_cosine(self) -> None:
+        data = {
+            "schema_version": 1,
+            "sweep": None,
+            "results": [
+                {
+                    "solver": "s",
+                    "sweep_value": None,
+                    "metrics": {
+                        "eps_sweep": {
+                            "0.01": {"rel_error": [0.5, 0.3], "cosine": 0.8},
+                            "0.001": {"rel_error": [0.1, 0.2], "cosine": 0.95},
+                        }
+                    },
+                }
+            ],
+        }
+        cell = self._collect("gradient", "fd_check", data)
+        # best_rel = min over eps of median rel_error = min(0.4, 0.15) = 0.15
+        self.assertAlmostEqual(cell.metrics["rel_err"], 0.15)
+        self.assertAlmostEqual(cell.metrics["cosine"], 0.95)
+
+    def test_forward_median_error_skips_invalid(self) -> None:
+        data = {
+            "schema_version": 1,
+            "sweep": {"key": "nu", "values": ["1", "2", "3"]},
+            "results": [
+                {
+                    "solver": "s",
+                    "sweep_value": "1",
+                    "metrics": {"error": 0.1, "valid": True},
+                },
+                {
+                    "solver": "s",
+                    "sweep_value": "2",
+                    "metrics": {"error": 0.3, "valid": True},
+                },
+                {"solver": "s", "sweep_value": "3", "metrics": {"valid": False}},
+            ],
+        }
+        cell = self._collect("forward", "agreement", data)
+        self.assertAlmostEqual(cell.metrics["fwd_error"], 0.2)
+
+    def test_optimization_final_ratio_from_trajectory(self) -> None:
+        data = {
+            "schema_version": 1,
+            "sweep": None,
+            "results": [
+                {
+                    "solver": "s",
+                    "sweep_value": None,
+                    "metrics": {"errors": [10.0, 5.0, 2.0]},
+                }
+            ],
+        }
+        cell = self._collect("optimization", "recovery", data)
+        self.assertAlmostEqual(cell.metrics["final_ratio"], 0.2)
+        self.assertAlmostEqual(cell.metrics["final_loss"], 2.0)
+
+    def test_non_ok_cell_gets_no_metrics(self) -> None:
+        from mosaic.benchmarks.core.status import _collect_metrics_for_suite
+
+        data = {
+            "schema_version": 1,
+            "sweep": None,
+            "results": [{"solver": "s", "sweep_value": None, "metrics": {"mean": 1.0}}],
+        }
+        cells = {"s": Cell(FAILED, "boom")}
+        _collect_metrics_for_suite("cost", "scaling", data, cells)
+        self.assertEqual(cells["s"].metrics, {})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -710,5 +710,189 @@ class TestMetricCollection(unittest.TestCase):
         self.assertEqual(cells["s"].metrics, {})
 
 
+class TestDiffScoping(unittest.TestCase):
+    """Only cells actually re-measured this run are attributed to the PR.
+
+    A ``benchmark:solver`` run re-runs one solver on one problem; every other
+    cell in the overlaid tree is carried-over baseline data. Baseline drift on
+    those cells (e.g. an infra flake recorded as failed) must not surface as a
+    PR regression (F3)."""
+
+    @staticmethod
+    def _cell(status: str, **extra) -> dict:
+        return {
+            "status": status,
+            "reason": "",
+            "category": "",
+            "stale": False,
+            "resource_frontier": extra.get("frontier", ""),
+            "metrics": extra.get("metrics", {}),
+        }
+
+    def _snap(self, cells_by_problem: dict) -> dict:
+        problems = {}
+        for problem, rows in cells_by_problem.items():
+            problems[problem] = {
+                "problem": problem,
+                "solvers": sorted({s for r in rows.values() for s in r}),
+                "rows": [
+                    {
+                        "suite": "cost",
+                        "experiment": lbl,
+                        "label": f"cost/{lbl}",
+                        "cells": c,
+                    }
+                    for lbl, c in rows.items()
+                ],
+            }
+        return {"score": 0.9, "problems": problems}
+
+    def _pair(self):
+        # jax-cfd (in scope) unchanged; PhiFlow (out of scope) drifts ok->fail.
+        old = self._snap(
+            {
+                "ns-grid": {
+                    "spatial": {
+                        "jax-cfd": self._cell("ok"),
+                        "PhiFlow": self._cell("ok"),
+                    }
+                }
+            }
+        )
+        new = self._snap(
+            {
+                "ns-grid": {
+                    "spatial": {
+                        "jax-cfd": self._cell("ok"),
+                        "PhiFlow": self._cell("failed"),
+                    }
+                }
+            }
+        )
+        return old, new
+
+    def test_unscoped_diff_reports_baseline_drift(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        old, new = self._pair()
+        d = diff_snapshots(old, new)  # measured=None → diff everything
+        self.assertEqual(len(d["regressions"]), 1)
+        self.assertEqual(d["regressions"][0]["solver"], "PhiFlow")
+
+    def test_scoped_diff_suppresses_out_of_scope_regression(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        old, new = self._pair()
+        d = diff_snapshots(
+            old, new, measured={"problems": ["ns-grid"], "solvers": ["jax-cfd"]}
+        )
+        self.assertEqual(d["regressions"], [])
+
+    def test_scoped_diff_keeps_in_scope_regression(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        old = self._snap({"ns-grid": {"spatial": {"jax-cfd": self._cell("ok")}}})
+        new = self._snap({"ns-grid": {"spatial": {"jax-cfd": self._cell("failed")}}})
+        d = diff_snapshots(
+            old, new, measured={"problems": ["ns-grid"], "solvers": ["jax-cfd"]}
+        )
+        self.assertEqual(len(d["regressions"]), 1)
+        self.assertEqual(d["regressions"][0]["solver"], "jax-cfd")
+
+    def test_scope_filters_by_problem_too(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        # jax-cfd drifts on a problem NOT in scope → suppressed.
+        old = self._snap({"ns-3d-grid": {"spatial": {"jax-cfd": self._cell("ok")}}})
+        new = self._snap({"ns-3d-grid": {"spatial": {"jax-cfd": self._cell("failed")}}})
+        d = diff_snapshots(
+            old, new, measured={"problems": ["ns-grid"], "solvers": ["jax-cfd"]}
+        )
+        self.assertEqual(d["regressions"], [])
+
+    def test_empty_problem_list_means_all_problems(self) -> None:
+        from mosaic.benchmarks.core.status import _cell_measured
+
+        m = {"problems": [], "solvers": ["jax-cfd"]}
+        self.assertTrue(_cell_measured(m, "ns-grid", "jax-cfd"))
+        self.assertTrue(_cell_measured(m, "ns-3d-grid", "jax-cfd"))
+        self.assertFalse(_cell_measured(m, "ns-grid", "PhiFlow"))
+
+    def test_scope_suppresses_frontier_and_metric_shifts(self) -> None:
+        from mosaic.benchmarks.core.status import diff_snapshots
+
+        old = self._snap(
+            {
+                "ns-grid": {
+                    "spatial": {
+                        "PhiFlow": self._cell(
+                            "ok", frontier="", metrics={"cost_time_s": 1.0}
+                        )
+                    }
+                }
+            }
+        )
+        new = self._snap(
+            {
+                "ns-grid": {
+                    "spatial": {
+                        "PhiFlow": self._cell(
+                            "ok", frontier="64", metrics={"cost_time_s": 5.0}
+                        )
+                    }
+                }
+            }
+        )
+        d = diff_snapshots(
+            old, new, measured={"problems": ["ns-grid"], "solvers": ["jax-cfd"]}
+        )
+        self.assertEqual(d["frontier_shifts"], [])
+        self.assertEqual(d["metric_shifts"], [])
+
+
+class TestDiffScopeHelper(unittest.TestCase):
+    """`_diff_scope` maps a run-scope dict to the diff's ``measured`` filter."""
+
+    def _import(self):
+        from mosaic.benchmarks.cli._status_helpers import _diff_scope
+
+        return _diff_scope
+
+    def test_none_scope_is_none(self) -> None:
+        self.assertIsNone(self._import()(None))
+
+    def test_all_label_is_none(self) -> None:
+        self.assertIsNone(
+            self._import()(
+                {"label": "all", "is_release_pr": False, "solvers": [], "problems": []}
+            )
+        )
+
+    def test_release_pr_is_none(self) -> None:
+        self.assertIsNone(
+            self._import()(
+                {"label": "", "is_release_pr": True, "solvers": [], "problems": []}
+            )
+        )
+
+    def test_solver_label_scopes(self) -> None:
+        m = self._import()(
+            {
+                "label": "solver",
+                "is_release_pr": False,
+                "solvers": ["jax-cfd"],
+                "problems": ["ns-grid"],
+            }
+        )
+        self.assertEqual(m, {"problems": ["ns-grid"], "solvers": ["jax-cfd"]})
+
+    def test_unlabelled_is_none(self) -> None:
+        self.assertIsNone(
+            self._import()(
+                {"label": "", "is_release_pr": False, "solvers": [], "problems": []}
+            )
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_coverage_banner.py
+++ b/tests/test_coverage_banner.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the PR-comment coverage banner (``_coverage_banner``).
+
+The banner makes "0 regressions" honest about what actually ran (F3 in the
+reporting audit): under ``benchmark:solver`` only changed solvers re-run, so
+unchanged cells are baseline copies that can never diff.
+"""
+
+from __future__ import annotations
+
+import json
+
+from mosaic.benchmarks.cli._status_helpers import _coverage_banner
+
+
+def _write(tmp_path, scope: dict) -> str:
+    p = tmp_path / "run-scope.json"
+    p.write_text(json.dumps(scope))
+    return str(p)
+
+
+def test_no_scope_file_is_empty():
+    assert _coverage_banner(None) == ""
+
+
+def test_unreadable_file_is_empty_not_fatal(tmp_path):
+    assert _coverage_banner(str(tmp_path / "missing.json")) == ""
+
+
+def test_all_label_reports_full_coverage(tmp_path):
+    banner = _coverage_banner(_write(tmp_path, {"label": "all"}))
+    assert "all solvers" in banner
+
+
+def test_release_pr_reports_full_coverage(tmp_path):
+    banner = _coverage_banner(_write(tmp_path, {"label": "", "is_release_pr": True}))
+    assert "all solvers" in banner
+
+
+def test_solver_label_names_what_ran(tmp_path):
+    banner = _coverage_banner(
+        _write(
+            tmp_path,
+            {"label": "solver", "solvers": ["exponax"], "problems": ["ns-grid"]},
+        )
+    )
+    assert "`exponax`" in banner
+    assert "`ns-grid`" in banner
+    assert "applies only to what ran" in banner
+
+
+def test_solver_label_accepts_csv_strings(tmp_path):
+    # CI may emit comma-joined strings rather than JSON arrays.
+    banner = _coverage_banner(
+        _write(
+            tmp_path,
+            {"label": "solver", "solvers": "a,b", "problems": "ns-grid,thermal"},
+        )
+    )
+    assert "`a`" in banner and "`b`" in banner
+
+
+def test_unlabelled_scope_states_partial(tmp_path):
+    banner = _coverage_banner(_write(tmp_path, {"label": ""}))
+    assert "partial run" in banner

--- a/tests/test_status_pipeline.py
+++ b/tests/test_status_pipeline.py
@@ -151,7 +151,11 @@ def test_score_computation():
 
 
 def test_cell_weight_key_mapping():
-    """cell_weight_key returns the correct SCORE_WEIGHTS key for each status."""
+    """cell_weight_key returns the correct SCORE_WEIGHTS key for each status.
+
+    Staleness is invisible to the score: a stale cell maps to the same key as
+    its fresh counterpart, so the ``*`` marker never moves the headline number.
+    """
     from mosaic.benchmarks.core.config import ExclusionCategory
     from mosaic.benchmarks.core.status import (
         ANOMALY,
@@ -164,11 +168,11 @@ def test_cell_weight_key_mapping():
     )
 
     assert cell_weight_key(Cell(status=OK)) == "ok"
-    assert cell_weight_key(Cell(status=OK, stale=True)) == "ok*"
+    assert cell_weight_key(Cell(status=OK, stale=True)) == "ok"
     assert cell_weight_key(Cell(status=ANOMALY)) == "anom"
-    assert cell_weight_key(Cell(status=ANOMALY, stale=True)) == "anom*"
+    assert cell_weight_key(Cell(status=ANOMALY, stale=True)) == "anom"
     assert cell_weight_key(Cell(status=FAILED)) == "fail"
-    assert cell_weight_key(Cell(status=FAILED, stale=True)) == "fail*"
+    assert cell_weight_key(Cell(status=FAILED, stale=True)) == "fail"
     assert cell_weight_key(Cell(status=NOT_RUN)) == "missing"
     assert (
         cell_weight_key(


### PR DESCRIPTION
## What

Improves the PR benchmark comment so it reliably surfaces the improvements and regressions contributors actually care about. Three changes:

1. **Numeric metric diffs** — the status ladder (ok/anom/fail) is coarse, so a solver that stays `ok` while its gradient rel-error doubles or its converged loss drifts produced *no* signal. The snapshot now carries per-cell numeric scalars and the diff surfaces same-status shifts in a **📊 Metric changes** section. Wall-clock is split into a separate **⏱ Timing (indicative)** section, since shared-runner contention makes it noisier than the deterministic correctness metrics.

2. **Scoped diff attribution (F3 fix)** — a `benchmark:solver` PR re-runs only the changed solver; every other cell is carried-over baseline data. Baseline drift on those cells (e.g. an infra flake) was being mis-attributed as a PR regression. [PR #133](https://github.com/pasteurlabs/mosaic/pull/133) showed 13 "regressions" for solvers/problems it never ran. `diff_snapshots` now scopes attribution to the cells actually re-measured this run (derived from `run-scope.json`).

3. **Coverage banner + always-a-verdict** — the comment states what was actually measured vs shown from baseline, and a skipped run (`benchmark:none`, unlabelled) now posts a one-line verdict instead of silence.

Also: stale runs no longer count toward the overall score.

## Why

See the reporting audit (findings F1–F6). This addresses F1/F5 (numeric deltas), F2 (firm vs indicative timing), F3 (scoped attribution), and F4 (always a verdict).

## Testing

- 66 unit tests across `test_status.py` / `test_coverage_banner.py` covering metric collection, diff, scoping, banner, and backward-compat with metric-less baselines.
- Note: the new metric/timing sections only render once `main` has a metrics-aware baseline (the first `publish-results.yml` run after this merges). A separate throwaway PR deliberately perturbs jax-cfd to demo them end-to-end.