### PR TITLE
fix: result merge and plotting

### DIFF
--- a/.github/scripts/merge-results.py
+++ b/.github/scripts/merge-results.py
@@ -18,7 +18,8 @@ This script replaces that naive merge:
    ``structural-mesh/forward/baseline/result.json``).
 3. Deep-merge ``result.json`` files using the flat-list merge
    (schema_version=1: deduplicate by (solver, sweep_value), last wins).
-4. Merge ``fields.npz`` files (combine per-solver arrays).
+4. Merge ``fields.npz`` files at the solver level (union per-solver arrays
+   *and* the ``solver_names`` metadata array).
 5. Write merged results to the final output directory.
 
 Usage (in CI):
@@ -28,6 +29,7 @@ Usage (in CI):
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import sys
 from collections import defaultdict
@@ -99,27 +101,161 @@ def _merge_results(results: list[dict]) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# fields.npz merge
+# fields.npz merge — solver-level union
 # ---------------------------------------------------------------------------
+#
+# Field-snapshot NPZs come in two on-disk layouts (see
+# ``save_field_snapshots_npz`` in mosaic/benchmarks/core/io.py):
+#
+#   positional: ``{prefix}_{j}`` / ``{prefix}_{j}_{suffix}`` where ``j`` indexes
+#               into the file's ``solver_names`` array (gradient/optimization)
+#   flat:       ``{solver_name}_{suffix}`` (forward-agreement, e.g. ``exponax_0``
+#               where the trailing index is a *sweep* index, not a solver index)
+#
+# Each file is decoded against *its own* ``solver_names`` into a
+# ``{solver: {template: array}}`` map, where ``template`` is the original key
+# with the solver's slot replaced by a ``{S}`` placeholder. Re-encoding then
+# reproduces the exact key for whatever slot the solver lands in. Keys that
+# don't resolve to a known solver are kept as shared (later files win).
+#
+# Order matters: a flat key like ``exponax_0`` would also match the positional
+# pattern (prefix=``exponax``, idx=0). So each key is classified shared → flat →
+# positional, in that order, and only falls back to positional once it's neither
+# a known shared prefix nor prefixed by a known solver name.
+
+_POSITIONAL_RE = re.compile(r"^(?P<prefix>.+?)_(?P<idx>-?\d+)(?:_(?P<suffix>.*))?$")
+
+# Shared (non-per-solver) array prefixes used across mosaic's field NPZs. These
+# must be matched before positional decoding because some (e.g. ``consensus_0``)
+# carry a trailing integer that would otherwise be misread as a solver index.
+# Mirrors the ``shared_prefixes`` / shared-key sets in
+# mosaic/benchmarks/problems/**: forward (consensus, x_axis, ic, sweep_values),
+# gradient/jacobian (singular_values, singular_vectors, ic), recovery (rep_val,
+# rep_horizon, ic_true, ic_init), cost (sweep_values).
+_SHARED_PREFIXES = (
+    "sweep_values",
+    "solver_names",
+    "consensus",
+    "x_axis",
+    "singular_values",
+    "singular_vectors",
+    "rep_val",
+    "rep_horizon",
+    "ic_true",
+    "ic_init",
+    "ic",
+)
+
+
+def _is_shared_key(key: str) -> bool:
+    """True if *key* is a shared array (matched by prefix), not per-solver."""
+    return any(key == p or key.startswith(p + "_") for p in _SHARED_PREFIXES)
+
+
+def _decode_npz(
+    arrays: dict[str, np.ndarray], names: list[str]
+) -> tuple[dict[str, dict[str, np.ndarray]], dict[str, np.ndarray]]:
+    """Split a loaded NPZ into ({solver: {template: array}}, shared).
+
+    ``template`` carries a ``{S}`` placeholder where the solver identity sat,
+    so the slot is re-derivable at encode time regardless of layout.
+    """
+    # Longest-first so "ins_jl_diff" matches before "ins_jl" in the flat layout.
+    names_by_len = sorted(names, key=len, reverse=True)
+    per_solver: dict[str, dict[str, np.ndarray]] = {}
+    shared: dict[str, np.ndarray] = {}
+
+    for key, arr in arrays.items():
+        if key == "solver_names":
+            continue
+
+        # Shared arrays (consensus, ic, singular_values, …) are not per-solver.
+        # Checked first so e.g. "consensus_0" isn't decoded as solver-index 0.
+        if _is_shared_key(key):
+            shared[key] = arr
+            continue
+
+        # Flat: {solver_name}[_suffix]. Tried next — a flat key such as
+        # "exponax_0" must not be misread as positional prefix="exponax", idx=0.
+        matched = next(
+            (s for s in names_by_len if key == s or key.startswith(s + "_")),
+            None,
+        )
+        if matched is not None:
+            suffix = key[len(matched) :]  # "" or "_suffix"
+            per_solver.setdefault(matched, {})["{S}" + suffix] = arr
+            continue
+
+        # Positional: prefix_{j}[_suffix] where j indexes solver_names.
+        m = _POSITIONAL_RE.match(key)
+        if m:
+            idx = int(m.group("idx"))
+            if 0 <= idx < len(names):
+                suffix = m.group("suffix")
+                template = (
+                    f"{m.group('prefix')}_{{S}}"
+                    if suffix is None
+                    else f"{m.group('prefix')}_{{S}}_{suffix}"
+                )
+                per_solver.setdefault(names[idx], {})[template] = arr
+                continue
+
+        shared[key] = arr
+
+    return per_solver, shared
+
+
+def _encode_template(template: str, idx: int, name: str) -> str:
+    """Reproduce an on-disk key from a ``{S}`` template.
+
+    Positional templates carry a ``_{S}`` index slot → fill with ``idx``;
+    flat templates start with ``{S}`` → fill with the solver ``name``.
+    """
+    if template.startswith("{S}"):
+        return name + template[len("{S}") :]
+    return template.replace("{S}", str(idx))
 
 
 def _merge_npz(paths: list[Path], out_path: Path) -> None:
