### PR TITLE
feat(solver): Add openfoam-ad reverse mode VJP tesseract for navier-stokes-grid

### DIFF
--- a/mosaic/benchmarks/problems/navier_stokes_grid/exclusions.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/exclusions.py
@@ -62,6 +62,17 @@ OPENFOAM_NON_DIFFERENTIABLE_OPT = Exclusion(
     ExclusionCategory.CATEGORICAL,
     "standard icoFoam is non-differentiable forward-only solver",
 )
+OPENFOAM_AD_NO_OBSTACLE = Exclusion(
+    ExclusionCategory.CATEGORICAL,
+    "openfoam-ad wraps icoFoam on a fully cyclic mesh; obstacle and "
+    "inflow-profile cases would need the ESI channel case writers, which this "
+    "tesseract does not implement",
+)
+OPENFOAM_AD_TAPE_MEMORY = Exclusion(
+    ExclusionCategory.INFEASIBLE,
+    "the CoDiPack tape covers the whole time loop, using 6.7 GB at N=16/320 steps"
+    "making higher N/steps infeasible; needs step-wise re-taping with checkpointing",
+)
 XLB_MA_FLOOR = Exclusion(
     ExclusionCategory.ANOMALY_EXPLAINED,
     "irreducible O(Ma²) LBM compressibility error floor: at fixed "
@@ -93,6 +104,7 @@ _OBSTACLE_GATE = {
     "jax_cfd": JAX_CFD_NO_OBSTACLE,
     "ins_jl": INS_JL_NO_OBSTACLE,
     "warp_ns": WARP_NS_NO_OBSTACLE,
+    "openfoam_ad": OPENFOAM_AD_NO_OBSTACLE,
 }
 
 
@@ -115,12 +127,21 @@ def register(problem: Problem) -> None:
     problem.exclude("forward/cylinder", _OBSTACLE_GATE)
 
     # Cost
-    problem.exclude("cost/vjp_cost", {"openfoam": OPENFOAM_NO_VJP})
+    problem.exclude(
+        "cost/vjp_cost",
+        {"openfoam": OPENFOAM_NO_VJP, "openfoam_ad": OPENFOAM_AD_TAPE_MEMORY},
+    )
 
     # Gradient — suite-level, covers every gradient/* below
     problem.exclude("gradient", {"openfoam": OPENFOAM_NON_DIFFERENTIABLE_GRAD})
 
     # Optimization — suite-level + per-experiment obstacle gates
-    problem.exclude("optimization", {"openfoam": OPENFOAM_NON_DIFFERENTIABLE_OPT})
+    problem.exclude(
+        "optimization",
+        {
+            "openfoam": OPENFOAM_NON_DIFFERENTIABLE_OPT,
+            "openfoam_ad": OPENFOAM_AD_NO_OBSTACLE,
+        },
+    )
     problem.exclude("optimization/drag_opt", _OBSTACLE_GATE)
     problem.exclude("optimization/drag_opt_bfgs", _OBSTACLE_GATE)

--- a/mosaic/benchmarks/problems/navier_stokes_grid/exclusions.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/exclusions.py
@@ -70,7 +70,7 @@ OPENFOAM_AD_NO_OBSTACLE = Exclusion(
 )
 OPENFOAM_AD_TAPE_MEMORY = Exclusion(
     ExclusionCategory.INFEASIBLE,
-    "the CoDiPack tape covers the whole time loop, using 6.7 GB at N=16/320 steps"
+    "the CoDiPack tape covers the whole time loop, using 6.7 GB at N=16/320 steps, "
     "making higher N/steps infeasible; needs step-wise re-taping with checkpointing",
 )
 XLB_MA_FLOOR = Exclusion(

--- a/mosaic/benchmarks/problems/navier_stokes_grid/exclusions.py
+++ b/mosaic/benchmarks/problems/navier_stokes_grid/exclusions.py
@@ -70,8 +70,9 @@ OPENFOAM_AD_NO_OBSTACLE = Exclusion(
 )
 OPENFOAM_AD_TAPE_MEMORY = Exclusion(
     ExclusionCategory.INFEASIBLE,
-    "the CoDiPack tape covers the whole time loop, using 6.7 GB at N=16/320 steps, "
-    "making higher N/steps infeasible; needs step-wise re-taping with checkpointing",
+    "the CoDiPack tape covers the whole time loop, costing about 45 MiB per step "
+    "at N=16 and reaching 14.5 GiB at 320 steps, so the cost sweeps are out of "
+    "reach; needs step-wise re-taping with checkpointing",
 )
 XLB_MA_FLOOR = Exclusion(
     ExclusionCategory.ANOMALY_EXPLAINED,

--- a/mosaic/benchmarks/problems/shared/plots/solver_styles.py
+++ b/mosaic/benchmarks/problems/shared/plots/solver_styles.py
@@ -26,6 +26,7 @@ SOLVER_STYLES: dict[str, dict[str, Any]] = {
     "phiflow": {"color": "#EE3333", "linestyle": "--", "marker": "s"},
     "ins_jl": {"color": "#228833", "linestyle": "-.", "marker": "^"},
     "openfoam": {"color": "#DDAA33", "linestyle": ":", "marker": "D"},
+    "openfoam_ad": {"color": "#996611", "linestyle": (0, (7, 2)), "marker": "d"},
     "pict": {"color": "#AA44AA", "linestyle": (0, (5, 1)), "marker": "v"},
     "warp_ns": {"color": "#EE7733", "linestyle": (0, (1, 1)), "marker": "X"},
     "xlb": {"color": "#66CCEE", "linestyle": (0, (3, 1, 1, 1)), "marker": "P"},

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/Make/files
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/Make/files
@@ -1,0 +1,3 @@
+icoFoamADR.C
+
+EXE = $(FOAM_APPBIN)/icoFoamADR

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/Make/options
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/Make/options
@@ -1,0 +1,11 @@
+EXE_INC = \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude
+
+/* OpenFOAM-AD renames every library with the WM_AD_MODE suffix (renameAD.sh),
+   including libOpenFOAM, so the wmake default PROJECT_LIBS no longer resolves. */
+PROJECT_LIBS = -lOpenFOAM$(WM_AD_MODE) -ldl
+
+EXE_LIBS = \
+    -lfiniteVolume$(WM_AD_MODE) \
+    -lmeshTools$(WM_AD_MODE)

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/createFields.H
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/createFields.H
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011-2017 OpenFOAM Foundation
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+Info<< "Reading transportProperties\n" << endl;
+
+IOdictionary transportProperties
+(
+    IOobject
+    (
+        "transportProperties",
+        runTime.constant(),
+        mesh,
+        IOobject::MUST_READ_IF_MODIFIED,
+        IOobject::NO_WRITE
+    )
+);
+
+dimensionedScalar nu
+(
+    "nu",
+    dimViscosity,
+    transportProperties
+);
+
+Info<< "Reading field p\n" << endl;
+volScalarField p
+(
+    IOobject
+    (
+        "p",
+        runTime.timeName(),
+        mesh,
+        IOobject::MUST_READ,
+        IOobject::AUTO_WRITE
+    ),
+    mesh
+);
+
+Info<< "Reading field U\n" << endl;
+volVectorField U
+(
+    IOobject
+    (
+        "U",
+        runTime.timeName(),
+        mesh,
+        IOobject::MUST_READ,
+        IOobject::AUTO_WRITE
+    ),
+    mesh
+);
+
+#include "createPhi.H"
+
+label pRefCell = 0;
+scalar pRefValue = 0.0;
+setRefCell(p, mesh.solutionDict().subDict("PISO"), pRefCell, pRefValue);
+mesh.setFluxRequired(p.name());

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/icoFoamADR.C
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/icoFoamADR.C
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
 
     // Usually fvc::ddtCorr is used, but we pin the coeff to 1
     // because fvc::ddtCorr applies fvcDdtPhiCoeff, whose limiter
-    // makes the discrete map non-smooth along random directions. 
+    // makes the discrete map non-smooth along random directions.
     // Pinning the coefficient to 1 makes the map smooth
     // Caveat: forward field is 4.4% off (L2) from stock icoFoam
     // BUT the two gradients converge under grid refinement

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/icoFoamADR.C
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/src/icoFoamADR/icoFoamADR.C
@@ -1,0 +1,262 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2011-2017 OpenFOAM Foundation
+    Copyright (C) 2026 Pasteur Labs (reverse-mode AD instrumentation)
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Application
+    icoFoamADR
+
+Description
+    icoFoam with a CoDiPack reverse-mode tape over the whole time loop.
+
+    Without -vjp this is icoFoam. With -vjp the initial velocity is registered
+    as the tape input, the scalar J = sum_c w_c . U_c(T) is registered as the
+    tape output, and one reverse sweep writes dJ/dU(0) per cell, which is the
+    vector-Jacobian product of the final velocity field with cotangent w.
+
+    Requires an OpenFOAM-AD build with WM_AD_MODE=ADR.
+
+\*---------------------------------------------------------------------------*/
+
+#include "fvCFD.H"
+#include "pisoControl.H"
+#include <fstream>
+#include <iomanip>
+
+#ifndef CODI_ADR
+#error "icoFoamADR requires an OpenFOAM-AD build with WM_AD_MODE=ADR"
+#endif
+
+namespace
+{
+
+List<vector> readCotangent(const fileName& path, const label nCells)
+{
+    std::ifstream is(path);
+    if (!is)
+    {
+        FatalErrorInFunction << "cannot open " << path << exit(FatalError);
+    }
+
+    List<vector> w(nCells, Zero);
+    for (label cellI = 0; cellI < nCells; ++cellI)
+    {
+        double wx, wy, wz;
+        if (!(is >> wx >> wy >> wz))
+        {
+            FatalErrorInFunction
+                << "expected " << nCells << " rows in " << path
+                << ", got " << cellI << exit(FatalError);
+        }
+        w[cellI] = vector(wx, wy, wz);
+    }
+    return w;
+}
+
+
+double peakRssMB()
+{
+    std::ifstream status("/proc/self/status");
+    std::string key;
+    double kb = 0.0;
+    while (status >> key)
+    {
+        if (key == "VmHWM:")
+        {
+            status >> kb;
+            break;
+        }
+        status.ignore(4096, '\n');
+    }
+    return kb/1024.0;
+}
+
+} // End anonymous namespace
+
+
+int main(int argc, char *argv[])
+{
+    argList::addNote
+    (
+        "Transient solver for incompressible laminar flow with a reverse-mode"
+        " AD tape over the time loop."
+    );
+
+    argList::addBoolOption
+    (
+        "vjp",
+        "seed the initial velocity, then write dJ/dU(0) to gradient.dat"
+    );
+
+    #include "setRootCaseLists.H"
+    #include "createTime.H"
+    #include "createMesh.H"
+
+    pisoControl piso(mesh);
+
+    #include "createFields.H"
+    #include "initContinuityErrs.H"
+
+    const bool vjp = args.found("vjp");
+
+    codi::RealReverse::Tape& tape = codi::RealReverse::getTape();
+
+    List<vector> U0(mesh.nCells());
+    forAll(U0, cellI)
+    {
+        U0[cellI] = U[cellI];
+    }
+
+    if (vjp)
+    {
+        tape.setActive();
+        forAll(U0, cellI)
+        {
+            for (direction cmpt = 0; cmpt < 3; ++cmpt)
+            {
+                tape.registerInput(U0[cellI][cmpt]);
+            }
+        }
+    }
+
+    // Reassign through U0 so the flux carries the tape dependency, and so the
+    // primal and VJP runs follow bit-identical code paths.
+    forAll(U0, cellI)
+    {
+        U[cellI] = U0[cellI];
+    }
+    U.correctBoundaryConditions();
+    phi = linearInterpolate(U) & mesh.Sf();
+
+    // Usually fvc::ddtCorr is used, but we pin the coeff to 1
+    // because fvc::ddtCorr applies fvcDdtPhiCoeff, whose limiter
+    // makes the discrete map non-smooth along random directions. 
+    // Pinning the coefficient to 1 makes the map smooth
+    // Caveat: forward field is 4.4% off (L2) from stock icoFoam
+    // BUT the two gradients converge under grid refinement
+    const dimensionedScalar rDeltaT = scalar(1)/runTime.deltaT();
+
+    Info<< "\nStarting time loop\n" << endl;
+
+    while (runTime.loop())
+    {
+        Info<< "Time = " << runTime.timeName() << nl << endl;
+
+        #include "CourantNo.H"
+
+        fvVectorMatrix UEqn
+        (
+            fvm::ddt(U)
+          + fvm::div(phi, U)
+          - fvm::laplacian(nu, U)
+        );
+
+        if (piso.momentumPredictor())
+        {
+            solve(UEqn == -fvc::grad(p));
+        }
+
+        while (piso.correct())
+        {
+            volScalarField rAU(1.0/UEqn.A());
+            volVectorField HbyA(constrainHbyA(rAU*UEqn.H(), U, p));
+            surfaceScalarField phiHbyA
+            (
+                "phiHbyA",
+                fvc::flux(HbyA)
+              + fvc::interpolate(rAU)*rDeltaT
+               *(phi.oldTime() - fvc::dotInterpolate(mesh.Sf(), U.oldTime()))
+            );
+
+            adjustPhi(phiHbyA, U, p);
+
+            constrainPressure(p, U, phiHbyA, rAU);
+
+            while (piso.correctNonOrthogonal())
+            {
+                fvScalarMatrix pEqn
+                (
+                    fvm::laplacian(rAU, p) == fvc::div(phiHbyA)
+                );
+
+                pEqn.setReference(pRefCell, pRefValue);
+
+                pEqn.solve(p.select(piso.finalInnerIter()));
+
+                if (piso.finalNonOrthogonalIter())
+                {
+                    phi = phiHbyA - pEqn.flux();
+                }
+            }
+
+            #include "continuityErrs.H"
+
+            U = HbyA - rAU*fvc::grad(p);
+            U.correctBoundaryConditions();
+        }
+
+        runTime.write();
+
+        runTime.printExecutionTime(Info);
+    }
+
+    if (vjp)
+    {
+        const List<vector> w =
+            readCotangent(runTime.path()/"cotangent.dat", mesh.nCells());
+
+        scalar J = 0.0;
+        forAll(U, cellI)
+        {
+            for (direction cmpt = 0; cmpt < 3; ++cmpt)
+            {
+                J += w[cellI][cmpt]*U[cellI][cmpt];
+            }
+        }
+        reduce(J, sumOp<scalar>());
+
+        tape.registerOutput(J);
+        tape.setPassive();
+        J.setGradient(1.0);
+        tape.evaluate();
+
+        std::ofstream os((runTime.path()/"gradient.dat").c_str());
+        os << std::setprecision(17);
+        forAll(U0, cellI)
+        {
+            for (direction cmpt = 0; cmpt < 3; ++cmpt)
+            {
+                os << U0[cellI][cmpt].getGradient() << "\n";
+            }
+        }
+    }
+
+    Info<< "peakRssMB " << peakRssMB() << endl;
+    Info<< "End\n" << endl;
+
+    return 0;
+}
+
+
+// ************************************************************************* //

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_api.py
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_api.py
@@ -4,8 +4,8 @@
 """OpenFOAM-AD tesseract: icoFoam with a reverse-mode discrete adjoint.
 
 Runs icoFoamADR, a PISO transient laminar solver built against DAFoam's
-OpenFOAM-AD (OpenFOAM v2506). The whole time loop is taped, so the VJP 
-is the exact discrete adjoint of the final velocity field with respect 
+OpenFOAM-AD (OpenFOAM v2506). The whole time loop is taped, so the VJP
+is the exact discrete adjoint of the final velocity field with respect
 to the initial condition.
 
 Periodic mode only: N*N (2-D) or N*N*N (3-D) Cartesian grid with cyclic

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_api.py
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_api.py
@@ -1,0 +1,471 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenFOAM-AD tesseract: icoFoam with a reverse-mode discrete adjoint.
+
+Runs icoFoamADR, a PISO transient laminar solver built against DAFoam's
+OpenFOAM-AD (OpenFOAM v2506). The whole time loop is taped, so the VJP 
+is the exact discrete adjoint of the final velocity field with respect 
+to the initial condition.
+
+Periodic mode only: N*N (2-D) or N*N*N (3-D) Cartesian grid with cyclic
+patches. Obstacle and inflow-profile cases are not supported.
+
+Two deviations from stock icoFoam, both applied to the forward path as well
+so that apply and the VJP describe the same discrete map:
+  - GAMG for pressure. PCG diverges in the AD build.
+  - The Rhie-Chow time correction uses a constant coefficient in place of
+    fvcDdtPhiCoeff's limiter, which is non-smooth at the scale of a
+    finite-difference step and so puts AD and FD 0.6 to 14 percent apart along
+    random directions. See src/icoFoamADR/icoFoamADR.C.
+"""
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from mosaic_shared.problems.navier_stokes_grid import (
+    InputSchema as _CanonicalInputSchema,
+)
+from mosaic_shared.problems.navier_stokes_grid import (
+    OutputSchema as _CanonicalOutputSchema,
+)
+from mosaic_shared.schema_types import make_differentiable
+
+_OF_BASHRC = "/home/dafoamuser/dafoam/OpenFOAM/OpenFOAM-AD/etc/bashrc"
+
+
+class InputSchema(make_differentiable(_CanonicalInputSchema, ["v0"])):
+    """OpenFOAM-AD Navier-Stokes inputs with a differentiable initial condition."""
+
+
+class OutputSchema(make_differentiable(_CanonicalOutputSchema, ["result"])):
+    """OpenFOAM-AD Navier-Stokes outputs with a differentiable velocity field."""
+
+
+def _run_of(cmd: str, cwd: Path) -> None:
+    """Run an OpenFOAM command with the OpenFOAM-AD environment sourced."""
+    result = subprocess.run(
+        ["bash", "-c", f". {_OF_BASHRC} && {cmd}"],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"'{cmd}' failed (exit {result.returncode}):\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+
+
+def _write_block_mesh_dict(system_dir: Path, N: int, L: float, ndim: int) -> None:
+    """Write blockMeshDict for an N**ndim Cartesian periodic grid."""
+    if ndim == 2:
+        dz = L / N
+        vertices = (
+            f"    (0 0 0)\n    ({L} 0 0)\n    ({L} {L} 0)\n    (0 {L} 0)\n"
+            f"    (0 0 {dz})\n    ({L} 0 {dz})\n    ({L} {L} {dz})\n    (0 {L} {dz})"
+        )
+        blocks = f"hex (0 1 2 3 4 5 6 7) ({N} {N} 1) simpleGrading (1 1 1)"
+        boundary = """\
+    x_lo { type cyclic; neighbourPatch x_hi; faces ((0 4 7 3)); }
+    x_hi { type cyclic; neighbourPatch x_lo; faces ((1 2 6 5)); }
+    y_lo { type cyclic; neighbourPatch y_hi; faces ((0 1 5 4)); }
+    y_hi { type cyclic; neighbourPatch y_lo; faces ((3 7 6 2)); }
+    front { type empty; faces ((0 3 2 1)); }
+    back  { type empty; faces ((4 5 6 7)); }"""
+    else:
+        vertices = (
+            f"    (0 0 0)\n    ({L} 0 0)\n    ({L} {L} 0)\n    (0 {L} 0)\n"
+            f"    (0 0 {L})\n    ({L} 0 {L})\n    ({L} {L} {L})\n    (0 {L} {L})"
+        )
+        blocks = f"hex (0 1 2 3 4 5 6 7) ({N} {N} {N}) simpleGrading (1 1 1)"
+        boundary = """\
+    x_lo { type cyclic; neighbourPatch x_hi; faces ((0 4 7 3)); }
+    x_hi { type cyclic; neighbourPatch x_lo; faces ((1 2 6 5)); }
+    y_lo { type cyclic; neighbourPatch y_hi; faces ((0 1 5 4)); }
+    y_hi { type cyclic; neighbourPatch y_lo; faces ((3 7 6 2)); }
+    z_lo { type cyclic; neighbourPatch z_hi; faces ((0 3 2 1)); }
+    z_hi { type cyclic; neighbourPatch z_lo; faces ((4 5 6 7)); }"""
+
+    (system_dir / "blockMeshDict").write_text(
+        f"""\
+FoamFile
+{{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      blockMeshDict;
+}}
+scale   1;
+
+vertices
+(
+{vertices}
+);
+
+blocks
+(
+    {blocks}
+);
+
+edges ();
+
+boundary
+(
+{boundary}
+);
+
+mergePatchPairs ();
+"""
+    )
+
+
+def _write_control_dict(system_dir: Path, dt: float, steps: int) -> None:
+    (system_dir / "controlDict").write_text(
+        f"""\
+FoamFile
+{{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      controlDict;
+}}
+application     icoFoamADR;
+startFrom       startTime;
+startTime       0;
+stopAt          endTime;
+endTime         {steps * dt:.10g};
+deltaT          {dt:.10g};
+writeControl    timeStep;
+writeInterval   {steps};
+purgeWrite      1;
+writeFormat     ascii;
+writePrecision  16;
+writeCompression off;
+timeFormat      general;
+timePrecision   10;
+runTimeModifiable false;
+"""
+    )
+
+
+def _write_fv_schemes(system_dir: Path) -> None:
+    (system_dir / "fvSchemes").write_text(
+        """\
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      fvSchemes;
+}
+ddtSchemes      { default Euler; }
+gradSchemes     { default Gauss linear; }
+divSchemes      { default none; div(phi,U) Gauss linear; }
+laplacianSchemes { default Gauss linear corrected; }
+interpolationSchemes { default linear; }
+snGradSchemes   { default corrected; }
+"""
+    )
+
+
+def _write_fv_solution(system_dir: Path, p_tol: float, u_tol: float) -> None:
+    """Write fvSolution with GAMG for pressure; PCG diverges in the AD build."""
+    (system_dir / "fvSolution").write_text(
+        f"""\
+FoamFile
+{{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      fvSolution;
+}}
+solvers
+{{
+    p
+    {{
+        solver          GAMG;
+        smoother        DIC;
+        tolerance       {p_tol:.10g};
+        relTol          0;
+        nCellsInCoarsestLevel 1;
+    }}
+    pFinal {{ $p; }}
+    U
+    {{
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       {u_tol:.10g};
+        relTol          0;
+    }}
+}}
+PISO
+{{
+    nCorrectors              2;
+    nNonOrthogonalCorrectors 0;
+    pRefCell                 0;
+    pRefValue                0;
+}}
+"""
+    )
+
+
+def _write_transport_properties(constant_dir: Path, nu: float) -> None:
+    (constant_dir / "transportProperties").write_text(
+        f"""\
+FoamFile
+{{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      transportProperties;
+}}
+nu              {nu:.10g};
+"""
+    )
+
+
+def _cell_order(field: np.ndarray) -> np.ndarray:
+    """Flatten a v0-shaped array to OpenFOAM cell order (x fastest), (n_cells, 3)."""
+    ndim = field.shape[-1]
+    N = field.shape[0]
+    out = np.zeros((N**ndim, 3), dtype=np.float64)
+    if ndim == 2:
+        vel = field[:, :, 0, :]
+        out[:, 0] = vel[:, :, 0].T.ravel()
+        out[:, 1] = vel[:, :, 1].T.ravel()
+    else:
+        for c in range(3):
+            out[:, c] = field[:, :, :, c].transpose(2, 1, 0).ravel()
+    return out
+
+
+def _from_cell_order(flat: np.ndarray, N: int, ndim: int) -> np.ndarray:
+    """Inverse of _cell_order: (n_cells, 3) back to v0 shape, float32."""
+    flat = np.asarray(flat, dtype=np.float32)
+    if ndim == 2:
+        vel = flat.reshape(N, N, 3).transpose(1, 0, 2)
+        return vel[:, :, None, :2].copy()
+    vel = flat.reshape(N, N, N, 3).transpose(2, 1, 0, 3)
+    return vel.copy()
+
+
+def _write_initial_u(case_dir: Path, v0: np.ndarray) -> None:
+    ndim = v0.shape[-1]
+    rows = _cell_order(v0)
+    lines = "\n".join(f"({r[0]:.17g} {r[1]:.17g} {r[2]:.17g})" for r in rows)
+    if ndim == 2:
+        boundary = """\
+    x_lo  { type cyclic; }
+    x_hi  { type cyclic; }
+    y_lo  { type cyclic; }
+    y_hi  { type cyclic; }
+    front { type empty; }
+    back  { type empty; }"""
+    else:
+        boundary = """\
+    x_lo  { type cyclic; }
+    x_hi  { type cyclic; }
+    y_lo  { type cyclic; }
+    y_hi  { type cyclic; }
+    z_lo  { type cyclic; }
+    z_hi  { type cyclic; }"""
+
+    (case_dir / "0" / "U").write_text(
+        f"""\
+FoamFile
+{{
+    version     2.0;
+    format      ascii;
+    class       volVectorField;
+    object      U;
+}}
+dimensions      [0 1 -1 0 0 0 0];
+
+internalField   nonuniform List<vector>
+{len(rows)}
+(
+{lines}
+)
+;
+
+boundaryField
+{{
+{boundary}
+}}
+"""
+    )
+
+
+def _write_initial_p(case_dir: Path, ndim: int) -> None:
+    if ndim == 2:
+        boundary = """\
+    x_lo  { type cyclic; }
+    x_hi  { type cyclic; }
+    y_lo  { type cyclic; }
+    y_hi  { type cyclic; }
+    front { type empty; }
+    back  { type empty; }"""
+    else:
+        boundary = """\
+    x_lo  { type cyclic; }
+    x_hi  { type cyclic; }
+    y_lo  { type cyclic; }
+    y_hi  { type cyclic; }
+    z_lo  { type cyclic; }
+    z_hi  { type cyclic; }"""
+
+    (case_dir / "0" / "p").write_text(
+        f"""\
+FoamFile
+{{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      p;
+}}
+dimensions      [0 2 -2 0 0 0 0];
+
+internalField   uniform 0;
+
+boundaryField
+{{
+{boundary}
+}}
+"""
+    )
+
+
+def _read_final_velocity(workdir: Path, N: int, ndim: int) -> np.ndarray:
+    """Parse the latest written time directory into a v0-shaped float32 array."""
+    times = []
+    for d in workdir.iterdir():
+        if d.is_dir():
+            try:
+                t = float(d.name)
+            except ValueError:
+                continue
+            if t > 0:
+                times.append((t, d))
+    if not times:
+        raise RuntimeError(f"no output time directories in {workdir}")
+
+    text = (max(times, key=lambda x: x[0])[1] / "U").read_text()
+    match = re.search(
+        r"internalField\s+nonuniform\s+List<vector>\s+\d+\s*\(\s*(.*?)\s*\)\s*;",
+        text,
+        re.DOTALL,
+    )
+    if not match:
+        raise RuntimeError(f"could not parse internalField in {workdir}")
+
+    rows = re.findall(r"\(([^)]+)\)", match.group(1))
+    if len(rows) != N**ndim:
+        raise RuntimeError(f"expected {N**ndim} rows, got {len(rows)}")
+
+    flat = np.array([[float(x) for x in r.split()] for r in rows])
+    return _from_cell_order(flat, N, ndim)
+
+
+def _reject_unsupported(inputs: InputSchema) -> None:
+    if inputs.inflow_profile is not None:
+        raise NotImplementedError(
+            "openfoam-ad is periodic-only and does not support inflow_profile"
+        )
+    if inputs.obstacle is not None:
+        raise NotImplementedError(
+            "openfoam-ad is periodic-only and does not support obstacles"
+        )
+
+
+def _build_case(workdir: Path, inputs: InputSchema, v0: np.ndarray) -> None:
+    (workdir / "0").mkdir(parents=True)
+    (workdir / "constant").mkdir()
+    (workdir / "system").mkdir()
+
+    N = v0.shape[0]
+    ndim = v0.shape[-1]
+    _write_block_mesh_dict(workdir / "system", N, float(inputs.domain_extent), ndim)
+    _write_control_dict(workdir / "system", float(inputs.dt[0]), int(inputs.steps))
+    _write_fv_schemes(workdir / "system")
+    # The finite-difference reference in gradient/fd_check is only as accurate
+    # as the forward map, so the linear solves are tightened
+    _write_fv_solution(workdir / "system", p_tol=1e-12, u_tol=1e-12)
+    _write_transport_properties(workdir / "constant", float(inputs.viscosity[0]))
+    _write_initial_u(workdir, v0)
+    _write_initial_p(workdir, ndim)
+
+    _run_of("blockMesh", workdir)
+
+
+def apply(inputs: InputSchema) -> OutputSchema:
+    """Run icoFoamADR and return the final velocity field."""
+    _reject_unsupported(inputs)
+    v0 = np.asarray(inputs.v0, dtype=np.float64)
+    N, ndim = v0.shape[0], v0.shape[-1]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workdir = Path(tmpdir) / "case"
+        _build_case(workdir, inputs, v0)
+        _run_of("icoFoamADR", workdir)
+        result = _read_final_velocity(workdir, N, ndim)
+
+    return {"result": result, "drag": np.zeros((1,), dtype=np.float32)}
+
+
+def vector_jacobian_product(
+    inputs: InputSchema,
+    vjp_inputs: set[str],
+    vjp_outputs: set[str],
+    cotangent_vector: dict[str, Any],
+) -> dict[str, Any]:
+    """Reverse-mode discrete adjoint of the final velocity w.r.t. v0."""
+    _reject_unsupported(inputs)
+    if vjp_inputs != {"v0"}:
+        raise NotImplementedError(
+            f"openfoam-ad differentiates only v0, got {sorted(vjp_inputs)}"
+        )
+    if "result" not in vjp_outputs:
+        raise NotImplementedError(
+            f"openfoam-ad differentiates only result, got {sorted(vjp_outputs)}"
+        )
+
+    v0 = np.asarray(inputs.v0, dtype=np.float64)
+    N, ndim = v0.shape[0], v0.shape[-1]
+    cotangent = np.asarray(cotangent_vector["result"], dtype=np.float64)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workdir = Path(tmpdir) / "case"
+        _build_case(workdir, inputs, v0)
+
+        rows = _cell_order(cotangent)
+        (workdir / "cotangent.dat").write_text(
+            "\n".join(f"{r[0]:.17g} {r[1]:.17g} {r[2]:.17g}" for r in rows) + "\n"
+        )
+
+        _run_of("icoFoamADR -vjp", workdir)
+
+        values = np.fromstring(
+            (workdir / "gradient.dat").read_text(), sep="\n", dtype=np.float64
+        )
+        if values.size != 3 * N**ndim:
+            raise RuntimeError(
+                f"expected {3 * N**ndim} gradient entries, got {values.size}"
+            )
+
+    return {"v0": _from_cell_order(values.reshape(-1, 3), N, ndim)}
+
+
+def abstract_eval(abstract_inputs: InputSchema) -> dict:
+    """Return output shapes and dtypes without running the solver."""
+    v0 = abstract_inputs.v0
+    shape = v0["shape"] if isinstance(v0, dict) else tuple(v0.shape)
+    return {
+        "result": {"shape": shape, "dtype": "float32"},
+        "drag": {"shape": (1,), "dtype": "float32"},
+    }

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_config.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_config.yaml
@@ -1,0 +1,38 @@
+name: openfoam_ad_navier_stokes_grid
+version: "0.1.0"
+description: >
+  OpenFOAM icoFoam built against DAFoam's OpenFOAM-AD (OpenFOAM v2506). 
+  The whole PISO time loop is taped, so the VJP is the exact discrete
+  adjoint of the final velocity field with respect to the initial condition. Periodic mode only.
+build_config:
+  # Pinned by digest: the :v5 tag is rebuilt and overwritten by DAFoam CI on every
+  # commit to the v2506-ad branch, so the tag alone is not reproducible.
+  base_image: "dafoam/opt-packages@sha256:89de4d074dd3085f158c6194954b0bc0ad9d0438af5e8ef89535df2375e9cf55"
+  target_platform: "linux/x86_64"
+
+  package_data:
+    - ["./src", "/opt/openfoam-ad/src"]
+
+  custom_build_steps:
+    - USER root
+    # The image ships both an ADF and an ADR build; select reverse mode, then
+    # compile the solver against the ADR-suffixed libraries.
+    - |
+      RUN sed -i 's/export WM_AD_MODE=.*/export WM_AD_MODE=ADR/' \
+            /home/dafoamuser/dafoam/OpenFOAM/OpenFOAM-AD/etc/bashrc && \
+          bash -c '. /home/dafoamuser/dafoam/OpenFOAM/OpenFOAM-AD/etc/bashrc && \
+                   cd /opt/openfoam-ad/src/icoFoamADR && wmake'
+
+metadata:
+  mosaic:
+    name: "OpenFOAM-AD"
+    backend: cpp
+    family: projection
+    scheme: "icoFoam PISO"
+    discretization: FV
+    numerics: "PISO, Euler, GAMG"
+    ad_strategy: autodiff
+    differentiable: true
+    uses_gpu: false
+    internal_dtype: float64
+    doc_url: "https://github.com/DAFoam/OpenFOAM-AD"

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_config.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_config.yaml
@@ -1,7 +1,7 @@
 name: openfoam_ad_navier_stokes_grid
 version: "0.1.0"
 description: >
-  OpenFOAM icoFoam built against DAFoam's OpenFOAM-AD (OpenFOAM v2506). 
+  OpenFOAM icoFoam built against DAFoam's OpenFOAM-AD (OpenFOAM v2506).
   The whole PISO time loop is taped, so the VJP is the exact discrete
   adjoint of the final velocity field with respect to the initial condition. Periodic mode only.
 build_config:

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_config.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_config.yaml
@@ -22,6 +22,9 @@ build_config:
             /home/dafoamuser/dafoam/OpenFOAM/OpenFOAM-AD/etc/bashrc && \
           bash -c '. /home/dafoamuser/dafoam/OpenFOAM/OpenFOAM-AD/etc/bashrc && \
                    cd /opt/openfoam-ad/src/icoFoamADR && wmake'
+    # The base image leaves /home/dafoamuser at 0750, so the unprivileged
+    # runtime user cannot traverse it to source the OpenFOAM-AD bashrc.
+    - RUN chmod o+x /home/dafoamuser
 
 metadata:
   mosaic:

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_environment.yaml
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_environment.yaml
@@ -1,0 +1,6 @@
+name: openfoam-ad-env
+channels:
+  - conda-forge
+dependencies:
+  - python==3.12
+  - pip

--- a/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_requirements.txt
+++ b/mosaic/tesseracts/navier-stokes-grid/openfoam-ad/tesseract_requirements.txt
@@ -1,0 +1,2 @@
+numpy==2.4.4
+../../../mosaic_shared


### PR DESCRIPTION
## Summary

A new `openfoam-ad` tesseract for the navier-stokes-grid problem. It runs
`icoFoamADR` (vendored solver), a PISO transient laminar solver built against
DAFoam's OpenFOAM-AD (OpenFOAM v2506). The whole time loop is recorded on a
CoDiPack tape, so the VJP is the exact discrete adjoint of the final velocity
field with respect to the initial condition.

The existing `openfoam` tesseract stays as it is. This entry covers the gradient
suites that `openfoam` is permanently excluded from.

## Type of change

- [x] New solver backend
- [ ] Solver tuning / improvement
- [ ] New benchmark domain
- [ ] Harness / infrastructure change
- [ ] Documentation
- [ ] Bug fix

### For new solvers

- [x] `tesseract_config.yaml` has a `metadata.mosaic:` block with at least `name` and `backend`
- [x] `tesseract build mosaic/tesseracts/navier-stokes-grid/openfoam-ad` succeeds
- [x] `mosaic run -p ns-grid --suites forward -s OpenFOAM-AD --debug` completes
- [x] `mosaic status -p ns-grid -f` output pasted below
- [x] Exclusions and explained anomalies documented (if any)

### For solver tuning

- [ ] Before/after `mosaic status --format json` snapshots compared
- [ ] No regressions to other solvers

## Benchmark label

`benchmark:solver`. This PR adds one new tesseract and touches only that
solver's exclusions and its plot style entry, so no other solver's results
change.

## Status

Output of `mosaic status -p ns-grid -f`, OpenFOAM-AD column. Only this solver was
run locally, so the peer columns are empty.

```
experiment                       OpenFOAM-AD
-------------------------------  -----------
forward/agreement/multimode      fail   (local artifact, see below)
forward/agreement/tgv            ok
forward/baseline                 ok
forward/cylinder                 perm
forward/physical_laws/vs_N       ok
forward/physical_laws/vs_nu      ok
forward/physical_laws/vs_steps   ok
forward/tgv_nu_sweep             ok
gradient/fd_check                ok
gradient/horizon_sweep           ok
gradient/jacobian_svd            ok
gradient/jacobian_svd_nu01       ok
gradient/jacobian_svd_steps20    ok
gradient/jacobian_svd_steps40    ok
gradient/param_sweep             ok
cost/vjp_cost/by_N               excl
cost/vjp_cost/by_steps           excl
optimization/drag_opt            perm

ok 13 | anom 0 | fail 1 | excl work 2 | excl perm 18
```

Forward results, production sizes:

| experiment | sweep | value |
| --- | --- | --- |
| forward/baseline | N=16,32,64,128 | rel error 9.60e-04, 2.52e-04, 5.67e-05, 2.49e-05 |
| forward/agreement/tgv | nu=0.001 to 0.05 | rel error 5.95e-03 down to 5.10e-04 |
| forward/tgv_nu_sweep | nu=1e-4 to 0.05 | rel error 7.09e-03 down to 5.10e-04 |
| forward/physical_laws/vs_N | N=16 to 128 | divergence rms 2.15e-02 down to 2.80e-05 |

Gradient results:

| experiment | metric |
| --- | --- |
| gradient/fd_check | best max rel err 1.34e-04 at eps 0.1, min cosine 0.99999999993 |
| gradient/horizon_sweep | mean rel err 1.2e-05 to 2.7e-05 at eps 0.1 for every horizon from 5 to 320 steps |
| gradient/jacobian_svd | cond 7.19, effective rank 117 of 128, grad norm 1.05 |
| gradient/jacobian_svd_nu01 | cond 7.27, effective rank 117.0 |
| gradient/jacobian_svd_steps20 | cond 7.57, effective rank 116.8 |
| gradient/jacobian_svd_steps40 | cond 8.40, effective rank 115.8 |
| gradient/param_sweep | best mean rel err 1.2e-05 to 1.7e-04 over nu=0.05 to 0.001 at steps=200 |

## Notes

### Two deviations from stock icoFoam

Both are applied to the forward path as well, so `apply` and the VJP describe the
same discrete map.

**GAMG for pressure.** PCG diverges in the AD build.

**A constant Rhie-Chow time correction coefficient in place of `fvcDdtPhiCoeff`.** 
Its limiter makes the discrete map non-smooth. So we just use a constant coefficient of 1.
AFAIK this is not an AD bug.

### Exclusions

`OPENFOAM_AD_NO_OBSTACLE` (CATEGORICAL), on `forward/cylinder` and the
`optimization` suite. The tesseract writes a fully cyclic Cartesian mesh.
Obstacle and inflow profile cases not implemented.

`OPENFOAM_AD_TAPE_MEMORY` (INFEASIBLE), on `cost/vjp_cost`. The tape spans the
whole time loop, costing about 45 MiB per step at N=16: peak RSS is 1.0 GiB at 20
steps, 14.5 GiB at 320, which puts the cost sweeps out of reach. Step wise re-taping with
checkpointing fixes this and is a possible follow up. `xlb` solves the same
problem in `_checkpointed_scan` with sqrt-checkpointing.

**Important for CI**: `gradient/horizon_sweep` runs to 320 steps and so needs
about 15 GiB of RAM in its largest cell. It passes.

### Anomaly (local artifact due to lack of GPU)

`forward/agreement/multimode` shows `fail` in the table above. The multimode IC
has no closed form, so it scores against a cross-solver consensus, and I could
only run one solver locally, due to a lack of GPU. It should score normally in CI. 
For the same reason `rel_err_peer_outlier` and the `cross_cosine` matrix in `jacobian_svd`
were not computed locally.

### Base image pinning

The base image is pinned by digest rather than tag. DAFoam CI rebuilds and
overwrites the `:v5` tag on every commit to the v2506-ad branch, so the tag alone
is not reproducible.

The build also needs `chmod o+x /home/dafoamuser`: the base image leaves that
directory at 0750, so the unprivileged tesseract runtime user cannot traverse it
to source the OpenFOAM-AD environment.

CPU only. No GPU requirement.

### Open Questions

**Licensing.** The solver derives from `icoFoam.C` and is therefore GPL-3, which 
cannot be asserted as Apache-2.0 in the CLA. Happy to discuss the options here.