### PR TITLE
chore: gate codecov on patch coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,10 +1,15 @@
 coverage:
   status:
-    project:
+    patch:
       default:
+        target: auto
+        threshold: 0.1%
         informational: false
         only_pulls: false
-    patch: off
+    project:
+      default:
+        informational: true
+        only_pulls: false
 comment:
   layout: "condensed_header, diff, condensed_files, condensed_footer"
   hide_project_coverage: false


### PR DESCRIPTION
Codecov now reports on **patch** coverage (how well the current change is covered) rather than overall project coverage, which fluctuates with unrelated code. Project coverage is retained as an informational (non-gating) status.

If a branch-protection rule or org ruleset requires the `codecov/project` status as a merge check, reroute it to `codecov/patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)