### PR TITLE
fix: status-check overrides replace suite defaults

### DIFF
--- a/mosaic/benchmarks/core/status.py
+++ b/mosaic/benchmarks/core/status.py
@@ -143,42 +143,46 @@ def compute_score(cells: list[Cell]) -> tuple[float | None, int]:
 
 
 def _lookup_check(cfg: Problem, suite: str, experiment: str) -> list:
-    """Return the merged list of check callables for (suite, experiment).
+    """Return the check callables for (suite, experiment).
 
-    Sources are accumulated in order of increasing specificity; suite-level
-    defaults come first so per-experiment checks can override them by
-    short-circuiting (the classifier walks the list and stops on the first
-    ``anom``, so more-specific entries should appear *later* — placing them
-    at the tail ensures they're consulted last and thus have the final say
-    only when earlier checks pass).
+    The most-specific source that supplies any checks *replaces* the less
+    specific ones — it does not merge with them. Replacement (rather than
+    accumulation) is required because the classifier short-circuits on the
+    first ``anom`` (see :func:`_run_checks`): an appended looser override
+    could never overturn a stricter default that fires first. Every override
+    site in the configs already lists a complete set of checks for its suite,
+    so replacement matches the intent.
 
-    Sources:
-      1. ``cfg.status_checks[suite]`` — suite-level defaults
+    Sources, from most to least specific — the first non-empty one wins:
+      1. ``cfg.experiments[key].params["status_check"]`` — inline override on
+         the ``.add_experiment(..., status_check=[...])`` call
       2. ``cfg.status_checks[<suite>/<experiment>]`` /
          ``cfg.status_checks[<suite>/<leading>]`` — per-experiment / per-IC
-         overrides from the Problem-level dict
-      3. ``cfg.experiments[full].params["status_check"]`` — inline overrides
-         set on the ``.add_experiment(..., status_check=[...])`` call
+         override from the Problem-level dict
+      3. ``cfg.status_checks[suite]`` — suite-level defaults
 