-    """Merge multiple .npz files, combining per-solver arrays."""
-    merged: dict[str, np.ndarray] = {}
+    """Solver-level union of field-snapshot NPZs (later files win per solver).
+
+    Each CI job's NPZ carries only the solvers that job ran — including the
+    ``solver_names`` metadata array. A naive key-level merge would keep every
+    per-solver array but let the last artifact's ``solver_names`` overwrite
+    the others'; the field plots read their solver set from that array, so
+    the merged file would silently hide the other jobs' solvers. Decode each
+    file against its own ``solver_names``, union per solver, and re-encode.
+    """
+    merged_solver: dict[str, dict[str, np.ndarray]] = {}
+    merged_shared: dict[str, np.ndarray] = {}
+    ordered: list[str] = []
     for p in paths:
         try:
             with np.load(str(p), allow_pickle=False) as data:
-                for key in data.files:
-                    # Later artifacts override earlier ones for the same key.
-                    # Metadata keys (sweep_values, solver_names, etc.) are
-                    # overwritten; per-solver keys accumulate.
-                    merged[key] = np.asarray(data[key])
+                arrays = {k: np.asarray(data[k]) for k in data.files}
         except Exception as e:
             print(f"  warning: failed to merge {p}: {e}", file=sys.stderr)
             continue
-    if merged:
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        np.savez(out_path, **merged)
+        names = [str(n) for n in arrays.get("solver_names", np.array([]))]
+        per_solver, shared = _decode_npz(arrays, names)
+        merged_solver.update(per_solver)
+        merged_shared.update(shared)
+        ordered += [n for n in names if n not in ordered]
+
+    ordered += [s for s in merged_solver if s not in ordered]
+    if not ordered and not merged_shared:
+        return
+
+    payload: dict[str, np.ndarray] = {}
+    if ordered:
+        payload["solver_names"] = np.array(ordered)
+    payload.update(merged_shared)
+    for idx, name in enumerate(ordered):
+        for template, arr in merged_solver.get(name, {}).items():
+            payload[_encode_template(template, idx, name)] = arr
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(out_path, **payload)
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/overlay-results.py
+++ b/.github/scripts/overlay-results.py
@@ -15,8 +15,8 @@ only ran Exponax writes a ``gradient_fields.npz`` containing just Exponax's
 arrays (and a one-entry ``solver_names``). A naive file-level copy would
 clobber every baseline solver's fields, so the field plots — which read
 their solver set straight from the NPZ's ``solver_names`` — would then show
-only Exponax. :func:`_merge_npz_pair` instead unions the per-solver arrays,
-PR winning per solver, so baseline solvers survive.
+only Exponax. The solver-level union from merge-results.py instead merges
+the per-solver arrays, PR winning per solver, so baseline solvers survive.
 
 All other files (``*.png``, ``*.gif``, ``params.json``) are overlaid with
 simple file-level copy (PR wins).
@@ -33,12 +33,9 @@ from __future__ import annotations
 # Reuse the solver-level merge logic from merge-results.py.
 import importlib.util
 import json
-import re
 import shutil
 import sys
 from pathlib import Path
