### PR TITLE
test: smoke-test PR benchmark reporting (do not merge)

### DIFF
--- a/.github/workflows/reseed-baseline-snapshot.yml
+++ b/.github/workflows/reseed-baseline-snapshot.yml
@@ -1,0 +1,55 @@
+# TEMPORARY (do not merge): one-shot manual re-seed of the baseline snapshot.
+#
+# The metrics-reporting feature (#137) merged as benchmark:none, so
+# publish-results.yml never re-uploaded the baseline artifact and its
+# snapshot.json predates per-cell metrics. This workflow downloads the current
+# baseline result tree, regenerates snapshot.json with the current
+# (metrics-aware) `mosaic status`, and re-uploads the baseline artifact — so a
+# benchmark:solver demo PR has real metrics to diff against. No result data is
+# re-run; only the snapshot is regenerated. Delete this file after use.
+name: Reseed baseline snapshot (temp)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  reseed:
+    name: Regenerate baseline snapshot with metrics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install Mosaic
+        run: cp production.uv.lock uv.lock && uv sync --frozen
+
+      - name: Download current baseline artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          bash .github/scripts/fetch-artifact.sh baseline mosaic-results/
+          test -d mosaic-results && [ "$(ls mosaic-results/ 2>/dev/null)" ] \
+            || { echo "::error::baseline artifact empty or missing"; exit 1; }
+
+      - name: Regenerate snapshot + report (metrics-aware)
+        run: |
+          uv run mosaic status --format json > mosaic-results/snapshot.json
+          uv run mosaic status --format md > mosaic-results/status-report.md
+          echo "cells with metrics:"
+          python3 -c "import json;d=json.load(open('mosaic-results/snapshot.json'));print(sum(1 for p in d['problems'].values() for r in p['rows'] for c in r['cells'].values() if c.get('metrics')))"
+
+      - name: Re-upload baseline artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: baseline
+          path: mosaic-results/
+          overwrite: true
+          retention-days: 400

--- a/.github/workflows/reseed-baseline-snapshot.yml
+++ b/.github/workflows/reseed-baseline-snapshot.yml
@@ -9,8 +9,14 @@
 # re-run; only the snapshot is regenerated. Delete this file after use.
 name: Reseed baseline snapshot (temp)
 
+# workflow_dispatch requires the file on the default branch, which we don't want
+# for a throwaway. Trigger on push to this temp branch instead, but only when
+# this workflow file itself changes, so re-pushing perturbation commits doesn't
+# re-run it.
 on:
-  workflow_dispatch:
+  push:
+    branches: [dion/reporting-smoke-test]
+    paths: [.github/workflows/reseed-baseline-snapshot.yml]
 
 permissions:
   contents: read

--- a/mosaic/tesseracts/navier-stokes-grid/jax-cfd/tesseract_api.py
+++ b/mosaic/tesseracts/navier-stokes-grid/jax-cfd/tesseract_api.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Pasteur Labs. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from typing import Any
 
 import equinox as eqx
@@ -203,6 +204,34 @@ def _extract_pressure_jaxcfd(v_grid: Any, grid: Any, bc: Any) -> jnp.ndarray:
     return q.data.astype(jnp.float32)
 
 
+# ---------------------------------------------------------------------------
+# TEMPORARY: reporting-pipeline smoke test (remove before merge)
+#
+# Two knobs deliberately regress this solver so the PR benchmark comment has
+# real signal to render against the main baseline:
+#   * MOSAIC_TEST_ACCURACY_BIAS scales the final field, inflating forward error
+#     (a *firm* metric regression — deterministic, trustworthy cross-run).
+#   * MOSAIC_TEST_BUSY_ITERS runs throwaway FFT round-trips on the result to
+#     burn wall-clock (an *indicative* timing regression).
+# Both default ON with modest magnitudes; set to "1.0" / 0 to disable. The
+# block reverts cleanly — it only reads these two vars and touches `result`.
+_TEST_ACCURACY_BIAS = float(os.environ.get("MOSAIC_TEST_ACCURACY_BIAS", "1.10"))
+_TEST_BUSY_ITERS = int(os.environ.get("MOSAIC_TEST_BUSY_ITERS", "80"))
+
+
+def _test_perturb(result: jax.Array) -> jax.Array:
+    """Apply the temporary accuracy + timing perturbations to a result field."""
+    if _TEST_BUSY_ITERS > 0:
+        # Throwaway FFT→iFFT round-trips: real wall-clock, identity transform.
+        # Fold a 1e-30 slice back so JIT can't dead-code-eliminate the work.
+        def _busy(carry: jax.Array, _: Any) -> tuple[jax.Array, None]:
+            return jnp.real(jnp.fft.ifftn(jnp.fft.fftn(carry))), None
+
+        busy, _ = jax.lax.scan(_busy, result, None, length=_TEST_BUSY_ITERS)
+        result = result + 1e-30 * busy
+    return result * _TEST_ACCURACY_BIAS
+
+
 def cfd_fwd(
     v0: jnp.ndarray,
     density: float,
@@ -386,6 +415,8 @@ def cfd_fwd(
 
     if ndim == 2:
         result = result[:, :, None, :]  # (nx, ny, 2) → (nx, ny, 1, 2)
+    # TEMPORARY (reporting smoke test): perturb accuracy + timing. Remove before merge.
+    result = _test_perturb(result)
     return result, drag
 
 


### PR DESCRIPTION
## ⚠️ Do not merge — throwaway smoke test

Deliberately regresses **jax-cfd** so the PR benchmark comment (from #137) has real signal to render against the now-metrics-aware `main` baseline. Revert / close after inspecting the comment.

Two env-tunable knobs in the jax-cfd solver (defaults on):
- `MOSAIC_TEST_ACCURACY_BIAS=1.10` — scales the final field, inflating forward error → **firm** metric regression (📊 Metric changes).
- `MOSAIC_TEST_BUSY_ITERS=80` — throwaway FFT round-trips burn wall-clock → **indicative** timing regression (⏱ Timing).

Labeled `benchmark:solver`, so only jax-cfd on ns-grid re-runs; the diff compares those fresh results against the accumulated baseline. Also exercises the F3 scope fix: no spurious regressions should appear for solvers/problems this PR didn't run.

Expected in the comment:
- Coverage banner naming jax-cfd on ns-grid.
- 📊 Metric changes: jax-cfd forward error jumps.
- ⏱ Timing (indicative): jax-cfd median time rises.
- **No** regressions attributed to other solvers/problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)