-    Each source is a list of callables (or a single callable); both shapes
-    are normalised via :func:`status_checks.normalize`.
+    Experiment labels may include an IC sub-dir (e.g. ``agreement/tgv``), so
+    the full label is tried before its leading token. Each source is a list
+    of callables (or a single callable); both shapes are normalised via
+    :func:`status_checks.normalize`.
     """
     from .status_checks import normalize
 
     checks = cfg.status_checks
-    merged: list = []
-    merged.extend(normalize(checks.get(suite)))
-    # experiment labels may include an IC sub-dir (e.g. "agreement/tgv");
-    # match both the full label and the leading token.
+    # Most-specific first: full experiment label, then its leading token.
     for key in (f"{suite}/{experiment}", f"{suite}/{experiment.split('/', 1)[0]}"):
-        merged.extend(normalize(checks.get(key)))
         exp = cfg.experiments.get(key)
-        if exp is not None:
-            inline = (
-                exp.params.get("status_check") if isinstance(exp.params, dict) else None
-            )
-            merged.extend(normalize(inline))
-    return merged
+        inline = (
+            exp.params.get("status_check")
+            if exp and isinstance(exp.params, dict)
+            else None
+        )
+        if inline:
+            return normalize(inline)
+        override = checks.get(key)
+        if override:
+            return normalize(override)
+    return normalize(checks.get(suite))
 
 
 @dataclass

--- a/tests/core/test_status_checks.py
+++ b/tests/core/test_status_checks.py
@@ -29,12 +29,16 @@ import unittest
 from typing import ClassVar
 
 from mosaic.benchmarks.core import status_checks
+from mosaic.benchmarks.core.config import Problem
+from mosaic.benchmarks.core.experiment import kernel
 from mosaic.benchmarks.core.status import (
     ANOMALY,
     OK,
     Cell,
+    _lookup_check,
     _refine_fd_check,
     _refine_for_suite,
+    _run_checks,
 )
 from mosaic.benchmarks.core.status_checks import (
     CostSummary,
@@ -280,3 +284,72 @@ class TestForwardPipeline:
             }
         }
         assert self._run([median_k(3.0)], data)["outlier"].status == ANOMALY
+
+
+@kernel(sweep_mode="none")
+def _noop(t, ctx) -> dict:
+    return {"metrics": {}}
+
+
+class TestLookupCheckPrecedence:
+    """A more-specific status-check source *replaces* the suite default.
+
+    The regression this pins: ns-grid gives ``forward/agreement/multimode`` a
+    looser ``max_error(1.5)`` override, but ``_lookup_check`` used to *append*
+    it to the suite default ``max_error(0.5)``. Since ``_run_checks``
+    short-circuits on the first anomaly, the stricter default fired first and
+    the override never applied — flagging every solver at error 1.03. Sources
+    must replace, not accumulate.
+    """
+
+    # An error that trips the strict default (0.5) but not the loose override
+    # (1.5) — the exact multimode case from the v0.2.0 run.
+    SUMMARY: ClassVar[ForwardSummary] = ForwardSummary(
+        errs_by_pval={"0.001": 1.03},
+        peer_medians_by_pval={"0.001": 1.03},
+        n_valid_points=1,
+    )
+
+    def _problem(self, status_checks: dict) -> Problem:
+        return Problem(name="t", status_checks=status_checks)
+
+    def test_suite_default_applies_without_an_override(self) -> None:
+        p = self._problem({"forward": [median_k(3.0), max_error(0.5)]})
+        checks = _lookup_check(p, "forward", "agreement/tgv")
+        assert _run_checks(checks, self.SUMMARY) is not None
+
+    def test_per_ic_override_replaces_the_suite_default(self) -> None:
+        # The looser per-IC override must win outright — no strict default
+        # left behind to fire first.
+        p = self._problem(
+            {
+                "forward": [median_k(3.0), max_error(0.5)],
+                "forward/agreement/multimode": [median_k(3.0), max_error(1.5)],
+            }
+        )
+        checks = _lookup_check(p, "forward", "agreement/multimode")
+        assert len(checks) == 2
+        assert _run_checks(checks, self.SUMMARY) is None
+
+    def test_full_label_beats_leading_token(self) -> None:
+        # A per-IC key ("agreement/multimode") is more specific than a
+        # per-experiment key ("agreement") and must take precedence.
+        p = self._problem(
+            {
+                "forward/agreement": [max_error(0.5)],
+                "forward/agreement/multimode": [max_error(1.5)],
+            }
+        )
+        checks = _lookup_check(p, "forward", "agreement/multimode")
+        assert _run_checks(checks, self.SUMMARY) is None
+
+    def test_inline_override_replaces_dict_sources(self) -> None:
+        p = self._problem({"forward": [max_error(0.5)]})
+        p.add_experiment(
+            "forward/loose", _noop, physics={"N": 16}, status_check=[max_error(1.5)]
+        )
+        checks = _lookup_check(p, "forward", "loose")
+        assert _run_checks(checks, self.SUMMARY) is None
+
+    def test_no_config_means_no_checks(self) -> None:
+        assert _lookup_check(self._problem({}), "forward", "agreement/tgv") == []


### PR DESCRIPTION
## Problem

In the v0.2.0 full-benchmark run (#149), **all 7 `ns-grid` solvers** were flagged 🟠 anom on `forward/agreement/multimode` with the *identical* message:

> `error 1.03 at sweep=0.001 > max_error=0.5`

When every solver trips a check with the exact same number, it's the check that's wrong, not the solvers.

## Root cause

`_lookup_check` accumulated checks across specificity levels (suite default → per-experiment/per-IC → inline) and returned the **merged** list. But `_run_checks` short-circuits on the *first* anomaly, so an appended **looser** override can never overturn a stricter default that fires first.

The ns-grid config intends a looser bound for the multimode IC:

```python
"forward":                        [median_k(3.0), max_error(0.5)],
"forward/agreement/multimode":    [median_k(3.0), max_error(1.5)],   # looser
```

The merged list became `[median_k(3.0), max_error(0.5), median_k(3.0), max_error(1.5)]`, so `max_error(0.5)` fired at 1.03 before the intended `max_error(1.5)` was ever consulted. Latent until #148 activated forward-suite status checks.

## Fix

The most-specific source that supplies any checks now **replaces** the less-specific ones instead of appending. Every override site in the configs already lists a complete set of checks for its suite, so replacement matches author intent (and is why the checks are bare closures with no type tag to merge on).

## Verification

- New `TestLookupCheckPrecedence` (the function had no direct tests): per-IC override replaces suite default, full label beats leading token, inline replaces dict sources, suite default applies without an override, empty config → no checks.
- Repro against the real config now returns **ok** (no anomaly) for multimode while `agreement/tgv` (no override) still correctly flags at 1.03.
- `tests/core/test_status_checks.py`, `test_status.py`, `test_status_pipeline.py`, `test_coords.py` all pass (70 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)