### PR TITLE
feat: compare release PRs against the previous release

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -338,6 +338,38 @@ jobs:
             fi
           fi
 
+      # Release PRs compare against the *previous release* rather than main's
+      # rolling baseline: fetch the prior release's results asset (which bundles
+      # its snapshot.json) into the same baseline/ location the extract step
+      # below reads from. The release PR runs the full suite and its results are
+      # NOT overlaid onto the baseline (the overlay step above is gated off for
+      # release PRs), so this is a clean release-vs-release diff. Degrades to no
+      # diff (plain report) when there's no prior release or its asset predates
+      # the results-bundle scheme (older releases have no mosaic-results-*.zip).
+      - name: Download previous release snapshot
+        id: prev_release
+        if: >-
+          needs.plan.outputs.should_run == 'true'
+          && needs.plan.outputs.is_release_pr == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PREV_TAG=$(gh release view --json tagName --jq '.tagName' 2>/dev/null || true)
+          echo "tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+          if [ -z "$PREV_TAG" ]; then
+            echo "No prior release found — release comparison will be skipped."
+            exit 0
+          fi
+          mkdir -p /tmp/prev-release
+          if ! gh release download "$PREV_TAG" \
+              --pattern 'mosaic-results-*.zip' --dir /tmp/prev-release 2>/dev/null; then
+            echo "Prior release $PREV_TAG has no mosaic-results-*.zip asset — skipping comparison."
+            exit 0
+          fi
+          mkdir -p baseline/mosaic-results
+          unzip -q -o /tmp/prev-release/mosaic-results-*.zip -d baseline/mosaic-results
+          echo "Fetched previous release snapshot ($PREV_TAG)"
+
       # The status snapshot/report exist only to summarise *this run's* results
       # against the baseline. When no benchmarks ran (e.g. benchmark:none or a
       # docs-only PR), the result tree is just a copy of the baseline, so the
@@ -384,6 +416,11 @@ jobs:
           DIFF_FLAG=""
           if [[ -n "${{ steps.baseline.outputs.path }}" ]]; then
             DIFF_FLAG="--diff-against ${{ steps.baseline.outputs.path }}"
+            # Release PRs diff against the previous release tag; name it in the
+            # header so the comment reads "vs v0.1.1" instead of "vs base".
+            if [[ "${{ needs.plan.outputs.is_release_pr }}" == "true" && -n "${{ steps.prev_release.outputs.tag }}" ]]; then
+              DIFF_FLAG="$DIFF_FLAG --diff-label ${{ steps.prev_release.outputs.tag }}"
+            fi
           fi
           uv run mosaic status --format md $DIFF_FLAG --run-scope run-scope.json > status-report.md
 

