### PR TITLE
fix(harness): apply the forward suite's status checks

### DIFF
--- a/mosaic/benchmarks/core/status.py
+++ b/mosaic/benchmarks/core/status.py
@@ -331,6 +331,66 @@ def _refine_cost(data: dict, cells: dict[str, Cell], checks: list) -> None:
             cells[solver] = Cell(*verdict)
 
 
+def _refine_forward(data: dict, cells: dict[str, Cell], checks: list) -> None:
+    """Walk ``checks`` against per-solver :class:`ForwardSummary` instances.
+
+    Forward results are ``by_solver[solver] = {error, valid}`` (non-swept) or
+    ``by_solver[solver][pval] = {error, valid}`` (swept), the same layout
+    :func:`_collect_forward_metrics` reads. Peer medians are formed per sweep
+    point across OK solvers, so a solver is compared against its peers at the
+    same resolution rather than against a pooled figure. First anomaly wins.
+    """
+    from .status_checks import ForwardSummary
+
+    if not checks:
+        return
+    by_solver = data.get("by_solver", {})
+    if not isinstance(by_solver, dict):
+        return
+
+    errs_per_solver: dict[str, dict[Any, float]] = {}
+    for solver, cell in cells.items():
+        if cell.status != OK:
+            continue
+        entry = by_solver.get(solver)
+        if not isinstance(entry, dict):
+            continue
+        # Swept: values are per-pval dicts. Non-swept: entry is the metrics dict.
+        swept = bool(entry) and all(isinstance(v, dict) for v in entry.values())
+        points = entry.items() if swept else [("", entry)]
+        errs: dict[Any, float] = {}
+        for pval, sub in points:
+            if not isinstance(sub, dict) or sub.get("valid") is False:
+                continue
+            err = sub.get("error")
+            if isinstance(err, int | float) and math.isfinite(err):
+                errs[pval] = float(err)
+        if errs:
+            errs_per_solver[solver] = errs
+
+    if not errs_per_solver:
+        return
+
+    # Peer median per sweep point; needs >= 2 solvers to mean anything, and
+    # median_k skips any point whose peer median is absent or non-positive.
+    peer_medians: dict[Any, float] = {}
+    all_pvals = {p for errs in errs_per_solver.values() for p in errs}
+    for pval in all_pvals:
+        vals = [e[pval] for e in errs_per_solver.values() if pval in e]
+        if len(vals) >= 2:
+            peer_medians[pval] = _median(vals)
+
+    for solver, errs in errs_per_solver.items():
+        summary = ForwardSummary(
+            errs_by_pval=dict(errs),
+            peer_medians_by_pval=dict(peer_medians),
+            n_valid_points=len(errs),
+        )
+        verdict = _run_checks(checks, summary)
+        if verdict:
+            cells[solver] = Cell(*verdict)
+
+
 def _refine_fd_check(data: dict, cells: dict[str, Cell], checks: list) -> None:
     """Anomaly checks for fd_check / source_fd_check.
 
@@ -829,7 +889,9 @@ def _refine_for_suite(
 ) -> None:
     """Dispatch suite-specific anomaly refinements (no-op without thresholds)."""
     view = _v1_to_legacy_view(data) if data.get("schema_version") == 1 else data
-    if suite == "cost":
+    if suite == "forward":
+        _refine_forward(view, cells, checks)
+    elif suite == "cost":
         _refine_cost(view, cells, checks)
     elif suite == "gradient" and exp_label.split("/")[0] in (
         "fd_check",

--- a/tests/core/test_status_checks.py
+++ b/tests/core/test_status_checks.py
@@ -26,9 +26,16 @@ Nothing enforced that contract, so the tests here pin:
 from __future__ import annotations
 
 import unittest
+from typing import ClassVar
 
 from mosaic.benchmarks.core import status_checks
-from mosaic.benchmarks.core.status import ANOMALY, OK, Cell, _refine_fd_check
+from mosaic.benchmarks.core.status import (
+    ANOMALY,
+    OK,
+    Cell,
+    _refine_fd_check,
+    _refine_for_suite,
+)
 from mosaic.benchmarks.core.status_checks import (
     CostSummary,
     FdCheckSummary,
@@ -197,3 +204,79 @@ class TestFdCheckPipeline(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestForwardPipeline:
+    """The forward suite must actually apply its configured checks.
+
+    ``ForwardSummary`` had no producer: ``_refine_for_suite`` dispatched cost,
+    gradient and optimization but not forward, and ``_classify_from_v1`` takes
+    a ``checks`` argument it never reads. So every ``"forward"`` entry in a
+    problem config was inert, including the two in ns-grid.
+    """
+
+    DATA: ClassVar[dict] = {
+        "by_solver": {
+            "peer_a": {
+                "16": {"error": 1.0, "valid": True},
+                "32": {"error": 1.0, "valid": True},
+            },
+            "peer_b": {
+                "16": {"error": 1.0, "valid": True},
+                "32": {"error": 1.0, "valid": True},
+            },
+            "outlier": {
+                "16": {"error": 10.0, "valid": True},
+                "32": {"error": 12.0, "valid": True},
+            },
+        }
+    }
+
+    def _run(self, checks, data=None):
+        data = self.DATA if data is None else data
+        cells = {s: Cell(OK) for s in data["by_solver"]}
+        _refine_for_suite("forward", "agreement", data, cells, checks)
+        return cells
+
+    def test_peer_outlier_is_flagged(self) -> None:
+        cells = self._run([median_k(3.0)])
+        assert cells["outlier"].status == ANOMALY
+        assert cells["peer_a"].status == OK
+        assert cells["peer_b"].status == OK
+
+    def test_absolute_threshold_is_applied(self) -> None:
+        cells = self._run([max_error(0.5)])
+        assert all(c.status == ANOMALY for c in cells.values())
+
+    def test_no_checks_is_a_noop(self) -> None:
+        assert all(c.status == OK for c in self._run([]).values())
+
+    def test_invalid_points_are_ignored(self) -> None:
+        data = {
+            "by_solver": {
+                "peer_a": {"16": {"error": 1.0, "valid": True}},
+                "peer_b": {"16": {"error": 1.0, "valid": True}},
+                # its only bad point is marked invalid, so nothing should fire
+                "outlier": {
+                    "16": {"error": 1.0, "valid": True},
+                    "32": {"error": 99.0, "valid": False},
+                },
+            }
+        }
+        assert self._run([median_k(3.0), max_error(2.0)], data)["outlier"].status == OK
+
+    def test_peer_median_needs_two_solvers(self) -> None:
+        """A lone solver has no peers, so a relative check must stay quiet."""
+        data = {"by_solver": {"only": {"16": {"error": 99.0, "valid": True}}}}
+        assert self._run([median_k(3.0)], data)["only"].status == OK
+
+    def test_non_swept_layout_is_handled(self) -> None:
+        """Non-swept forward results are a flat metrics dict per solver."""
+        data = {
+            "by_solver": {
+                "peer_a": {"error": 1.0, "valid": True},
+                "peer_b": {"error": 1.0, "valid": True},
+                "outlier": {"error": 50.0, "valid": True},
+            }
+        }
+        assert self._run([median_k(3.0)], data)["outlier"].status == ANOMALY


### PR DESCRIPTION
Refs #147.

Nothing constructed a `ForwardSummary`, so `median_k` and `max_error` never ran against a real result. `_refine_for_suite` dispatched cost, gradient and optimization but had no `forward` branch, and `_classify_from_v1` takes a `checks` argument it never reads.

Every other suite builds its summary (`CostSummary` at status.py:328, `FdCheckSummary` at 393, `OptimizationSummary` at 542). `ForwardSummary(` appeared nowhere in `mosaic/`.

So the forward suite published `ok` for any solver that produced finite numbers, however far off, unless an explicit exclusion had been written for it. The three forward entries in the ns-grid config have never gated anything.

Same shape as #141, where `min_cosine` returned the wrong status string. That was a typo; this is a missing producer.

## Approach

`_refine_forward` sits alongside the existing refiners and reads the same `by_solver` layout `_collect_forward_metrics` already walks for the metric column, including the non-swept flat-dict form.

Peer medians are formed per sweep point rather than pooled across the sweep, so a solver is compared with its peers at the same resolution. Pooling would let a cheap coarse point mask an expensive fine one. A point needs at least two solvers before it contributes a peer median, and `median_k` already skips points whose peer median is absent or non-positive.

## Tests

Six added to `TestForwardPipeline`, driving `_refine_for_suite` rather than the factories directly, so they fail if the dispatch is ever dropped again: peer-outlier flagged, absolute threshold applied, empty check list is a no-op, invalid sweep points ignored, a lone solver never trips a relative check, and the non-swept layout handled. Three fail on `main`; the other three pass either way by construction, since they assert nothing fires.

Suite is 568 passed, ruff clean.

## Benchmark run

This turns on gates that have never fired, so forward cells may flip on first contact. I cannot predict which from a local run, and the honest answer is that some probably will: that is the point of the change, but it is churn either way and worth seeing before merging.

Two of the existing forward anomalies are already handled through the exclusion table (`STAGGERED_MAC_BIAS` on `forward/baseline`, the XLB and PhiFlow entries on `forward/agreement/tgv`), so those should stay excluded rather than flip. Anything new that appears is a cell that was publishing `ok` while outside its configured threshold.

Happy to split the config thresholds out into a follow-up if you would rather land the mechanism first and tune numbers separately.