-
-import numpy as np
 
 _spec = importlib.util.spec_from_file_location(
     "merge_results", Path(__file__).parent / "merge-results.py"
@@ -46,6 +43,7 @@ _spec = importlib.util.spec_from_file_location(
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 _merge_result_pair = _mod._merge_result_pair
+_merge_npz = _mod._merge_npz
 
 
 def _load_json(path: Path) -> dict:
@@ -57,155 +55,6 @@ def _save_json(data: dict, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
-
-
-# ── per-solver NPZ overlay ──────────────────────────────────────────────────
-#
-# Field-snapshot NPZs come in two on-disk layouts (see
-# ``save_field_snapshots_npz`` in mosaic/benchmarks/core/io.py):
-#
-#   positional: ``{prefix}_{j}`` / ``{prefix}_{j}_{suffix}`` where ``j`` indexes
-#               into the file's ``solver_names`` array (gradient/optimization)
-#   flat:       ``{solver_name}_{suffix}`` (forward-agreement, e.g. ``exponax_0``
-#               where the trailing index is a *sweep* index, not a solver index)
-#
-# We decode each file against *its own* ``solver_names`` into a
-# ``{solver: {template: array}}`` map, where ``template`` is the original key
-# with the solver's slot replaced by a ``{S}`` placeholder. Re-encoding then
-# reproduces the exact key for whatever slot the solver lands in. Keys that
-# don't resolve to a known solver are kept as shared (PR wins).
-#
-# Order matters: a flat key like ``exponax_0`` would also match the positional
-# pattern (prefix=``exponax``, idx=0). So each key is classified shared → flat →
-# positional, in that order, and only falls back to positional once it's neither
-# a known shared prefix nor prefixed by a known solver name.
-
-_POSITIONAL_RE = re.compile(r"^(?P<prefix>.+?)_(?P<idx>-?\d+)(?:_(?P<suffix>.*))?$")
-
-# Shared (non-per-solver) array prefixes used across mosaic's field NPZs. These
-# must be matched before positional decoding because some (e.g. ``consensus_0``)
-# carry a trailing integer that would otherwise be misread as a solver index.
-# Mirrors the ``shared_prefixes`` / shared-key sets in
-# mosaic/benchmarks/problems/**: forward (consensus, x_axis, ic, sweep_values),
-# gradient/jacobian (singular_values, singular_vectors, ic), recovery (rep_val,
-# rep_horizon, ic_true, ic_init), cost (sweep_values).
-_SHARED_PREFIXES = (
-    "sweep_values",
-    "solver_names",
-    "consensus",
-    "x_axis",
-    "singular_values",
-    "singular_vectors",
-    "rep_val",
-    "rep_horizon",
-    "ic_true",
-    "ic_init",
-    "ic",
-)
-
-
-def _is_shared_key(key: str) -> bool:
-    """True if *key* is a shared array (matched by prefix), not per-solver."""
-    return any(key == p or key.startswith(p + "_") for p in _SHARED_PREFIXES)
-
-
-def _decode_npz(
-    arrays: dict[str, np.ndarray], names: list[str]
-) -> tuple[dict[str, dict[str, np.ndarray]], dict[str, np.ndarray]]:
-    """Split a loaded NPZ into ({solver: {template: array}}, shared).
-
-    ``template`` carries a ``{S}`` placeholder where the solver identity sat,
-    so the slot is re-derivable at encode time regardless of layout.
-    """
-    # Longest-first so "ins_jl_diff" matches before "ins_jl" in the flat layout.
-    names_by_len = sorted(names, key=len, reverse=True)
-    per_solver: dict[str, dict[str, np.ndarray]] = {}
-    shared: dict[str, np.ndarray] = {}
-
-    for key, arr in arrays.items():
-        if key == "solver_names":
-            continue
-
-        # Shared arrays (consensus, ic, singular_values, …) are not per-solver.
-        # Checked first so e.g. "consensus_0" isn't decoded as solver-index 0.
-        if _is_shared_key(key):
-            shared[key] = arr
-            continue
-
-        # Flat: {solver_name}[_suffix]. Tried next — a flat key such as
-        # "exponax_0" must not be misread as positional prefix="exponax", idx=0.
-        matched = next(
-            (s for s in names_by_len if key == s or key.startswith(s + "_")),
-            None,
-        )
-        if matched is not None:
-            suffix = key[len(matched) :]  # "" or "_suffix"
-            per_solver.setdefault(matched, {})["{S}" + suffix] = arr
-            continue
-
-        # Positional: prefix_{j}[_suffix] where j indexes solver_names.
-        m = _POSITIONAL_RE.match(key)
-        if m:
-            idx = int(m.group("idx"))
-            if 0 <= idx < len(names):
-                suffix = m.group("suffix")
-                template = (
-                    f"{m.group('prefix')}_{{S}}"
-                    if suffix is None
-                    else f"{m.group('prefix')}_{{S}}_{suffix}"
-                )
-                per_solver.setdefault(names[idx], {})[template] = arr
-                continue
-
-        shared[key] = arr
-
-    return per_solver, shared
-
-
-def _encode_template(template: str, idx: int, name: str) -> str:
-    """Reproduce an on-disk key from a ``{S}`` template.
-
-    Positional templates carry a ``_{S}`` index slot → fill with ``idx``;
-    flat templates start with ``{S}`` → fill with the solver ``name``.
-    """
-    if template.startswith("{S}"):
-        return name + template[len("{S}") :]
-    return template.replace("{S}", str(idx))
-
-
-def _merge_npz_pair(baseline_path: Path, pr_path: Path, out_path: Path) -> None:
-    """Solver-level union of two field-snapshot NPZs (PR wins per solver).
-
-    Baseline solvers absent from the PR are carried forward; shared
-    (non-per-solver) arrays take the PR copy when present.
-    """
-    with np.load(str(baseline_path), allow_pickle=False) as b:
-        base_arrays = {k: np.asarray(b[k]) for k in b.files}
-    with np.load(str(pr_path), allow_pickle=False) as p:
-        pr_arrays = {k: np.asarray(p[k]) for k in p.files}
-
-    base_names = [str(n) for n in base_arrays.get("solver_names", np.array([]))]
-    pr_names = [str(n) for n in pr_arrays.get("solver_names", np.array([]))]
-
-    base_solver, base_shared = _decode_npz(base_arrays, base_names)
-    pr_solver, pr_shared = _decode_npz(pr_arrays, pr_names)
-
-    # PR wins per solver; baseline-only solvers carried forward.
-    merged_solver: dict[str, dict[str, np.ndarray]] = {**base_solver, **pr_solver}
-    merged_shared: dict[str, np.ndarray] = {**base_shared, **pr_shared}
-
-    # Canonical ordering: PR solvers first, then baseline-only.
-    ordered = list(pr_names) + [s for s in base_names if s not in pr_names]
-    ordered += [s for s in merged_solver if s not in ordered]
-
-    payload: dict[str, np.ndarray] = {"solver_names": np.array(ordered)}
-    payload.update(merged_shared)
-    for idx, name in enumerate(ordered):
-        for template, arr in merged_solver.get(name, {}).items():
-            payload[_encode_template(template, idx, name)] = arr
-
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    np.savez(out_path, **payload)
 
 
 def main() -> None:
@@ -278,8 +127,9 @@ def main() -> None:
         elif in_baseline and in_pr and relpath.endswith(".npz"):
             # Solver-level NPZ union so a single-solver PR doesn't clobber the
             # baseline solvers' field arrays (which drive the field plots).
+            # Later files win per solver, so the PR copy overrides the baseline.
             try:
-                _merge_npz_pair(baseline_files[relpath], pr_files[relpath], out_path)
+                _merge_npz([baseline_files[relpath], pr_files[relpath]], out_path)
                 n_npz_merged += 1
             except Exception as e:
                 print(

--- a/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
+++ b/mosaic/benchmarks/problems/navier_stokes_3d_grid/plots.py
@@ -24,11 +24,8 @@ from mosaic.benchmarks.core.io import (
 )
 from mosaic.benchmarks.problems.shared.plots.optimization import _save_animation
 from mosaic.benchmarks.problems.shared.plots.style import (
-    NS_ORDER,
     RCPARAMS,
-    STRUCTURAL_ORDER,
     TEXTWIDTH,
-    THERMAL_ORDER,
     apply_style,
     dedup_handles,
     fig_shared_legend,
@@ -37,6 +34,7 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     paper_image_grid,
     resolve_solver_alias,
     save_fig,
+    solver_order_for_problem,
     solver_plot_props,
     solver_props,
     solver_styles,
@@ -403,17 +401,6 @@ def _plot_per_sigma_grid(
             save_fig(fig_sg, f"recovery_sigma_{sv_str}", out_dir)
 
 
-def _solver_order_for(cfg_name: str) -> list[str]:
-    """Heuristic solver-ordering pick by problem name."""
-    if "ns" in cfg_name:
-        return NS_ORDER
-    if "structural" in cfg_name:
-        return STRUCTURAL_ORDER
-    if "thermal" in cfg_name:
-        return THERMAL_ORDER
-    return NS_ORDER
-
-
 def _plot_ns_recovery(
     ax: Any, data: dict, solver_order: list[str], title: str, seen: set[str]
 ) -> None:
@@ -423,7 +410,7 @@ def _plot_ns_recovery(
     # ``by_sweep`` is keyed by spec.name (display form); build alias→display.
     alias_to_display: dict[str, str] = {}
     for display_name in by_sweep:
-        a = resolve_solver_alias(display_name)
+        a = resolve_solver_alias(display_name, prefer=solver_order)
         if a is not None:
             alias_to_display[a] = display_name
 
@@ -485,7 +472,7 @@ def _plot_recovery_experiment(
     fig.subplots_adjust(bottom=0.36, top=0.90, left=0.13, right=0.96)
 
     seen: set[str] = set()
-    solver_order = _solver_order_for(cfg.name)
+    solver_order = solver_order_for_problem(cfg.name)
 
     if "by_sweep" in data or "by_horizon" in data:
         _plot_ns_recovery(
@@ -520,7 +507,7 @@ def _plot_recovery_experiment(
         # ``by_solver`` keyed by spec.name; bridge to alias for ordering.
         alias_to_display: dict[str, str] = {}
         for display_name in by_solver:
-            a = resolve_solver_alias(display_name)
+            a = resolve_solver_alias(display_name, prefer=solver_order)
             if a is not None:
                 alias_to_display[a] = display_name
         for alias in solver_order:

--- a/mosaic/benchmarks/problems/shared/plots/cost_overview.py
+++ b/mosaic/benchmarks/problems/shared/plots/cost_overview.py
@@ -22,13 +22,12 @@ import numpy as np
 
 from mosaic.benchmarks.core.io import load_json, results_dir
 from mosaic.benchmarks.problems.shared.plots.style import (
-    NS_ORDER,
     RCPARAMS,
-    STRUCTURAL_ORDER,
-    THERMAL_ORDER,
     dedup_handles,
     make_handle,
     paper_grid,
+    resolve_solver_alias,
+    solver_order_for_problem,
     solver_props,
 )
 
@@ -185,17 +184,12 @@ def plot_cost_overview(
     failure_types_seen: set[str] = set()
 
     for solver in all_solvers:
-        alias = solver.lower().replace("-", "_").replace(".", "_")
-        # Direct alias lookup: SOLVER_STYLES keys are aliases (jax_cfd, openfoam, ...)
-        # and result.json keys are display names ("OpenFOAM", "jax-cfd"). Normalise.
-        from mosaic.benchmarks.problems.shared.plots.style import SOLVER_STYLES
-
-        if alias not in SOLVER_STYLES:
-            # Try matching by stripping common label tweaks.
-            for key, (label, *_rest) in SOLVER_STYLES.items():
-                if label == solver:
-                    alias = key
-                    break
+        # SOLVER_STYLES keys are aliases (jax_cfd, openfoam, ...) and
+        # result.json keys are display names ("OpenFOAM", "jax-cfd"); prefer
+        # this domain's aliases so shared labels (e.g. the structural and
+        # thermal "FEniCS") resolve into ``solver_order`` and stay in the
+        # legend. Unresolvable names fall through to the grey style.
+        alias = resolve_solver_alias(solver, prefer=solver_order) or solver
         _label, color, ls, mk = solver_props(alias)
         kw = {
             "color": color,
@@ -340,17 +334,6 @@ def plot_cost_overview(
     print(f"Saved {out}")
 
 
-# Default solver-order lookup keyed by ``Problem.name``. Lets the helper
-# below auto-pick the right ordering without each domain importing the
-# style module to thread the constant through.
-_DEFAULT_ORDER_BY_PROBLEM: dict[str, list[str]] = {
-    "ns-grid": NS_ORDER,
-    "ns-3d-grid": NS_ORDER,
-    "structural-mesh": STRUCTURAL_ORDER,
-    "thermal-mesh": THERMAL_ORDER,
-}
-
-
 def plot_cost_overview_for(
     cfg: Any,
     *,
@@ -361,13 +344,13 @@ def plot_cost_overview_for(
 
     Reads ``cfg.tesseract_dir.name`` as the results subdirectory and
     ``cfg.category_label`` (with ``cfg.name`` fallback) as the panel
-    label. ``solver_order`` defaults to the per-domain entry in
-    ``_DEFAULT_ORDER_BY_PROBLEM`` keyed by ``cfg.name``.
+    label. ``solver_order`` defaults to the problem's canonical ordering
+    via :func:`solver_order_for_problem`.
     """
     out_dir = results_dir() / cfg.name / "_extra"
     out_dir.mkdir(parents=True, exist_ok=True)
     if solver_order is None:
-        solver_order = _DEFAULT_ORDER_BY_PROBLEM.get(cfg.name, cfg.solver_names)
+        solver_order = solver_order_for_problem(cfg.name)
     plot_cost_overview(
         out_dir,
         subdir=cfg.tesseract_dir.name,

--- a/mosaic/benchmarks/problems/shared/plots/forward.py
+++ b/mosaic/benchmarks/problems/shared/plots/forward.py
@@ -36,6 +36,7 @@ from mosaic.benchmarks.problems.shared.plots.style import (
     resolve_solver_alias,
     save_fig,
     solver_legend,
+    solver_order_for_problem,
     solver_plot_props,
     solver_props,
     solver_styles,
@@ -293,27 +294,29 @@ def _agreement_plot_curves_styled(
 ) -> list[float]:
     """Plot per-solver error-vs-sweep curves onto ``ax``.
 
-    Walks :data:`NS_ORDER`, drawing every solver that produced at least
-    one valid finite positive error. Updates ``seen`` so the caller can
-    build a legend covering only solvers that actually appear, and returns
-    the flat list of plotted error values (so the caller can pick a tick
-    strategy that stays legible when the spread is sub-decade).
+    Walks the problem's canonical solver order, drawing every solver that
+    produced at least one valid finite positive error. Updates ``seen`` so
+    the caller can build a legend covering only solvers that actually
+    appear, and returns the flat list of plotted error values (so the
+    caller can pick a tick strategy that stays legible when the spread is
+    sub-decade).
     """
     all_errors: list[float] = []
     by_param = data.get("by_param", {})
     if not by_param:
         return all_errors
+    order = solver_order_for_problem(cfg.name)
     params = sorted(by_param.keys(), key=float)
     # ``by_param`` may be keyed by alias ('jax_cfd') or display name ('jax-cfd')
     # depending on the run; resolve every present key to its canonical alias so
-    # the NS_ORDER walk finds the data regardless of which form was written.
+    # the ordered walk finds the data regardless of which form was written.
     alias_to_key: dict[str, str] = {}
     for p in params:
         for k in by_param[p]:
-            a = resolve_solver_alias(k) or k
+            a = resolve_solver_alias(k, prefer=order) or k
             alias_to_key.setdefault(a, k)
 
-    for solver in NS_ORDER:
+    for solver in order:
         data_key = alias_to_key.get(solver)
         if data_key is None:
             continue
@@ -443,7 +446,11 @@ def _agreement_figure(
     )
 
     handles = dedup_handles(
-        [make_handle(s) for s in NS_ORDER if s in seen and s in SOLVER_STYLES]
+        [
+            make_handle(s)
+            for s in solver_order_for_problem(cfg.name)
+            if s in seen and s in SOLVER_STYLES
+        ]
     )
     if handles:
         fig.legend(

--- a/mosaic/benchmarks/problems/shared/plots/style.py
+++ b/mosaic/benchmarks/problems/shared/plots/style.py
@@ -18,6 +18,7 @@ during ``mosaic run --plots-only`` or saved off-line.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -150,7 +151,7 @@ def _norm_solver_name(s: str) -> str:
     return s.lower().replace("-", "").replace("_", "").replace(".", "").replace(" ", "")
 
 
-def resolve_solver_alias(name: str) -> str | None:
+def resolve_solver_alias(name: str, prefer: Sequence[str] | None = None) -> str | None:
     """Map a solver string to its canonical alias in :data:`SOLVER_STYLES`.
 
     Handles three forms:
@@ -161,14 +162,38 @@ def resolve_solver_alias(name: str) -> str | None:
     Returns ``None`` if no entry matches. Used to bridge ``result.json``
     keys (which are ``spec.name``) and ``NS_ORDER`` / ``FEM_ORDER`` /
     ``SOLVER_STYLES`` (which are alias-keyed).
+
+    ``prefer`` breaks label ties between domains: structural and thermal
+    both label their FEniCS solver "FEniCS", so a bare lookup resolves to
+    whichever entry comes first in :data:`SOLVER_STYLES` (the structural
+    one) — and thermal plots that filter against :data:`THERMAL_ORDER`
+    then silently drop the solver. Pass the domain's canonical order
+    (e.g. ``THERMAL_ORDER``) so matches from that domain win.
     """
     if name in SOLVER_STYLES:
         return name
     target = _norm_solver_name(name)
-    for k, v in SOLVER_STYLES.items():
-        if _norm_solver_name(k) == target or _norm_solver_name(v[0]) == target:
-            return k
-    return None
+    matches = [
+        k
+        for k, v in SOLVER_STYLES.items()
+        if _norm_solver_name(k) == target or _norm_solver_name(v[0]) == target
+    ]
+    if not matches:
+        return None
+    if prefer:
+        for p in prefer:
+            if p in matches:
+                return p
+    return matches[0]
+
+
+def solver_order_for_problem(name: str) -> list[str]:
+    """Canonical solver ordering for a problem, picked by problem name."""
+    if "thermal" in name:
+        return THERMAL_ORDER
+    if "structural" in name:
+        return STRUCTURAL_ORDER
+    return NS_ORDER
 
 
 def solver_props(name: str) -> tuple:

--- a/mosaic/benchmarks/problems/structural_mesh/extras.py
+++ b/mosaic/benchmarks/problems/structural_mesh/extras.py
@@ -336,7 +336,7 @@ def _plot_convergence(
         # ``by_solver`` keyed by spec.name (display form); bridge to alias.
         alias_to_display: dict[str, str] = {}
         for display_name in by_solver:
-            a = resolve_solver_alias(display_name)
+            a = resolve_solver_alias(display_name, prefer=STRUCTURAL_ORDER)
             if a is not None:
                 alias_to_display[a] = display_name
         for alias in STRUCTURAL_ORDER:
@@ -428,7 +428,7 @@ def _topopt_overview_generate(out_dir: Path) -> None:
         # canonical order while resolving back to the npz key when needed.
         _npz_alias_to_display: dict[str, str] = {}
         for display_name in npz_solvers:
-            a = resolve_solver_alias(display_name)
+            a = resolve_solver_alias(display_name, prefer=STRUCTURAL_ORDER)
             if a is not None:
                 _npz_alias_to_display[a] = display_name
         field_solvers = [s for s in STRUCTURAL_ORDER if s in _npz_alias_to_display]

--- a/mosaic/benchmarks/problems/structural_mesh/plots.py
+++ b/mosaic/benchmarks/problems/structural_mesh/plots.py
@@ -28,15 +28,14 @@ from mosaic.benchmarks.problems.shared.plots.optimization import (
 from mosaic.benchmarks.problems.shared.plots.style import (
     RCPARAMS,
     SOLVER_STYLES,
-    STRUCTURAL_ORDER,
     TEXTWIDTH,
-    THERMAL_ORDER,
     dedup_handles,
     make_handle,
     paper_image_grid,
     paper_row,
     resolve_solver_alias,
     save_fig,
+    solver_order_for_problem,
     solver_props,
     solver_styles,
 )
@@ -134,15 +133,6 @@ def _voxel_facecolors(
     return fc
 
 
-def _solver_order_for(cfg_name: str) -> list[str]:
-    """Best-effort solver-ordering pick based on problem name."""
-    if "structural" in cfg_name:
-        return STRUCTURAL_ORDER
-    if "thermal" in cfg_name:
-        return THERMAL_ORDER
-    return STRUCTURAL_ORDER
-
-
 def _field_solver_names(npz: Any, by_solver: dict | None = None) -> list[str]:
     """Per-field solver names aligned with the ``rho_final_<j>`` arrays.
 
@@ -204,7 +194,7 @@ def _plot_topopt_figure(
     data = v1_to_legacy(load_json(result_path))
     by_solver = data.get("by_solver", {})
 
-    solver_order = _solver_order_for(cfg.name)
+    solver_order = solver_order_for_problem(cfg.name)
 
     # Optional fields npz + physics params
     fields_path = out_dir / "topopt_fields.npz"
@@ -242,7 +232,7 @@ def _plot_topopt_figure(
     # ── Compliance vs iteration ──────────────────────────────────────────────
     present: set[str] = set()
     for solver, sdata in by_solver.items():
-        alias = resolve_solver_alias(solver)
+        alias = resolve_solver_alias(solver, prefer=solver_order)
         _label, color, ls, _mk = solver_props(alias or solver)
         compliances = sdata.get("compliances", [])
         if compliances:
@@ -269,7 +259,7 @@ def _plot_topopt_figure(
             rho_xyz = rho_flat.reshape(nz, ny, nx).transpose(2, 1, 0)
             filled = rho_xyz > _THRESH
 
-            alias = resolve_solver_alias(sname)
+            alias = resolve_solver_alias(sname, prefer=solver_order)
             _label, color, _ls, _mk = solver_props(alias or sname)
             fc = _voxel_facecolors(rho_xyz, filled, color)
             ax.voxels(filled, facecolors=fc, edgecolors=fc, shade=True)

--- a/mosaic/benchmarks/problems/thermal_mesh/extras.py
+++ b/mosaic/benchmarks/problems/thermal_mesh/extras.py
@@ -104,7 +104,7 @@ def _conductivity_overview_generate(out_dir: Path) -> None:
                 continue
             alias_to_display: dict[str, str] = {}
             for display_name in by_solver_d:
-                a = resolve_solver_alias(display_name)
+                a = resolve_solver_alias(display_name, prefer=THERMAL_ORDER)
                 if a is not None:
                     alias_to_display[a] = display_name
             for alias in THERMAL_ORDER:
@@ -176,7 +176,7 @@ def _conductivity_overview_generate(out_dir: Path) -> None:
             ]
             alias_to_display: dict[str, str] = {}
             for display_name in _display_names:
-                a = resolve_solver_alias(display_name)
+                a = resolve_solver_alias(display_name, prefer=THERMAL_ORDER)
                 if a is not None:
                     alias_to_display[a] = display_name
             for alias in THERMAL_ORDER:

--- a/mosaic/benchmarks/problems/thermal_mesh/plots.py
+++ b/mosaic/benchmarks/problems/thermal_mesh/plots.py
@@ -13,33 +13,13 @@ from mosaic.benchmarks.core.config import Problem
 from mosaic.benchmarks.core.io import load_json, results_dir, v1_to_legacy
 from mosaic.benchmarks.problems.shared.plots.style import (
     RCPARAMS,
-    SOLVER_STYLES,
     THERMAL_ORDER,
-    _norm_solver_name,
     paper_row,
+    resolve_solver_alias,
     save_fig,
     solver_plot_props,
     solver_styles,
 )
-
-# Map a result's solver display name (e.g. "FEniCS") to its *thermal* style
-# alias. The global resolve_solver_alias() is domain-blind: "FEniCS" and
-# "Firedrake" share a label with their structural entries and resolve to
-# ``*_structural`` first, which isn't in THERMAL_ORDER, so the shared legend
-# silently dropped them. Resolving against the thermal aliases fixes that.
-# Keyed on the normalised label so "torch-fem" matches the "TorchFEM" style.
-_THERMAL_ALIAS_BY_NORM = {
-    _norm_solver_name(SOLVER_STYLES[a][0]): a
-    for a in THERMAL_ORDER
-    if a in SOLVER_STYLES
-}
-
-
-def _thermal_alias(name: str) -> str | None:
-    """Resolve a solver display name to its THERMAL_ORDER alias, or None."""
-    if name in THERMAL_ORDER:
-        return name
-    return _THERMAL_ALIAS_BY_NORM.get(_norm_solver_name(name))
 
 
 def plot_conductivity_recovery(
@@ -85,7 +65,7 @@ def plot_conductivity_recovery(
                 label=sty.get("label", name),
                 **solver_plot_props(sty, marker=False),
             )
-            alias = _thermal_alias(name)
+            alias = resolve_solver_alias(name, prefer=THERMAL_ORDER)
             if alias is not None:
                 handles_by_alias[alias] = line
 

--- a/tests/core/test_merge_results_npz.py
+++ b/tests/core/test_merge_results_npz.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the solver-level NPZ merge in .github/scripts/merge-results.py.
+
+In CI the CPU and GPU jobs for the same (suite, problem) each write a
+``fields.npz`` containing only the solvers that job ran — including the
+``solver_names`` metadata array the field plots read their solver set from.
+The merge must union the per-solver arrays *and* ``solver_names``; a naive
+key-level merge keeps every array but lets the last artifact's
+``solver_names`` hide the other job's solvers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / ".github" / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "merge_results", _SCRIPTS / "merge-results.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+_merge_npz = _mod._merge_npz
+
+
+def _write_npz(path: Path, **arrays) -> Path:
+    np.savez(path, **arrays)
+    return path
+
+
+class TestMergeNpzSolverUnion:
+    def test_unions_solver_names_across_artifacts(self, tmp_path: Path):
+        # Thermal-mesh split: CPU job runs the FEM triple, GPU job the rest.
+        cpu = _write_npz(
+            tmp_path / "cpu.npz",
+            solver_names=np.array(["deal.II", "FEniCS", "Firedrake"]),
+            sweep_values=np.array([0.05, 0.1]),
+            **{"deal.II_0": np.array(1.0), "FEniCS_0": np.array(2.0)},
+            Firedrake_0=np.array(3.0),
+        )
+        gpu = _write_npz(
+            tmp_path / "gpu.npz",
+            solver_names=np.array(["JAX-FEM", "torch-fem"]),
+            sweep_values=np.array([0.05, 0.1]),
+            **{"JAX-FEM_0": np.array(4.0), "torch-fem_0": np.array(5.0)},
+        )
+        out = tmp_path / "merged.npz"
+        _merge_npz([cpu, gpu], out)
+
+        with np.load(out) as data:
+            names = [str(n) for n in data["solver_names"]]
+            assert names == ["deal.II", "FEniCS", "Firedrake", "JAX-FEM", "torch-fem"]
+            for key, val in [
+                ("deal.II_0", 1.0),
+                ("FEniCS_0", 2.0),
+                ("Firedrake_0", 3.0),
+                ("JAX-FEM_0", 4.0),
+                ("torch-fem_0", 5.0),
+            ]:
+                assert float(data[key]) == val
+
+    def test_later_artifact_wins_per_solver(self, tmp_path: Path):
+        first = _write_npz(
+            tmp_path / "a.npz",
+            solver_names=np.array(["exponax"]),
+            exponax_0=np.array([1.0]),
+        )
+        second = _write_npz(
+            tmp_path / "b.npz",
+            solver_names=np.array(["exponax"]),
+            exponax_0=np.array([9.0]),
+        )
+        out = tmp_path / "merged.npz"
+        _merge_npz([first, second], out)
+
+        with np.load(out) as data:
+            assert [str(n) for n in data["solver_names"]] == ["exponax"]
+            np.testing.assert_array_equal(data["exponax_0"], [9.0])
+
+    def test_positional_layout_reindexed(self, tmp_path: Path):
+        # Gradient-suite layout: grad_{j} indexes into solver_names. After the
+        # union the indices must follow the merged ordering, not the per-file one.
+        a = _write_npz(
+            tmp_path / "a.npz",
+            solver_names=np.array(["solver_x"]),
+            grad_0=np.array([1.0]),
+        )
+        b = _write_npz(
+            tmp_path / "b.npz",
+            solver_names=np.array(["solver_y"]),
+            grad_0=np.array([2.0]),
+        )
+        out = tmp_path / "merged.npz"
+        _merge_npz([a, b], out)
+
+        with np.load(out) as data:
+            assert [str(n) for n in data["solver_names"]] == ["solver_x", "solver_y"]
+            np.testing.assert_array_equal(data["grad_0"], [1.0])
+            np.testing.assert_array_equal(data["grad_1"], [2.0])
+
+    def test_shared_arrays_survive(self, tmp_path: Path):
+        # consensus_0 carries a trailing integer that must not be misread as a
+        # solver index; later artifacts win for shared keys.
+        a = _write_npz(
+            tmp_path / "a.npz",
+            solver_names=np.array(["solver_x"]),
+            solver_x_0=np.array([1.0]),
+            consensus_0=np.array([0.5]),
+            x_axis=np.array([0.0, 1.0]),
+        )
+        b = _write_npz(
+            tmp_path / "b.npz",
+            solver_names=np.array(["solver_y"]),
+            solver_y_0=np.array([2.0]),
+            consensus_0=np.array([0.7]),
+        )
+        out = tmp_path / "merged.npz"
+        _merge_npz([a, b], out)
+
+        with np.load(out) as data:
+            np.testing.assert_array_equal(data["consensus_0"], [0.7])
+            np.testing.assert_array_equal(data["x_axis"], [0.0, 1.0])
+            np.testing.assert_array_equal(data["solver_x_0"], [1.0])
+            np.testing.assert_array_equal(data["solver_y_0"], [2.0])
+
+    def test_unreadable_file_skipped(self, tmp_path: Path):
+        good = _write_npz(
+            tmp_path / "good.npz",
+            solver_names=np.array(["solver_x"]),
+            solver_x_0=np.array([1.0]),
+        )
+        bad = tmp_path / "bad.npz"
+        bad.write_bytes(b"not an npz")
+        out = tmp_path / "merged.npz"
+        _merge_npz([bad, good], out)
+
+        with np.load(out) as data:
+            assert [str(n) for n in data["solver_names"]] == ["solver_x"]

--- a/tests/test_solver_alias.py
+++ b/tests/test_solver_alias.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for domain-aware solver alias resolution.
+
+Structural and thermal solvers share display labels ("FEniCS", "Firedrake",
+"deal.II"), so a bare lookup resolves to whichever SOLVER_STYLES entry comes
+first — and plots that filter the result against a domain order list then
+silently drop the solver. ``prefer`` breaks the tie toward the caller's domain.
+"""
+
+from __future__ import annotations
+
+from mosaic.benchmarks.problems.shared.plots.style import (
+    STRUCTURAL_ORDER,
+    THERMAL_ORDER,
+    resolve_solver_alias,
+    solver_order_for_problem,
+)
+
+
+class TestResolveSolverAlias:
+    def test_alias_key_returned_as_is(self):
+        assert resolve_solver_alias("openfoam") == "openfoam"
+
+    def test_prefer_breaks_label_tie_toward_thermal(self):
+        for label, expected in [
+            ("FEniCS", "fenics_heat"),
+            ("Firedrake", "firedrake_heat"),
+            ("deal.II", "dealii_heat"),
+        ]:
+            alias = resolve_solver_alias(label, prefer=THERMAL_ORDER)
+            assert alias == expected
+            assert alias in THERMAL_ORDER
+
+    def test_prefer_breaks_label_tie_toward_structural(self):
+        for label, expected in [
+            ("FEniCS", "fenics_structural"),
+            ("Firedrake", "firedrake_structural"),
+            ("deal.II", "dealii_structural"),
+        ]:
+            alias = resolve_solver_alias(label, prefer=STRUCTURAL_ORDER)
+            assert alias == expected
+            assert alias in STRUCTURAL_ORDER
+
+    def test_prefer_is_noop_for_unambiguous_labels(self):
+        assert resolve_solver_alias("JAX-FEM", prefer=THERMAL_ORDER) == "jax_fem"
+        assert resolve_solver_alias("torch-fem", prefer=THERMAL_ORDER) == (
+            "torch_fem_thermal"
+        )
+        assert resolve_solver_alias("OpenFOAM") == "openfoam"
+
+    def test_unknown_name_returns_none(self):
+        assert resolve_solver_alias("no-such-solver", prefer=THERMAL_ORDER) is None
+
+
+class TestSolverOrderForProblem:
+    def test_domain_pick(self):
+        assert solver_order_for_problem("thermal-mesh") is THERMAL_ORDER
+        assert solver_order_for_problem("structural-mesh") is STRUCTURAL_ORDER
+        # NS problems (and unknown names) fall back to the fluid ordering.
+        assert "jax_cfd" in solver_order_for_problem("ns-grid")
+        assert "jax_cfd" in solver_order_for_problem("ns-3d-grid")


### PR DESCRIPTION
Fixes thermal-mesh plots (forward/agreement and others) showing only JAX-FEM and torch-fem while deal.II, FEniCS, and Firedrake are missing. Two independent bugs produced the same two-solver symptom.

## Problem

**CI merge clobbers `solver_names`.** The CPU and GPU benchmark jobs each write a `fields.npz` containing only the solvers that job ran — including the `solver_names` metadata array the field plots read their solver set from. `merge-results.py` merged NPZs key-by-key with last-wins, so the per-solver arrays all survived but the GPU artifact's two-entry `solver_names` overwrote the CPU one. The published thermal agreement NPZ confirms it: arrays for all five solvers, `solver_names = ["JAX-FEM", "torch-fem"]`. `result.json` was unaffected (it gets a proper per-solver deep merge), which is why the data looked complete while the plots didn't.

**Domain-blind alias resolution.** Structural and thermal solvers share display labels ("FEniCS", "Firedrake", "deal.II"), so `resolve_solver_alias("FEniCS")` returned `fenics_structural` — which is not in `THERMAL_ORDER`, silently dropping the solver from any thermal plot or legend that filters against that list. Only `jax_fem` (alias shared across domains) and `torch_fem_thermal` (unique label) survived. `thermal_mesh/plots.py` had a local workaround for exactly this.

A third latent bug: the styled agreement figure walked `NS_ORDER` unconditionally, so it drew nothing for FEM domains.

## Approach

- `merge-results.py` now merges NPZs at the solver level: decode each artifact against its own `solver_names` (both flat and positional layouts), union per solver with later-wins, and re-encode with a merged `solver_names`. The decode/encode machinery moved here from `overlay-results.py`, which already did this correctly for PR-on-baseline overlays and now imports it instead of carrying its own copy. Overlay semantics are unchanged (PR wins per solver).
- `resolve_solver_alias` takes an optional `prefer` order list that breaks label ties toward the caller's domain. Callers that filter against a domain order pass it; the `thermal_mesh/plots.py` workaround is folded into the shared helper.
- New `solver_order_for_problem()` replaces three copies of the same problem-name heuristic (`cost_overview.py`, `structural_mesh/plots.py`, `navier_stokes_3d_grid/plots.py`) and the hardcoded `NS_ORDER` walk in the agreement figure.

## Tests

- `tests/core/test_merge_results_npz.py`: solver-name union across artifacts, later-wins per solver, positional re-indexing, shared-array handling, unreadable-file skip.
- `tests/test_solver_alias.py`: label ties resolve toward the preferred domain, unambiguous labels unaffected, order pick per problem.