### PR TITLE
chore(harness): remove the peer_final_loss_k check

### DIFF
--- a/mosaic/benchmarks/core/status.py
+++ b/mosaic/benchmarks/core/status.py
@@ -477,53 +477,6 @@ def _is_sweep_key(k: Any) -> bool:
     return False
 
 
-def _sweep_sub_entry(entry: dict, sweep_k: str) -> Any:
-    """Look up a sweep sub-entry by string key, falling back to a float key when the string parses as a plain number."""
-    sub = entry.get(sweep_k)
-    if sub is not None:
-        return sub
-    if sweep_k.replace(".", "").lstrip("-").isdigit():
-        return entry.get(float(sweep_k))
-    return entry.get(sweep_k)
-
-
-def _collect_sweep_keys(top: dict) -> set[str]:
-    """Return the union of numeric-style keys across all solver entries."""
-    keys: set[str] = set()
-    for entry in top.values():
-        if not isinstance(entry, dict):
-            continue
-        for k in entry:
-            if _is_sweep_key(k):
-                keys.add(str(k))
-    return keys
-
-
-def _peer_finals_at(top: dict, sweep_k: str) -> dict[str, float]:
-    """Gather non-trivial, finite final_loss values across all solvers at sweep value *sweep_k*.
-
-    Trivial points (initial_loss <= 0) are skipped.
-    """
-    peer_finals: dict[str, float] = {}
-    for solver, entry in top.items():
-        if not isinstance(entry, dict):
-            continue
-        sub = _sweep_sub_entry(entry, sweep_k)
-        if not isinstance(sub, dict):
-            continue
-        fl = sub.get("final_loss")
-        il = sub.get("initial_loss", 0.0)
-        if (
-            isinstance(fl, int | float)
-            and math.isfinite(fl)
-            and fl >= 0
-            and isinstance(il, int | float)
-            and float(il) > 0
-        ):
-            peer_finals[solver] = float(fl)
-    return peer_finals
-
-
 def _worst_case_trajectory(entry: dict) -> list[float] | None:
     """Pick the worst-case (highest initial loss) trajectory from a numeric-sweep dict.
 
@@ -554,13 +507,8 @@ def _worst_case_trajectory(entry: dict) -> list[float] | None:
 def _refine_recovery(data: dict, cells: dict[str, Cell], checks: list) -> None:
     """Walk ``checks`` against per-solver :class:`OptimizationSummary` instances.
 
-    Builds two metrics per solver: ``final_initial_ratio`` (from the
-    worst-case trajectory) and ``peer_final_loss_by_sweep`` (per-sweep
-    ratio to the best peer final loss). Then iterates each solver's check
-    list — first anomaly wins.
-
-    Note that peer values include categorically-excluded solvers since
-    their loss values still represent self-consistent optimisations.
+    Builds ``final_initial_ratio`` per solver from the worst-case
+    trajectory, then iterates each solver's check list — first anomaly wins.
     """
     from .status_checks import OptimizationSummary
 
@@ -569,16 +517,6 @@ def _refine_recovery(data: dict, cells: dict[str, Cell], checks: list) -> None:
     top = data.get("by_solver") or data.get("by_sweep") or {}
     if not isinstance(top, dict):
         return
-
-    # Per-sweep peer-min final losses (used for peer_final_loss_k checks).
-    peer_min_by_sweep: dict[Any, float] = {}
-    sweep_keys = _collect_sweep_keys(top)
-    for sweep_k in sweep_keys:
-        peer_finals = _peer_finals_at(top, sweep_k)
-        if len(peer_finals) >= 2:
-            best = min(peer_finals.values())
-            if best > 0:
-                peer_min_by_sweep[sweep_k] = best
 
     for solver in list(cells):
         if cells[solver].status != OK:
@@ -594,19 +532,7 @@ def _refine_recovery(data: dict, cells: dict[str, Cell], checks: list) -> None:
             final = abs(series[-1])
             if initial > 0 and math.isfinite(final):
                 ratio = final / initial
-        # Per-sweep ratios to peer-min final.
-        per_sweep: dict[Any, float] = {}
-        for sweep_k, peer_min in peer_min_by_sweep.items():
-            sub = _sweep_sub_entry(entry, sweep_k)
-            if not isinstance(sub, dict):
-                continue
-            fl = sub.get("final_loss")
-            if isinstance(fl, int | float) and math.isfinite(fl):
-                per_sweep[sweep_k] = float(fl) / peer_min
-        summary = OptimizationSummary(
-            final_initial_ratio=ratio,
-            peer_final_loss_by_sweep=per_sweep,
-        )
+        summary = OptimizationSummary(final_initial_ratio=ratio)
         verdict = _run_checks(checks, summary)
         if verdict:
             cells[solver] = Cell(*verdict)

--- a/mosaic/benchmarks/core/status_checks.py
+++ b/mosaic/benchmarks/core/status_checks.py
@@ -78,14 +78,9 @@ class OptimizationSummary:
     ``final_initial_ratio``: ``loss_final / loss_initial`` for the
     worst-case (highest-initial-loss) trajectory. A solver that didn't
     reduce loss has ratio ≥ 1.
-
-    ``peer_final_loss_by_sweep``: per-sweep-value ratio of this solver's
-    final loss to the best (minimum) final loss across all peers at the
-    same sweep value. Empty when the experiment isn't a numeric sweep.
     """
 
     final_initial_ratio: float | None = None