--- a/mosaic/benchmarks/cli/_status_helpers.py
+++ b/mosaic/benchmarks/cli/_status_helpers.py
@@ -109,6 +109,7 @@ def _status_emit_snapshot(
     output_format: str,
     diff_against: str | None,
     run_scope: str | None = None,
+    diff_label: str | None = None,
 ) -> None:
     """Handle --format md/json: build snapshot(s) and emit to stdout.
 
@@ -157,7 +158,8 @@ def _status_emit_snapshot(
             measured = _diff_scope(_load_run_scope(run_scope))
             out_parts.append(
                 render_diff_markdown(
-                    diff_snapshots(old_snapshot, new_snapshot, measured=measured)
+                    diff_snapshots(old_snapshot, new_snapshot, measured=measured),
+                    label=diff_label or "base",
                 )
             )
             diff_rendered = True

--- a/mosaic/benchmarks/cli/status.py
+++ b/mosaic/benchmarks/cli/status.py
@@ -60,6 +60,12 @@ def status(
         "With --format md, prepend a coverage banner stating what was actually measured "
         "this run vs. shown from the baseline.",
     ),
+    diff_label: str | None = typer.Option(
+        None,
+        "--diff-label",
+        help="Name for the --diff-against comparison point in the diff header "
+        "(e.g. a prior release tag like 'v0.1.1'). Defaults to 'base'.",
+    ),
     output_dir: Path | None = typer.Option(  # noqa: B008
         None,
         "--output-dir",
@@ -105,7 +111,9 @@ def status(
 
     # ── non-rich formats: skip terminal rendering and emit a snapshot ─────
     if format in ("md", "json"):
-        _status_emit_snapshot(problem_list, suite_list, format, diff_against, run_scope)
+        _status_emit_snapshot(
+            problem_list, suite_list, format, diff_against, run_scope, diff_label
+        )
         return
 
     failure_records: list[

--- a/mosaic/benchmarks/core/status.py
+++ b/mosaic/benchmarks/core/status.py
@@ -2030,9 +2030,14 @@ def _render_metric_shifts(lines: list[str], metric_shifts: list[dict]) -> None:
         lines.append("")
 
 
-def render_diff_markdown(diff: dict) -> str:
-    """Render a snapshot diff as markdown suitable for a PR comment."""
-    lines: list[str] = ["## Status diff vs base", "", _MD_LEGEND, ""]
+def render_diff_markdown(diff: dict, label: str = "base") -> str:
+    """Render a snapshot diff as markdown suitable for a PR comment.
+
+    ``label`` names the comparison point in the header (e.g. ``"base"`` for a
+    PR-vs-main diff, or a prior release tag like ``"v0.1.1"`` for a
+    release-to-release diff).
+    """
+    lines: list[str] = [f"## Status diff vs {label}", "", _MD_LEGEND, ""]
     n_reg = len(diff["regressions"])
     n_imp = len(diff["improvements"])
     n_oth = len(diff["other"])

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -613,6 +613,18 @@ class TestMetricDiff(unittest.TestCase):
         self.assertIn("### ⏱ Timing (indicative", md)
         self.assertIn("2 metric change(s)", md)
 
+    def test_render_label_names_the_comparison_point(self) -> None:
+        """The diff header names its comparison point (e.g. a release tag)."""
+        from mosaic.benchmarks.core.status import diff_snapshots, render_diff_markdown
+
+        diff = diff_snapshots(
+            self._snap({"rel_err": 1e-4}), self._snap({"rel_err": 1e-4})
+        )
+        self.assertIn("## Status diff vs base", render_diff_markdown(diff))
+        self.assertIn(
+            "## Status diff vs v0.1.1", render_diff_markdown(diff, label="v0.1.1")
+        )
+
 
 class TestMetricCollection(unittest.TestCase):
     """``_collect_metrics_for_suite`` populates ``cell.metrics`` from v1 results."""


### PR DESCRIPTION
## Motivation

PRs are diffed against `main`'s rolling baseline, but **release PRs** (`bot/release/*`) ran the full suite and then *skipped the diff entirely*. There was no automated "what got better/worse since the last release" signal — exactly the gap that made triaging the v0.2.0 anomalies (#149) hard: most turned out to be newly-*visible*, not newly-*broken*, but nothing said so.

## What this does

On a release PR, fetch the **previous release's** results asset (`mosaic-results-<tag>.zip`, already attached to every release by `publish-results.yml`, which bundles its `snapshot.json`) into the same `baseline/` location the report step already reads from. The existing `diff_snapshots` / `--diff-against` machinery then renders a **release-vs-release diff** in the PR comment — regressions, improvements, metric shifts, resource-frontier moves — with no changes to the diff logic itself.

Almost all the machinery already existed; this just points it at the right snapshot for release PRs.

### Details
- **Clean comparison:** for release PRs the overlay-onto-baseline step is already gated off, so `mosaic-results/` stays as the pure release results (not merged with baseline). `_diff_scope` already returns `None` for release PRs (full-suite runs diff everything).
- **Header naming:** adds a `--diff-label` option to `mosaic status` (default `"base"`) so the header reads `## Status diff vs v0.1.1` instead of `## Status diff vs base`.
- **Graceful degradation:** if there's no prior release, or the prior release predates the results-bundle scheme (older releases have `release-*.zip`, not `mosaic-results-*.zip`), the step no-ops and the PR gets a plain report with no diff — never fails the job.

## Verification

- Confirmed `v0.1.1`'s release asset contains a top-level `snapshot.json`; `mosaic compare` renders end-to-end against it.
- `render_diff_markdown(diff, label="v0.1.1")` → `## Status diff vs v0.1.1`; default → `## Status diff vs base`. New test `test_render_label_names_the_comparison_point`.
- `benchmark.yml` passes YAML + prettier + actionlint-style checks; existing diff tests (`TestFrontierDiff`, `TestMetricDiff`, `TestDiffScoping`) unchanged and green.
- Pre-existing unrelated failures in `test_run_*` solver-name-validation tests reproduce on clean `main` (local env can't load the structural-mesh config) — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)