-    peer_final_loss_by_sweep: dict[Any, float] = field(default_factory=dict)
 
 
 # ── Built-in check factories ─────────────────────────────────────────────────
@@ -210,27 +205,6 @@ def max_final_ratio(threshold: float) -> Callable[[OptimizationSummary], CheckOu
         return (
             "anomaly",
             f"final/initial = {s.final_initial_ratio:.2f} (> {threshold})",
-        )
-
-    return _check
-
-
-def peer_final_loss_k(k: float) -> Callable[[OptimizationSummary], CheckOutcome]:
-    """Optimization suite (sweeps only): anomaly if final loss exceeds ``k×`` the best peer.
-
-    Fires when any sweep value has this solver's final loss above the threshold.
-    """
-
-    def _check(s: OptimizationSummary) -> CheckOutcome:
-        if not s.peer_final_loss_by_sweep:
-            return None
-        worst = max(s.peer_final_loss_by_sweep.items(), key=lambda kv: kv[1])
-        sweep_k, ratio = worst
-        if ratio <= k:
-            return None
-        return (
-            "anomaly",
-            f"final_loss at sweep={sweep_k} is {ratio:.1f}× best peer (threshold {k}×)",
         )
 
     return _check

--- a/tests/core/test_status_checks.py
+++ b/tests/core/test_status_checks.py
@@ -51,7 +51,6 @@ from mosaic.benchmarks.core.status_checks import (
     max_rel_err,
     median_k,
     min_cosine,
-    peer_final_loss_k,
     rel_err_peer_outlier,
 )
 
@@ -108,12 +107,6 @@ CHECK_CASES = [
         max_final_ratio(0.5),
         OptimizationSummary(final_initial_ratio=1.2),
         OptimizationSummary(final_initial_ratio=0.1),
-    ),
-    (
-        "peer_final_loss_k",
-        peer_final_loss_k(5.0),
-        OptimizationSummary(peer_final_loss_by_sweep={"0.01": 40.0}),
-        OptimizationSummary(peer_final_loss_by_sweep={"0.01": 1.2}),
     ),
 ]
 


### PR DESCRIPTION
Closes #170.

The check reads `peer_final_loss_by_sweep`, which `_peer_finals_at` only fills for entries carrying a positive `initial_loss`. Nothing writes that key, so the dict was always empty and the check returned None for every summary. No problem config referenced it either.

Removed the check, the field, and the three helpers that existed only to feed it (`_peer_finals_at`, `_collect_sweep_keys`, `_sweep_sub_entry`), plus its test case. `_is_sweep_key` stays, `_worst_case_trajectory` still uses it.

Full test suite passes locally (596 passed, 3 skipped).